### PR TITLE
(feat): tests for ubuntu pro panel

### DIFF
--- a/src/features/ubuntupro/UbuntuProHeader/UbuntuProHeader.module.scss
+++ b/src/features/ubuntupro/UbuntuProHeader/UbuntuProHeader.module.scss
@@ -7,11 +7,6 @@
   border-bottom: 1px solid $color-mid-light;
 }
 
-.helpIcon {
-  margin-right: $sp-small;
-  margin-left: $sp-small;
-}
-
 .header {
   margin-bottom: $sp-small;
 }

--- a/src/features/ubuntupro/UbuntuProHeader/UbuntuProHeader.test.tsx
+++ b/src/features/ubuntupro/UbuntuProHeader/UbuntuProHeader.test.tsx
@@ -1,0 +1,57 @@
+import { instances } from "@/tests/mocks/instance";
+import { renderWithProviders } from "@/tests/render";
+import UbuntuProHeader from "./UbuntuProHeader";
+import { screen } from "@testing-library/react";
+
+const ubuntuProDataWithAccountInfo = instances.find(
+  (instance) => instance.ubuntu_pro_info && instance.ubuntu_pro_info?.account,
+)!.ubuntu_pro_info!;
+
+const ubuntuProDataWithoutAccountInfo = instances.find(
+  (instance) => instance.ubuntu_pro_info && !instance.ubuntu_pro_info?.account,
+)!.ubuntu_pro_info!;
+
+describe("renders Ubuntu Pro Panel", () => {
+  it.each([ubuntuProDataWithAccountInfo, ubuntuProDataWithoutAccountInfo])(
+    "renders Ubuntu Pro Panel with Ubuntu Pro entitlement",
+    (data) => {
+      const { container } = renderWithProviders(
+        <UbuntuProHeader ubuntuProData={data} />,
+      );
+      expect(screen.getByText(/account information/i)).toBeInTheDocument();
+
+      const ubuntuProHeaderFields = [
+        {
+          label: "Account",
+          value: data.account?.name ?? "-",
+        },
+        {
+          label: "Subscription",
+          value: data.contract?.name ?? "-",
+        },
+        {
+          label: "Valid Until",
+          value:
+            data.expires !== "n/a"
+              ? new Date(data.expires).toLocaleString("en-GB", {
+                  year: "numeric",
+                  month: "short",
+                  day: "numeric",
+                  hour: "numeric",
+                  minute: "numeric",
+                  timeZoneName: "short",
+                  timeZone: "UTC",
+                })
+              : "-",
+        },
+        {
+          label: "Technical Support Level",
+          value: data.contract?.tech_support_level ?? "-",
+        },
+      ];
+      ubuntuProHeaderFields.forEach((field) => {
+        expect(container).toHaveInfoItem(field.label, field.value);
+      });
+    },
+  );
+});

--- a/src/features/ubuntupro/UbuntuProHeader/UbuntuProHeader.tsx
+++ b/src/features/ubuntupro/UbuntuProHeader/UbuntuProHeader.tsx
@@ -1,39 +1,41 @@
 import { FC } from "react";
 import classes from "./UbuntuProHeader.module.scss";
-import classNames from "classnames";
 import { Col, Link, Row } from "@canonical/react-components";
 import InfoItem from "@/components/layout/InfoItem";
 import { UbuntuProInfo } from "@/types/Instance";
 
 interface UbuntuProHeaderProps {
-  data: UbuntuProInfo;
+  ubuntuProData: UbuntuProInfo;
 }
 
