### PR TITLE
(fix): add default organisation info

### DIFF
--- a/src/components/layout/InfoItem.tsx
+++ b/src/components/layout/InfoItem.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useState } from "react";
+import { FC, Fragment, ReactNode, useState } from "react";
 import classes from "./InfoItem.module.scss";
 import classNames from "classnames";
 import { Button } from "@canonical/react-components";
@@ -37,11 +37,11 @@ const getContentDisplayed = (
               {props.value
                 .replace(/\\r/g, "")
                 .split("\\n")
-                .map((str) => (
-                  <>
+                .map((str, index) => (
+                  <Fragment key={index}>
                     {str}
                     <br />
-                  </>
+                  </Fragment>
                 ))}
             </code>
           </pre>

--- a/src/features/account-settings/general/GeneralSettings.module.scss
+++ b/src/features/account-settings/general/GeneralSettings.module.scss
@@ -10,3 +10,7 @@
   display: flex;
   justify-content: space-between;
 }
+
+.identity {
+  word-break: break-word;
+}

--- a/src/features/account-settings/general/GeneralSettings.tsx
+++ b/src/features/account-settings/general/GeneralSettings.tsx
@@ -3,8 +3,9 @@ import LoadingState from "@/components/layout/LoadingState";
 import useSidePanel from "@/hooks/useSidePanel";
 import { UserDetails } from "@/types/UserDetails";
 import { Button, Col, Row } from "@canonical/react-components";
-import { FC, Suspense, lazy } from "react";
+import { FC, Suspense, lazy, useState } from "react";
 import classes from "./GeneralSettings.module.scss";
+import { useMediaQuery } from "usehooks-ts";
 
 interface GeneralSettingsProps {
   user: UserDetails;
@@ -14,7 +15,10 @@ const EditUserForm = lazy(() => import("../edit-user-form"));
 const ChangePasswordForm = lazy(() => import("../change-password-form"));
 
 const GeneralSettings: FC<GeneralSettingsProps> = ({ user }) => {
+  const [openDropdown, setOpenDropdown] = useState(false);
+
   const { setSidePanelContent } = useSidePanel();
+  const isLargeScreen = useMediaQuery("(min-width: 620px)");
 
   const userPersonalDetails = [
     {
@@ -27,7 +31,13 @@ const GeneralSettings: FC<GeneralSettingsProps> = ({ user }) => {
     },
     {
       label: "identity",
-      value: <code>{user.identity}</code>,
+      value: <code className={classes.identity}>{user.identity}</code>,
+    },
+    {
+      label: "default organisation",
+      value:
+        user.accounts.find((acc) => acc.name === user.preferred_account)
+          ?.title ?? "-",
     },
   ];
 
@@ -55,27 +65,68 @@ const GeneralSettings: FC<GeneralSettingsProps> = ({ user }) => {
         <h2 className="p-heading--4 u-no-margin--bottom u-no-padding--top">
           {user.name}
         </h2>
-        <div>
-          <Button
-            className="p-segmented-control__button u-no-margin--bottom"
-            type="button"
-            onClick={handleEditUser}
-          >
-            <span>Edit profile</span>
-          </Button>
-          <Button
-            className="p-segmented-control__button u-no-margin--bottom"
-            type="button"
-            onClick={handleChangePassword}
-          >
-            <span>Change password</span>
-          </Button>
-        </div>
+        {isLargeScreen ? (
+          <div>
+            <Button
+              className="p-segmented-control__button u-no-margin--bottom"
+              type="button"
+              onClick={handleEditUser}
+            >
+              <span>Edit profile</span>
+            </Button>
+            <Button
+              className="p-segmented-control__button u-no-margin--bottom"
+              type="button"
+              onClick={handleChangePassword}
+            >
+              <span>Change password</span>
+            </Button>
+          </div>
+        ) : (
+          <span className="p-contextual-menu">
+            <Button
+              className="p-contextual-menu__toggle u-no-margin--bottom"
+              aria-controls="series-cta"
+              aria-expanded={openDropdown}
+              aria-haspopup="true"
+              onClick={() => {
+                setOpenDropdown((prevState) => !prevState);
+              }}
+              onBlur={() => {
+                setOpenDropdown(false);
+              }}
+            >
+              Actions
+            </Button>
+            <span
+              className="p-contextual-menu__dropdown"
+              id="series-cta"
+              aria-hidden={!openDropdown}
+            >
+              <Button
+                className="p-contextual-menu__link p-segmented-control__button u-no-margin--bottom"
+                type="button"
+                onClick={handleEditUser}
+                onMouseDown={(e) => e.preventDefault()}
+              >
+                <span>Edit profile</span>
+              </Button>
+              <Button
+                className="p-contextual-menu__link p-segmented-control__button u-no-margin--bottom"
+                type="button"
+                onClick={handleChangePassword}
+                onMouseDown={(e) => e.preventDefault()}
+              >
+                <span>Change password</span>
+              </Button>
+            </span>
+          </span>
+        )}
       </div>
       <div className={classes.infoRow}>
         <Row className="u-no-padding--left u-no-padding--right u-no-max-width">
           {userPersonalDetails.map(({ label, value }) => (
-            <Col size={label === "identity" ? 6 : 3} key={label}>
+            <Col medium={3} size={3} key={label}>
               <InfoItem label={label} value={value} />
             </Col>
           ))}

--- a/src/features/activities/Activities/Activities.tsx
+++ b/src/features/activities/Activities/Activities.tsx
@@ -1,6 +1,5 @@
 import moment from "moment/moment";
-import { FC, lazy, Suspense, useEffect, useMemo, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { FC, lazy, Suspense, useMemo, useState } from "react";
 import { CellProps, Column } from "react-table";
 import {
   Button,
@@ -13,10 +12,13 @@ import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import ActivitiesEmptyState from "@/features/activities/ActivitiesEmptyState";
 import ActivitiesHeader from "@/features/activities/ActivitiesHeader";
 import { ACTIVITY_STATUSES } from "@/features/activities/constants";
-import { useActivities } from "@/features/activities/hooks";
+import {
+  useActivities,
+  useOpenActivityDetails,
+} from "@/features/activities/hooks";
 import useDebug from "@/hooks/useDebug";
 import useSidePanel from "@/hooks/useSidePanel";
-import { Activity, ActivityCommon } from "@/features/activities/types";
+import { ActivityCommon } from "@/features/activities/types";
 import classes from "./Activities.module.scss";
 
 const ActivityDetails = lazy(
@@ -36,7 +38,6 @@ const Activities: FC<ActivitiesProps> = ({ instanceId }) => {
   const debug = useDebug();
   const { setSidePanelContent } = useSidePanel();
   const { getActivitiesQuery } = useActivities();
-  const { state }: { state: { activity?: Activity } } = useLocation();
 
   const handleActivityDetailsOpen = (activity: ActivityCommon) => {
     setSidePanelContent(
@@ -47,14 +48,7 @@ const Activities: FC<ActivitiesProps> = ({ instanceId }) => {
     );
   };
 
-  useEffect(() => {
-    if (!state?.activity) {
-      return;
-    }
-
-    handleActivityDetailsOpen(state.activity);
-    window.history.replaceState({}, "");
-  }, [state?.activity]);
+  useOpenActivityDetails(handleActivityDetailsOpen);
 
   const handlePaginate = (pageNumber: number) => {
     setCurrentPage(pageNumber);

--- a/src/features/activities/hooks/index.ts
+++ b/src/features/activities/hooks/index.ts
@@ -1,1 +1,2 @@
 export { default as useActivities } from "./useActivities";
+export { default as useOpenActivityDetails } from "./useOpenActivityDetails";

--- a/src/features/activities/hooks/useOpenActivityDetails.ts
+++ b/src/features/activities/hooks/useOpenActivityDetails.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { Activity, ActivityCommon } from "../types";
+import { useLocation } from "react-router-dom";
+
+export default function useOpenActivityDetailsEffect(
+  handleActivityDetailsOpen: (activity: ActivityCommon) => void,
+) {
+  const { state }: { state: { activity?: Activity } } = useLocation();
+  const activity = state?.activity;
+  useEffect(() => {
+    if (!state?.activity) {
+      return;
+    }
+
+    handleActivityDetailsOpen(state.activity);
+    window.history.replaceState({}, "");
+  }, [activity]);
+}

--- a/src/features/overview/AlertCard/AlertCard.tsx
+++ b/src/features/overview/AlertCard/AlertCard.tsx
@@ -2,11 +2,12 @@ import { FC, ReactNode } from "react";
 import classes from "./AlertCard.module.scss";
 import classNames from "classnames";
 import useInstances from "@/hooks/useInstances";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { ROOT_PATH } from "@/constants";
 import useDebug from "@/hooks/useDebug";
 import { QUERY_STATUSES } from "@/pages/dashboard/instances/InstancesContainer/constants";
 import LoadingState from "@/components/layout/LoadingState";
+import { Button } from "@canonical/react-components";
 
 interface AlertCardProps {
   alertQueryData: {
@@ -18,6 +19,7 @@ interface AlertCardProps {
 
 const AlertCard: FC<AlertCardProps> = ({ alertQueryData }) => {
   const { getInstancesQuery } = useInstances();
+  const navigate = useNavigate();
   const debug = useDebug();
 
   const {
@@ -35,6 +37,10 @@ const AlertCard: FC<AlertCardProps> = ({ alertQueryData }) => {
     debug(error);
   }
 
+  const handleAlertClick = () => {
+    navigate(`${ROOT_PATH}instances?status=${alertQueryData.filterValue}`);
+  };
+
   return (
     <div className={classes.container}>
       <div className={classes.title}>
@@ -48,16 +54,18 @@ const AlertCard: FC<AlertCardProps> = ({ alertQueryData }) => {
         <p className="u-no-margin--bottom">Error loading data.</p>
       )}
       {!isLoading && !isError && (
-        <Link
+        <Button
+          appearance="link"
+          disabled={!alertsData.data.count}
+          onClick={handleAlertClick}
           className={classNames("u-no-margin u-no-padding", classes.link)}
-          to={`${ROOT_PATH}instances?status=${alertQueryData.filterValue}`}
         >
           <span className={classes.instancesNumber}>
             {alertsData.data.count}
           </span>{" "}
           instance
           {alertsData.data.count === 1 ? "" : "s"}
-        </Link>
+        </Button>
       )}
     </div>
   );

--- a/src/features/overview/InfoTablesContainer/InfoTablesContainer.module.scss
+++ b/src/features/overview/InfoTablesContainer/InfoTablesContainer.module.scss
@@ -21,6 +21,12 @@
   text-align: right;
 }
 
+.link {
+  &:visited {
+    color: $color-link;
+  }
+}
+
 .description {
   width: 50%;
 }

--- a/src/features/overview/InfoTablesContainer/InfoTablesContainer.tsx
+++ b/src/features/overview/InfoTablesContainer/InfoTablesContainer.tsx
@@ -111,6 +111,7 @@ const InfoTablesContainer: FC<InfoTablesContainerProps> = () => {
         0,
       );
       return {
+        id: instance.id,
         instanceName: instance.hostname,
         affectedPackages: affectedPackages,
       };
@@ -214,8 +215,8 @@ const InfoTablesContainer: FC<InfoTablesContainerProps> = () => {
             accessor: "instanceName",
             Cell: ({ row }: CellProps<InstancesUpgradesTableItem>) => (
               <Link
-                to={`${ROOT_PATH}instances/${row.original.instanceName}`}
-                className="u-no-margin--bottom"
+                to={`${ROOT_PATH}instances/${row.original.id}`}
+                className={classNames("u-no-margin--bottom", classes.link)}
               >
                 {row.original.instanceName}
               </Link>
@@ -239,7 +240,7 @@ const InfoTablesContainer: FC<InfoTablesContainerProps> = () => {
             Cell: ({ row }: CellProps<OldPackage>) => (
               <Link
                 to={`${ROOT_PATH}instances`}
-                className="u-no-margin--bottom"
+                className={classNames("u-no-margin--bottom", classes.link)}
               >
                 {row.original.computers.upgrades.length}
               </Link>
@@ -259,7 +260,7 @@ const InfoTablesContainer: FC<InfoTablesContainerProps> = () => {
             Cell: ({ row }: CellProps<Usn>) => (
               <Link
                 to={`${ROOT_PATH}instances`}
-                className="u-no-margin--bottom"
+                className={classNames("u-no-margin--bottom", classes.link)}
               >
                 {row.original.computers_count}
               </Link>
@@ -307,7 +308,7 @@ const InfoTablesContainer: FC<InfoTablesContainerProps> = () => {
           <Link
             to={`${ROOT_PATH}activities`}
             state={{ activity: row.original as Activity }}
-            className="u-no-margin--bottom"
+            className={classNames("u-no-margin--bottom", classes.link)}
           >
             {row.original.summary}
           </Link>
@@ -316,6 +317,9 @@ const InfoTablesContainer: FC<InfoTablesContainerProps> = () => {
       {
         Header: "Creator",
         accessor: "creator.name",
+        Cell: ({ row }: CellProps<ActivityCommon>) => (
+          <>{row.original.creator?.name ?? "-"}</>
+        ),
       },
       {
         Header: "Created at",

--- a/src/features/overview/InfoTablesContainer/helpers.ts
+++ b/src/features/overview/InfoTablesContainer/helpers.ts
@@ -2,6 +2,7 @@ import { OldPackage } from "@/types/Package";
 import { Usn } from "@/types/Usn";
 
 export interface InstancesUpgradesTableItem extends Record<string, unknown> {
+  id: number;
   instanceName: string;
   affectedPackages: number;
 }


### PR DESCRIPTION
- added default organisation information
- cta buttons in general settings now grouped in 1 button for smaller screen sizes
- added keys to InfoItem snippet
- refactored useEffect in Activities to a custom hook
- links in overview page now only appear as unvisited (blue)
- fixed url link redirection when clicking on an instance in overview page
- added fallback "-" when an activity's creator name isn't present in overview page