### PR TITLE
LNDENG-828: Make confirmation modals consistent

### DIFF
--- a/src/pages/dashboard/machines/ActivityConfirmation.tsx
+++ b/src/pages/dashboard/machines/ActivityConfirmation.tsx
@@ -1,5 +1,10 @@
 import { FC } from "react";
-import { CheckboxInput, Input, Modal } from "@canonical/react-components";
+import {
+  Button,
+  CheckboxInput,
+  Input,
+  Modal,
+} from "@canonical/react-components";
 import classes from "./ActivityConfirmation.module.scss";
 
 export interface ActivityProps {
@@ -35,22 +40,18 @@ const ActivityConfirmation: FC<ActivityConfirmationProps> = ({
         close={onClose}
         buttonRow={
           <>
-            <button
-              className="u-no-margin--bottom"
-              aria-controls="modal"
-              onClick={onClose}
-            >
-              Cancel
-            </button>
-            <button
-              className="p-button--negative u-no-margin--bottom"
+            <Button
+              appearance="negative"
               onClick={activityProps.acceptButton.onClick}
               disabled={
                 !checkboxValue && new Date(inputValue).getTime() < Date.now()
               }
             >
               {activityProps.acceptButton.label}
-            </button>
+            </Button>
+            <Button aria-controls="modal" onClick={onClose}>
+              Cancel
+            </Button>
           </>
         }
       >

--- a/src/pages/dashboard/machines/MachinesPage.tsx
+++ b/src/pages/dashboard/machines/MachinesPage.tsx
@@ -94,14 +94,14 @@ const MachinesPage: FC = () => {
 
   const handleRebootComputer = async () => {
     confirmModal({
-      title: "Rebooting selected machines",
-      body: `Are you sure you want to reboot ${selected.length} machine${
+      title: "Restarting selected machines",
+      body: `Are you sure you want to restart ${selected.length} machine${
         selected.length > 1 ? "s" : ""
       }?`,
       buttons: [
         <Button
-          key="reboot"
-          appearance="brand"
+          key="restart"
+          appearance="negative"
           onClick={async () => {
             try {
               await rebootComputers({
@@ -114,7 +114,7 @@ const MachinesPage: FC = () => {
             }
           }}
         >
-          Reboot
+          Restart
         </Button>,
       ],
     });


### PR DESCRIPTION
- Changed modal and button names from 'Reboot' to "Restart' and made its color red
- Removed unused styles from custom modal buttons and changed them to use React Vanilla Buttons instead
- Reordered custom modal buttons to be consistent