-const UbuntuProHeader: FC<UbuntuProHeaderProps> = ({ data }) => {
+const UbuntuProHeader: FC<UbuntuProHeaderProps> = ({ ubuntuProData }) => {
   const infoItems = [
     {
       label: "Account",
-      value: data.account?.name ?? "-",
+      value: ubuntuProData.account?.name ?? "-",
     },
     {
       label: "Subscription",
-      value: data.contract?.name ?? "-",
+      value: ubuntuProData.contract?.name ?? "-",
     },
     {
       label: "Valid Until",
-      value: new Date(data.expires).toLocaleString("en-GB", {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-        hour: "numeric",
-        minute: "numeric",
-        timeZoneName: "short",
-        timeZone: "UTC",
-      }),
+      value:
+        ubuntuProData.expires !== "n/a"
+          ? new Date(ubuntuProData.expires).toLocaleString("en-GB", {
+              year: "numeric",
+              month: "short",
+              day: "numeric",
+              hour: "numeric",
+              minute: "numeric",
+              timeZoneName: "short",
+              timeZone: "UTC",
+            })
+          : "-",
     },
     {
       label: "Technical Support Level",
-      value: data.contract?.tech_support_level ?? "-",
+      value: ubuntuProData.contract?.tech_support_level ?? "-",
     },
   ];
   return (
@@ -45,7 +47,6 @@ const UbuntuProHeader: FC<UbuntuProHeaderProps> = ({ data }) => {
             display: "inline",
           }}
         >
-          <i className={classNames("p-icon--information", classes.helpIcon)} />
           <span className="u-text--muted">listed from </span>
           <Link
             href="https://ubuntu.com/pro/dashboard"

--- a/src/features/ubuntupro/UbuntuProList/UbuntuProList.test.tsx
+++ b/src/features/ubuntupro/UbuntuProList/UbuntuProList.test.tsx
@@ -1,0 +1,77 @@
+import { renderWithProviders } from "@/tests/render";
+import UbuntuProList from "./UbuntuProList";
+import { instances } from "@/tests/mocks/instance";
+import { screen, within } from "@testing-library/react";
+
+const ubuntuProServices = instances.find(
+  (instance) =>
+    instance.ubuntu_pro_info &&
+    instance.ubuntu_pro_info?.services.some(
+      (service) => service.status === "enabled",
+    ) &&
+    instance.ubuntu_pro_info?.services.some(
+      (service) => service.status === "disabled",
+    ),
+)?.ubuntu_pro_info!.services!;
+
+describe("Ubuntu Pro List", () => {
+  it("renders Ubuntu Pro List", () => {
+    renderWithProviders(<UbuntuProList services={ubuntuProServices} />);
+    expect(screen.getByText(/services/i)).toBeInTheDocument();
+    for (const service of ubuntuProServices) {
+      expect(screen.getByText(service.name)).toBeInTheDocument();
+    }
+  });
+
+  it("renders all column headers", () => {
+    renderWithProviders(<UbuntuProList services={ubuntuProServices} />);
+    const headers = ["Name", "Entitled", "Status", "Description"];
+    for (const header of headers) {
+      expect(
+        screen.getByRole("columnheader", {
+          name: header,
+        }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("shows enabled icon status for an enabled service", () => {
+    renderWithProviders(<UbuntuProList services={ubuntuProServices} />);
+    const enabledService = ubuntuProServices.find(
+      (service) => service.status === "enabled",
+    );
+    expect(enabledService).toBeDefined();
+
+    const row = screen.getByRole("row", {
+      name: `${enabledService?.name} Entitled Status Description`,
+    });
+
+    const enabledServiceCellIcon = within(row).getByRole("cell", {
+      name: /status/i,
+    });
+
+    const iconElement = enabledServiceCellIcon.querySelector("i");
+    expect(iconElement).toBeInTheDocument();
+    expect(iconElement).toHaveClass("p-icon--status-succeeded-small");
+  });
+
+  it("shows disabled icon status for a disabled service", () => {
+    renderWithProviders(<UbuntuProList services={ubuntuProServices} />);
+    const disabledService = ubuntuProServices.find(
+      (service) => service.status === "disabled",
+    );
+    expect(disabledService).toBeDefined();
+
+    const row = screen.getByRole("row", {
+      name: `${disabledService?.name} Entitled Status Description`,
+    });
+
+    const disabledServiceCellIcon = within(row).getByRole("cell", {
+      name: /status/i,
+    });
+
+    const iconElement = disabledServiceCellIcon.querySelector("i");
+    expect(iconElement).toBeInTheDocument();
+    expect(iconElement).toHaveClass("p-icon--status-failed-small");
+  });
+});

--- a/src/features/ubuntupro/UbuntuProList/UbuntuProList.tsx
+++ b/src/features/ubuntupro/UbuntuProList/UbuntuProList.tsx
@@ -5,12 +5,11 @@ import classes from "./UbuntuProList.module.scss";
 import { UbuntuProService } from "@/types/Instance";
 
 interface UbuntuProServicesListProps {
-  items?: UbuntuProService[];
+  services: UbuntuProService[];
 }
 
-const UbuntuProList: FC<UbuntuProServicesListProps> = ({ items }) => {
-  const servicesData = useMemo(() => items, [items?.length]) ?? [];
-
+const UbuntuProList: FC<UbuntuProServicesListProps> = ({ services }) => {
+  const servicesData = useMemo(() => services, [services.length]) ?? [];
   const columns = useMemo<Column<UbuntuProService>[]>(
     () => [
       {
@@ -20,14 +19,24 @@ const UbuntuProList: FC<UbuntuProServicesListProps> = ({ items }) => {
       {
         accessor: "entitled",
         Header: "Entitled",
+        Cell: ({ row }: CellProps<UbuntuProService>) => (
+          <>{row.original.entitled ?? "-"}</>
+        ),
       },
       {
         accessor: "status",
         Header: "Status",
-        getCellIcon: ({ row }: CellProps<UbuntuProService>) =>
-          row.original.status === "enabled"
+        Cell: ({ row }: CellProps<UbuntuProService>) => (
+          <>{row.original.status ?? "-"}</>
+        ),
+        getCellIcon: ({ row: { original } }: CellProps<UbuntuProService>) => {
+          if (!original.status) {
+            return null;
+          }
+          return original.status === "enabled"
             ? "status-succeeded-small"
-            : "status-failed-small",
+            : "status-failed-small";
+        },
       },
       {
         accessor: "description",

--- a/src/pages/dashboard/instances/[single]/tabs/ubuntu-pro/UbuntuProPanel/UbuntuProPanel.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/ubuntu-pro/UbuntuProPanel/UbuntuProPanel.test.tsx
@@ -1,0 +1,22 @@
+import { instances } from "@/tests/mocks/instance";
+import { renderWithProviders } from "@/tests/render";
+import UbuntuProPanel from "./UbuntuProPanel";
+import { screen } from "@testing-library/react";
+
+const instanceWithUbuntuPro = instances.find(
+  (instance) => instance.ubuntu_pro_info,
+)!;
+
+const instanceWithoutUbuntuPro = instances.find(
+  (instance) => !instance.ubuntu_pro_info,
+)!;
+
+describe("renders Ubuntu Pro Panel", () => {
+  it("renders Ubuntu Pro Panel with Ubuntu Pro entitlement", () => {
+    renderWithProviders(<UbuntuProPanel instance={instanceWithUbuntuPro} />);
+  });
+  it("renders empty Ubuntu Pro Panel", () => {
+    renderWithProviders(<UbuntuProPanel instance={instanceWithoutUbuntuPro} />);
+    expect(screen.getByText(/no ubuntu pro entitlement/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/instances/[single]/tabs/ubuntu-pro/UbuntuProPanel/UbuntuProPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/ubuntu-pro/UbuntuProPanel/UbuntuProPanel.tsx
@@ -12,8 +12,8 @@ interface UbuntuProPanelProps {
 const UbuntuProPanel: FC<UbuntuProPanelProps> = ({ instance }) => {
   return instance.ubuntu_pro_info ? (
     <>
-      <UbuntuProHeader data={instance.ubuntu_pro_info} />
-      <UbuntuProList items={instance.ubuntu_pro_info.services} />
+      <UbuntuProHeader ubuntuProData={instance.ubuntu_pro_info} />
+      <UbuntuProList services={instance.ubuntu_pro_info.services} />
     </>
   ) : (
     <EmptyState
@@ -30,7 +30,8 @@ const UbuntuProPanel: FC<UbuntuProPanelProps> = ({ instance }) => {
             target="_blank"
             rel="nofollow noopener noreferrer"
           >
-            Learn more
+            Learn more about Ubuntu Pro
+            <i className="p-icon--external-link" />
           </Link>
         </>
       }

--- a/src/tests/mocks/instance.ts
+++ b/src/tests/mocks/instance.ts
@@ -333,8 +333,6 @@ export const instances: Instance[] = [
     vm_info: "",
     container_info: "lxc",
     ubuntu_pro_info: {
-      _doc: "Content provided in json response is currently considered Experimental and may change",
-      _schema_version: "0.1",
       account: {
         created_at: "2019-10-11T13:55:56+00:00",
         external_account_ids: [
@@ -351,26 +349,7 @@ export const instances: Instance[] = [
         name: "Canonical - staff",
       },
       attached: true,
-      config: {
-        contract_url: "https://contracts.canonical.com",
-        data_dir: "/var/lib/ubuntu-advantage",
-        log_file: "/var/log/ubuntu-advantage.log",
-        log_level: "debug",
-        security_url: "https://ubuntu.com/security",
-        ua_config: {
-          apt_news: true,
-          apt_news_url: "https://motd.ubuntu.com/aptnews.json",
-          global_apt_http_proxy: null,
-          global_apt_https_proxy: null,
-          http_proxy: null,
-          https_proxy: null,
-          metering_timer: 14400,
-          ua_apt_http_proxy: null,
-          ua_apt_https_proxy: null,
-          update_messaging_timer: 21600,
-        },
-      },
-      config_path: "/etc/ubuntu-advantage/uaclient.conf",
+
       contract: {
         created_at: "2020-09-29T15:52:51+00:00",
         id: "cAJMR-Wu2xaAS6tCkJ_vAIxedbbcXMnNRIvJ_AdKQcNo",
@@ -379,15 +358,7 @@ export const instances: Instance[] = [
         tech_support_level: "essential",
       },
       effective: "2020-09-29T00:00:00+00:00",
-      environment_vars: [],
-      errors: [],
-      execution_details: "No Ubuntu Pro operations are running",
-      execution_status: "inactive",
       expires: "3999-12-31T23:59:59+00:00",
-      features: {},
-      machine_id: "3258c4ed830c4c8ba11607dc7f9b35c4",
-      notices: [],
-      result: "success",
       services: [
         {
           available: "yes",
@@ -458,9 +429,6 @@ export const instances: Instance[] = [
           warning: null,
         },
       ],
-      simulated: false,
-      version: "30~22.04",
-      warnings: [],
     },
     is_wsl_instance: false,
     children: [],
@@ -485,12 +453,9 @@ export const instances: Instance[] = [
     cloud_instance_metadata: {},
     vm_info: "",
     container_info: "lxc",
-    // @ts-ignore
     ubuntu_pro_info: {
-      _doc: "Content provided in json response is currently considered Experimental and may change",
       attached: false,
       expires: "n/a",
-      origin: null,
       services: [
         {
           name: "cc-eal",

--- a/src/types/Instance.d.ts
+++ b/src/types/Instance.d.ts
@@ -152,26 +152,6 @@ interface UbuntuProAccount {
   name: string;
 }
 
-interface UbuntuProConfig {
-  contract_url: string;
-  data_dir: string;
-  log_file: string;
-  log_level: string;
-  security_url: string;
-  ua_config: {
-    apt_news: boolean;
-    apt_news_url: string;
-    global_apt_http_proxy: string | null;
-    global_apt_https_proxy: string | null;
-    http_proxy: string | null;
-    https_proxy: string | null;
-    metering_timer: number;
-    ua_apt_http_proxy: string | null;
-    ua_apt_https_proxy: string | null;
-    update_messaging_timer: number;
-  };
-}
-
 interface UbuntuProContract {
   created_at: string;
   id: string;
@@ -184,38 +164,19 @@ export interface UbuntuProService extends Record<string, unknown> {
   name: string;
   available: string;
   description: string;
-  blocked_by?: [];
-  description_override?: null;
   entitled?: string;
   status?: string;
   status_details?: string;
-  warning?: null;
 }
 
 interface UbuntuProInfo {
-  _doc: string;
-  account: UbuntuProAccount;
   attached: boolean;
-  config: UbuntuProConfig;
-  config_path: string;
-  contract: UbuntuProContract;
-  effective: string;
-  environment_vars: [];
-  errors: [];
-  execution_details: string;
-  execution_status: string;
   expires: string;
-  features: {};
-  machine_id: string;
-  notices: [];
-  result: string;
   services: UbuntuProService[];
-  simulated: boolean;
-  version: string;
-  warnings: [];
-  _schema_version?: string;
   techSupportLevel?: string;
-  origin?: unknown | null;
+  effective?: string;
+  contract?: UbuntuProContract;
+  account?: UbuntuProAccount;
 }
 
 export interface InstanceWithoutRelation extends Record<string, unknown> {


### PR DESCRIPTION
- now displays empty fields when no account / table data is present in ubuntu pro information
- added tests
- removed unnecessary interface fields from ubuntu pro