### PR TITLE
(fix): adjust sidepanel forms

### DIFF
--- a/src/components/form/CodeEditor.tsx
+++ b/src/components/form/CodeEditor.tsx
@@ -44,6 +44,7 @@ const CodeEditor: FC<CodeEditorProps> = ({
           language="shell"
           height="16rem"
           loading={<LoadingState />}
+          defaultValue="#!/bin/bash"
           className={classNames(
             classes.highlighter,
             {

--- a/src/features/activities/Activities/Activities.tsx
+++ b/src/features/activities/Activities/Activities.tsx
@@ -174,6 +174,9 @@ const Activities: FC<ActivitiesProps> = ({ instanceId }) => {
       {
         accessor: "creator.name",
         Header: "Creator",
+        Cell: ({ row }: CellProps<ActivityCommon>) => (
+          <>{row.original.creator?.name ?? "-"}</>
+        ),
       },
     ],
     [activities, selectedIds],

--- a/src/features/scripts/ScriptListActions/ScriptListActions.tsx
+++ b/src/features/scripts/ScriptListActions/ScriptListActions.tsx
@@ -110,7 +110,7 @@ const ScriptListActions: FC<ScriptListActionsProps> = ({ script }) => {
             aria-label={`Copy ${script.title} script`}
             onClick={() => handleScript({ action: "copy", script: script })}
           >
-            <Icon name="fork" className="u-no-margin--left" />
+            <Icon name="canvas" className="u-no-margin--left" />
           </Button>
         </Tooltip>
       </div>

--- a/src/features/scripts/ScriptRunForm/ScriptRunForm.module.scss
+++ b/src/features/scripts/ScriptRunForm/ScriptRunForm.module.scss
@@ -1,0 +1,10 @@
+@import "vanilla-framework/scss/settings_spacing";
+
+.bold {
+  font-weight: 550;
+}
+
+.radioGroup {
+  display: flex;
+  column-gap: $sph--x-large;
+}

--- a/src/features/scripts/ScriptRunForm/ScriptRunForm.tsx
+++ b/src/features/scripts/ScriptRunForm/ScriptRunForm.tsx
@@ -1,12 +1,7 @@
 import { useFormik } from "formik";
 import moment from "moment";
-import { FC } from "react";
-import {
-  CheckboxInput,
-  Form,
-  Input,
-  MultiSelectItem,
-} from "@canonical/react-components";
+import { ChangeEvent, FC } from "react";
+import { Form, Input, MultiSelectItem } from "@canonical/react-components";
 import MultiSelectField from "@/components/form/MultiSelectField";
 import SidePanelFormButtons from "@/components/form/SidePanelFormButtons";
 import { ExecuteScriptParams, useScripts } from "@/features/scripts/hooks";
@@ -17,6 +12,7 @@ import useNotify from "@/hooks/useNotify";
 import useSidePanel from "@/hooks/useSidePanel";
 import { INITIAL_VALUES, VALIDATION_SCHEMA } from "./constants";
 import { FormProps } from "./types";
+import classes from "./ScriptRunForm.module.scss";
 
 interface ScriptRunFormProps {
   script: Script;
@@ -94,6 +90,17 @@ const ScriptRunForm: FC<ScriptRunFormProps> = ({ script }) => {
       label: title,
       value: id,
     })) ?? [];
+
+  const handleDeliveryTimeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const deliverImmediately = event.currentTarget.value === "true";
+    formik.setFieldValue("deliverImmediately", deliverImmediately);
+    if (!deliverImmediately) {
+      formik.setFieldValue(
+        "deliver_after",
+        moment().toISOString().slice(0, 16),
+      );
+    }
+  };
 
   return (
     <Form onSubmit={formik.handleSubmit} noValidate>
@@ -177,24 +184,39 @@ const ScriptRunForm: FC<ScriptRunFormProps> = ({ script }) => {
             : undefined
         }
       />
-
-      <CheckboxInput
-        label="Deliver as soon as possible"
-        {...formik.getFieldProps("deliverImmediately")}
-        checked={formik.values.deliverImmediately}
-      />
-
-      <Input
-        type="datetime-local"
-        label="Deliver after"
-        disabled={formik.values.deliverImmediately}
-        {...formik.getFieldProps("deliver_after")}
-        error={
-          formik.touched.deliver_after && formik.errors.deliver_after
-            ? formik.errors.deliver_after
-            : undefined
-        }
-      />
+      <span className={classes.bold}>Delivery time</span>
+      <div className={classes.radioGroup}>
+        <Input
+          type="radio"
+          label="As soon as possible"
+          name="deliverImmediately"
+          value="true"
+          onChange={handleDeliveryTimeChange}
+          checked={formik.values.deliverImmediately}
+        />
+        <Input
+          type="radio"
+          label="Scheduled"
+          name="deliverImmediately"
+          value="false"
+          onChange={handleDeliveryTimeChange}
+          checked={!formik.values.deliverImmediately}
+        />
+      </div>
+      {!formik.values.deliverImmediately && (
+        <Input
+          type="datetime-local"
+          label="Deliver after"
+          labelClassName="u-off-screen"
+          {...formik.getFieldProps("deliver_after")}
+          error={
+            formik.touched.deliver_after && formik.errors.deliver_after
+              ? formik.errors.deliver_after
+              : undefined
+          }
+          help="Format MM-DD-YYYY HH:mm"
+        />
+      )}
 
       <SidePanelFormButtons
         submitButtonDisabled={formik.isSubmitting}

--- a/src/features/snaps/EditSnap/EditSnap.tsx
+++ b/src/features/snaps/EditSnap/EditSnap.tsx
@@ -243,7 +243,7 @@ const EditSnap: FC<EditSnapProps> = ({ installedSnaps, type, instanceId }) => {
         />
       )}
       <span className={classNames(classes.bold, classes.marginTop)}>
-        Randomize delivery over a time window
+        Randomise delivery over a time window
       </span>
       <div className={classes.radioGroup}>
         <Input

--- a/src/features/upgrade-profiles/SingleUpgradeProfileForm/SingleUpgradeProfileForm.test.tsx
+++ b/src/features/upgrade-profiles/SingleUpgradeProfileForm/SingleUpgradeProfileForm.test.tsx
@@ -22,7 +22,7 @@ describe("SingleUpgradeProfileForm", () => {
       "Time",
       "Expires after",
       "hours",
-      "Randomize delivery over a time window",
+      "Randomise delivery over a time window",
       "No",
       "Yes",
       "Association",

--- a/src/features/upgrade-profiles/UpgradeProfileScheduleBlock/UpgradeProfileScheduleBlock.tsx
+++ b/src/features/upgrade-profiles/UpgradeProfileScheduleBlock/UpgradeProfileScheduleBlock.tsx
@@ -153,7 +153,7 @@ const UpgradeProfileScheduleBlock: FC<UpgradeProfileScheduleBlockProps> = ({
         )}
       </div>
 
-      <p>Randomize delivery over a time window</p>
+      <p>Randomise delivery over a time window</p>
 
       <div className={classes.radioGroup}>
         <RadioInput

--- a/src/pages/dashboard/instances/RunScriptForm/RunScriptForm.module.scss
+++ b/src/pages/dashboard/instances/RunScriptForm/RunScriptForm.module.scss
@@ -1,0 +1,10 @@
+@import "vanilla-framework/scss/settings_spacing";
+
+.bold {
+  font-weight: 550;
+}
+
+.radioGroup {
+  display: flex;
+  column-gap: $sph--x-large;
+}

--- a/src/pages/dashboard/instances/RunScriptForm/RunScriptForm.tsx
+++ b/src/pages/dashboard/instances/RunScriptForm/RunScriptForm.tsx
@@ -18,6 +18,8 @@ import SidePanelFormButtons from "@/components/form/SidePanelFormButtons";
 import { SelectOption } from "@/types/SelectOption";
 import useRoles from "@/hooks/useRoles";
 import CodeEditor from "@/components/form/CodeEditor";
+import classes from "./RunScriptForm.module.scss";
+import moment from "moment";
 
 interface FormProps
   extends CreateScriptParams,
@@ -224,6 +226,17 @@ const RunScriptForm: FC<RunScriptFormProps> = ({ query }) => {
       })),
     [getAccessGroupResult],
   );
+
+  const handleDeliveryTimeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const deliverImmediately = event.currentTarget.value === "true";
+    formik.setFieldValue("deliverImmediately", deliverImmediately);
+    if (!deliverImmediately) {
+      formik.setFieldValue(
+        "deliver_after",
+        moment().toISOString().slice(0, 16),
+      );
+    }
+  };
 
   return (
     <Form onSubmit={formik.handleSubmit} noValidate>
@@ -439,24 +452,39 @@ const RunScriptForm: FC<RunScriptFormProps> = ({ query }) => {
         </>
       )}
 
-      <CheckboxInput
-        label="Deliver as soon as possible"
-        {...formik.getFieldProps("deliverImmediately")}
-        checked={formik.values.deliverImmediately}
-      />
-
-      <Input
-        label="Deliver after"
-        type="datetime-local"
-        required={!formik.values.deliverImmediately}
-        disabled={formik.values.deliverImmediately}
-        {...formik.getFieldProps("deliver_after")}
-        error={
-          formik.touched.deliver_after && formik.errors.deliver_after
-            ? formik.errors.deliver_after
-            : undefined
-        }
-      />
+      <span className={classes.bold}>Delivery time</span>
+      <div className={classes.radioGroup}>
+        <Input
+          type="radio"
+          label="As soon as possible"
+          name="deliverImmediately"
+          value="true"
+          onChange={handleDeliveryTimeChange}
+          checked={formik.values.deliverImmediately}
+        />
+        <Input
+          type="radio"
+          label="Scheduled"
+          name="deliverImmediately"
+          value="false"
+          onChange={handleDeliveryTimeChange}
+          checked={!formik.values.deliverImmediately}
+        />
+      </div>
+      {!formik.values.deliverImmediately && (
+        <Input
+          label="Deliver after"
+          type="datetime-local"
+          labelClassName="u-off-screen"
+          {...formik.getFieldProps("deliver_after")}
+          error={
+            formik.touched.deliver_after && formik.errors.deliver_after
+              ? formik.errors.deliver_after
+              : undefined
+          }
+          help="Format MM-DD-YYYY HH:mm"
+        />
+      )}
 
       <SidePanelFormButtons
         submitButtonDisabled={formik.isSubmitting}

--- a/src/pages/dashboard/instances/[single]/SingleInstanceTabs/SingleInstanceTabs.tsx
+++ b/src/pages/dashboard/instances/[single]/SingleInstanceTabs/SingleInstanceTabs.tsx
@@ -3,6 +3,7 @@ import { useLocation } from "react-router-dom";
 import { Tabs } from "@canonical/react-components";
 import LoadingState from "@/components/layout/LoadingState";
 import { Instance } from "@/types/Instance";
+import useSidePanel from "@/hooks/useSidePanel";
 import { getTabLinks } from "./helpers";
 import classes from "./SingleInstanceTabs.module.scss";
 
@@ -59,6 +60,7 @@ const SingleInstanceTabs: FC<SingleInstanceTabsProps> = ({
 }) => {
   const [currentTabLinkId, setCurrentTabLinkId] = useState("tab-link-info");
   const [tabState, setTabState] = useState<TabState | null>(null);
+  const { closeSidePanel } = useSidePanel();
 
   const { state } = useLocation();
 
@@ -82,6 +84,7 @@ const SingleInstanceTabs: FC<SingleInstanceTabsProps> = ({
     onActiveTabChange: (tabId) => {
       setCurrentTabLinkId(tabId);
       setTabState(null);
+      closeSidePanel();
     },
     packageCount,
     packagesLoading,

--- a/src/pages/dashboard/instances/[single]/tabs/packages/InstalledPackagesActionForm/InstalledPackagesActionForm.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/packages/InstalledPackagesActionForm/InstalledPackagesActionForm.tsx
@@ -209,6 +209,7 @@ const InstalledPackagesActionForm: FC<InstalledPackagesActionFormProps> = ({
               type="datetime-local"
               label="Deliver after"
               labelClassName="u-off-screen"
+              help="Format MM-DD-YYYY HH:mm"
               {...formik.getFieldProps("deliver_after")}
               error={
                 formik.touched.deliver_after && formik.errors.deliver_after
@@ -218,7 +219,7 @@ const InstalledPackagesActionForm: FC<InstalledPackagesActionFormProps> = ({
             />
           )}
           <span className={classNames(classes.bold, classes.marginTop)}>
-            Randomize delivery
+            Randomise delivery
           </span>
           <div className={classes.radioGroup}>
             <Input
@@ -247,6 +248,7 @@ const InstalledPackagesActionForm: FC<InstalledPackagesActionFormProps> = ({
               min={0}
               label="Delivery delay window"
               labelClassName="u-off-screen"
+              help="Time in minutes"
               {...formik.getFieldProps("deliver_delay_window")}
               error={
                 formik.touched.deliver_delay_window &&

--- a/src/pages/dashboard/settings/administrators/tabs/administrators/AdministratorRolesCell/AdministratorRolesCell.module.scss
+++ b/src/pages/dashboard/settings/administrators/tabs/administrators/AdministratorRolesCell/AdministratorRolesCell.module.scss
@@ -3,6 +3,8 @@
 
 .footer {
   margin-bottom: $spv--small;
+  width: 100%;
+  text-align: right;
 }
 
 .multiSelect {

--- a/src/pages/dashboard/settings/administrators/tabs/administrators/AdministratorRolesCell/AdministratorRolesCell.tsx
+++ b/src/pages/dashboard/settings/administrators/tabs/administrators/AdministratorRolesCell/AdministratorRolesCell.tsx
@@ -76,21 +76,6 @@ const AdministratorRolesCell: FC<AdministratorRolesCellProps> = ({
         dropdownFooter={
           <div className={classes.footer}>
             <Button
-              type="submit"
-              dense
-              small
-              appearance="positive"
-              className="u-no-margin--bottom"
-              disabled={
-                formik.values.roles.length === administrator.roles.length &&
-                administrator.roles.every((role) =>
-                  formik.values.roles.includes(role),
-                )
-              }
-            >
-              Save changes
-            </Button>
-            <Button
               type="button"
               dense
               small
@@ -104,6 +89,21 @@ const AdministratorRolesCell: FC<AdministratorRolesCellProps> = ({
               onClick={() => formik.setFieldValue("roles", administrator.roles)}
             >
               Revert
+            </Button>
+            <Button
+              type="submit"
+              dense
+              small
+              appearance="positive"
+              className="u-no-margin--bottom"
+              disabled={
+                formik.values.roles.length === administrator.roles.length &&
+                administrator.roles.every((role) =>
+                  formik.values.roles.includes(role),
+                )
+              }
+            >
+              Save changes
             </Button>
           </div>
         }

--- a/src/pages/dashboard/settings/administrators/tabs/administrators/InviteAdministratorForm/InviteAdministratorForm.tsx
+++ b/src/pages/dashboard/settings/administrators/tabs/administrators/InviteAdministratorForm/InviteAdministratorForm.tsx
@@ -9,6 +9,7 @@ import useDebug from "@/hooks/useDebug";
 import useNotify from "@/hooks/useNotify";
 import useRoles from "@/hooks/useRoles";
 import { SelectOption } from "@/types/SelectOption";
+import useSidePanel from "@/hooks/useSidePanel";
 
 interface FormProps {
   email: string;
@@ -35,6 +36,7 @@ const InviteAdministratorForm: FC = () => {
   const { notify } = useNotify();
   const { inviteAdministratorQuery } = useAdministrators();
   const { getRolesQuery } = useRoles();
+  const { closeSidePanel } = useSidePanel();
 
   const { mutateAsync: inviteAdministrator } = inviteAdministratorQuery;
 
@@ -45,6 +47,7 @@ const InviteAdministratorForm: FC = () => {
       try {
         await inviteAdministrator(values);
 
+        closeSidePanel();
         notify.success({
           title: "You sent an administrator invite",
           message: `${values.name} will receive an invitation email`,


### PR DESCRIPTION
- changed "randomize" to "randomise"
- added fallback text for creator of an activity in activities list
- sidepanel now automatically closes when changing tabs inside an instance
- added default value to script code editor
- changed duplicate icon at script list
- changed delivery time from "checkbox and disabled date input" to new format with radio buttons
- closed sidepanel when inviting an administrator before showing success notification
- added helper text to packages form (similar to snaps)