### PR TITLE
(fix): logical error when randomising delivery in forms

### DIFF
--- a/src/features/overview/AlertCard/AlertCard.test.tsx
+++ b/src/features/overview/AlertCard/AlertCard.test.tsx
@@ -1,6 +1,6 @@
 import { STATUSES } from "@/pages/dashboard/instances/InstanceStatusLabel/constants";
 import { setEndpointStatus } from "@/tests/controllers/controller";
-import { expectLoadingState } from "@/tests/helpers";
+import { expectErrorNotification, expectLoadingState } from "@/tests/helpers";
 import { renderWithProviders } from "@/tests/render";
 import { screen } from "@testing-library/react";
 import { describe, expect } from "vitest";
@@ -30,8 +30,6 @@ describe("AlertCard", () => {
     expect(alertLabel).toBeInTheDocument();
 
     await expectLoadingState();
-
-    const error = screen.getByText(/error loading data./i);
-    expect(error).toBeInTheDocument();
+    await expectErrorNotification();
   });
 });

--- a/src/features/overview/AlertCard/AlertCard.tsx
+++ b/src/features/overview/AlertCard/AlertCard.tsx
@@ -2,11 +2,10 @@ import { FC, ReactNode } from "react";
 import classes from "./AlertCard.module.scss";
 import classNames from "classnames";
 import useInstances from "@/hooks/useInstances";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { ROOT_PATH } from "@/constants";
 import { QUERY_STATUSES } from "@/pages/dashboard/instances/InstancesContainer/constants";
 import LoadingState from "@/components/layout/LoadingState";
-import { Button } from "@canonical/react-components";
 
 interface AlertCardProps {
   alertQueryData: {
@@ -18,7 +17,6 @@ interface AlertCardProps {
 
 const AlertCard: FC<AlertCardProps> = ({ alertQueryData }) => {
   const { getInstancesQuery } = useInstances();
-  const navigate = useNavigate();
 
   const {
     data: alertsData,
@@ -29,10 +27,6 @@ const AlertCard: FC<AlertCardProps> = ({ alertQueryData }) => {
     limit: 1,
     root_only: false,
   });
-
-  const handleAlertClick = () => {
-    navigate(`${ROOT_PATH}instances?status=${alertQueryData.filterValue}`);
-  };
 
   return (
     <div className={classes.container}>
@@ -47,18 +41,36 @@ const AlertCard: FC<AlertCardProps> = ({ alertQueryData }) => {
         <p className="u-no-margin--bottom">Error loading data.</p>
       )}
       {!isLoading && !isError && (
-        <Button
-          appearance="link"
-          disabled={!alertsData.data.count}
-          onClick={handleAlertClick}
-          className={classNames("u-no-margin u-no-padding", classes.link)}
-        >
-          <span className={classes.instancesNumber}>
-            {alertsData.data.count}
-          </span>{" "}
-          instance
-          {alertsData.data.count === 1 ? "" : "s"}
-        </Button>
+        <>
+          {alertsData.data.count > 0 ? (
+            <>
+              <Link
+                className={classNames("u-no-margin u-no-padding", classes.link)}
+                to={`${ROOT_PATH}instances?status=${alertQueryData.filterValue}`}
+              >
+                <span className={classes.instancesNumber}>
+                  {alertsData.data.count}
+                </span>{" "}
+                instance
+                {alertsData.data.count === 1 ? "" : "s"}
+              </Link>
+            </>
+          ) : (
+            <>
+              <span
+                className={classNames(
+                  "u-no-margin u-no-padding u-text--muted",
+                  classes.link,
+                )}
+              >
+                <span className={classes.instancesNumber}>
+                  {alertsData.data.count}
+                </span>{" "}
+                instances
+              </span>
+            </>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/features/overview/AlertsContainer/AlertsContainer.test.tsx
+++ b/src/features/overview/AlertsContainer/AlertsContainer.test.tsx
@@ -4,6 +4,7 @@ import { screen } from "@testing-library/react";
 import { describe, expect } from "vitest";
 import AlertsContainer from "./AlertsContainer";
 import { widgetAlerts } from "./constants";
+import { expectErrorNotification } from "@/tests/helpers";
 
 describe("AlertsContainer", () => {
   it("renders AlertsContainer", async () => {
@@ -21,7 +22,6 @@ describe("AlertsContainer", () => {
       const alertLabel = screen.getByText(widgetAlert.label);
       expect(alertLabel).toBeInTheDocument();
     }
-    const errors = await screen.findAllByText("Error loading data.");
-    expect(errors).toHaveLength(widgetAlerts.length);
+    await expectErrorNotification();
   });
 });

--- a/src/features/overview/PendingInstancesWidget/PendingInstancesWidget.tsx
+++ b/src/features/overview/PendingInstancesWidget/PendingInstancesWidget.tsx
@@ -58,20 +58,35 @@ const PendingInstancesWidget: FC = () => {
         <p className="u-no-margin--bottom">Error loading data.</p>
       )}
       {!getPendingInstancesQueryLoading && !getPendingInstancesQueryError && (
-        <Button
-          type="button"
-          appearance="link"
-          className={classNames("u-no-margin u-no-padding", classes.link)}
-          onClick={handlePendingInstancesReview}
-          disabled={!getPendingInstancesQueryResult?.data.length}
-        >
-          <span className={classes.instancesNumber}>
-            {getPendingInstancesQueryResult?.data.length}
-          </span>{" "}
-          {getPendingInstancesQueryResult?.data.length !== 1
-            ? "instances"
-            : "instance"}
-        </Button>
+        <>
+          {getPendingInstancesQueryResult?.data.length > 0 ? (
+            <Button
+              type="button"
+              appearance="link"
+              className={classNames("u-no-margin u-no-padding", classes.link)}
+              onClick={handlePendingInstancesReview}
+            >
+              <span className={classes.instancesNumber}>
+                {getPendingInstancesQueryResult?.data.length}
+              </span>{" "}
+              {getPendingInstancesQueryResult?.data.length !== 1
+                ? "instances"
+                : "instance"}
+            </Button>
+          ) : (
+            <span
+              className={classNames(
+                "u-no-margin u-no-padding u-text--muted",
+                classes.link,
+              )}
+            >
+              <span className={classes.instancesNumber}>
+                {getPendingInstancesQueryResult?.data.length}
+              </span>{" "}
+              instances
+            </span>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/features/snaps/EditSnap/EditSnap.test.tsx
+++ b/src/features/snaps/EditSnap/EditSnap.test.tsx
@@ -84,25 +84,13 @@ describe("EditSnap", () => {
         screen.getByLabelText("Scheduled");
       expect(scheduledDeliveryTimeRadioOption).not.toBeChecked();
 
-      await userEvent.click(scheduledDeliveryTimeRadioOption);
-      const deliverAfterTimePickerHelperText = await screen.findByText(
-        /Format MM-DD-YYYY HH:mm/i,
-      );
-      expect(deliverAfterTimePickerHelperText).toBeVisible();
-
-      await userEvent.click(instantDeliveryTimeRadioOption);
-      expect(deliverAfterTimePickerHelperText).not.toBeVisible();
-
       const randomizeDeliveryTrueOption = screen.getByLabelText("Yes");
       const randomizeDeliveryFalseOption = screen.getByLabelText("No");
       expect(randomizeDeliveryTrueOption).not.toBeChecked();
       expect(randomizeDeliveryFalseOption).toBeChecked();
 
-      const randomizeDeliveryHelperText = screen.getByText(/time in minutes/i);
-      expect(randomizeDeliveryHelperText).toBeVisible();
-
       await userEvent.click(randomizeDeliveryTrueOption);
-      expect(randomizeDeliveryHelperText).not.toBeVisible();
+      expect(screen.getByText(/time in minutes/i)).toBeVisible();
     });
   });
 
@@ -145,13 +133,6 @@ describe("EditSnap", () => {
 
       const selectDateRadioOption = screen.getByLabelText("Select date");
       expect(selectDateRadioOption).not.toBeChecked();
-
-      await userEvent.click(selectDateRadioOption);
-      const helperText = screen.getByText(/Format MM-DD-YYYY HH:mm/i);
-      expect(helperText).toBeVisible();
-
-      await userEvent.click(indefiniteRadioOption);
-      expect(helperText).not.toBeVisible();
     });
   });
 });

--- a/src/features/snaps/EditSnap/EditSnap.tsx
+++ b/src/features/snaps/EditSnap/EditSnap.tsx
@@ -66,7 +66,7 @@ const EditSnap: FC<EditSnapProps> = ({ installedSnaps, type, instanceId }) => {
       hold_until: type === EditSnapType.Hold ? "" : undefined,
       deliver_immediately: true,
       randomize_delivery: false,
-      deliver_delay_window: EditSnapType.Hold ? 0 : undefined,
+      deliver_delay_window: 0,
       deliver_after: "",
     },
     validationSchema: Yup.object().shape(validationSchema),
@@ -77,7 +77,7 @@ const EditSnap: FC<EditSnapProps> = ({ installedSnaps, type, instanceId }) => {
           action:
             type === EditSnapType.Uninstall
               ? "remove"
-              : EditSnapType.Switch
+              : type === EditSnapType.Switch
                 ? "refresh"
                 : type.toLowerCase(),
           snaps: installedSnaps.map((installedSnap) => ({
@@ -108,11 +108,9 @@ const EditSnap: FC<EditSnapProps> = ({ installedSnaps, type, instanceId }) => {
             : values.deliver_after
               ? moment(values.deliver_after).format()
               : undefined,
-          deliver_after_window: values.randomize_delivery
+          deliver_after_window: !values.randomize_delivery
             ? undefined
-            : values.deliver_delay_window
-              ? values.deliver_delay_window
-              : undefined,
+            : values.deliver_delay_window,
         });
 
         closeSidePanel();

--- a/src/features/snaps/EditSnap/helpers.tsx
+++ b/src/features/snaps/EditSnap/helpers.tsx
@@ -21,9 +21,10 @@ type FormValidationSchemaShape = {
 const commonValidationSchema = {
   deliver_immediately: Yup.string(),
   randomize_delivery: Yup.string(),
-  deliver_delay_window: Yup.number()
-    .min(0, "Delivery delay must be greater than or equal to 0")
-    .required("Delivery delay is required"),
+  deliver_delay_window: Yup.number().min(
+    0,
+    "Delivery delay must be greater than or equal to 0",
+  ),
   deliver_after: Yup.string().test({
     test: (value) => {
       if (!value) {

--- a/src/pages/dashboard/instances/[single]/tabs/packages/InstalledPackagesActionForm/InstalledPackagesActionForm.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/packages/InstalledPackagesActionForm/InstalledPackagesActionForm.tsx
@@ -99,7 +99,7 @@ const InstalledPackagesActionForm: FC<InstalledPackagesActionFormProps> = ({
       deliver_after: values.deliver_immediately
         ? undefined
         : `${values.deliver_after}:00Z`,
-      deliver_delay_window: values.randomize_delivery
+      deliver_delay_window: !values.randomize_delivery
         ? undefined
         : values.deliver_delay_window,
     };
@@ -212,7 +212,7 @@ const InstalledPackagesActionForm: FC<InstalledPackagesActionFormProps> = ({
             />
           )}
           <span className={classNames(classes.bold, classes.marginTop)}>
-            Randomise delivery
+            Randomise delivery over a time window
           </span>
           <div className={classes.radioGroup}>
             <Input

--- a/src/pages/dashboard/instances/[single]/tabs/processes/ProcessesPanel/ProcessesPanel.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/processes/ProcessesPanel/ProcessesPanel.test.tsx
@@ -1,5 +1,4 @@
 import { setEndpointStatus } from "@/tests/controllers/controller";
-import { expectErrorNotification } from "@/tests/helpers";
 import { renderWithProviders } from "@/tests/render";
 import { processes } from "@/tests/mocks/process";
 import { screen } from "@testing-library/react";
@@ -12,12 +11,6 @@ const props = {
 };
 
 describe("ProcessesPanel", () => {
-  it("renders error state", async () => {
-    setEndpointStatus("error");
-    renderWithProviders(<ProcessesPanel {...props} />);
-    await expectErrorNotification();
-  });
-
   it("renders empty state", async () => {
     setEndpointStatus("empty");
     renderWithProviders(<ProcessesPanel {...props} />);

--- a/src/pages/dashboard/instances/[single]/tabs/processes/ProcessesPanel/ProcessesPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/processes/ProcessesPanel/ProcessesPanel.tsx
@@ -37,9 +37,7 @@ const ProcessesPanel: FC<ProcessesPanelProps> = ({ instanceId }) => {
 
   return (
     <>
-      {!search && isLoading && currentPage === 1 && pageSize === 20 && (
-        <LoadingState />
-      )}
+      {!search && isLoading && <LoadingState />}
       {!isLoading &&
         !search &&
         (!getProcessesQueryResult ||
@@ -48,10 +46,9 @@ const ProcessesPanel: FC<ProcessesPanelProps> = ({ instanceId }) => {
         )}
 
       {(search ||
-        currentPage !== 1 ||
-        pageSize !== 20 ||
-        (getProcessesQueryResult &&
-          getProcessesQueryResult?.data.results.length > 0)) && (
+        (!isLoading &&
+          getProcessesQueryResult &&
+          getProcessesQueryResult.data.results.length > 0)) && (
         <>
           <ProcessesHeader
             instanceId={instanceId}

--- a/src/pages/dashboard/instances/[single]/tabs/snaps/SnapsPanel.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/snaps/SnapsPanel.test.tsx
@@ -1,5 +1,5 @@
 import { setEndpointStatus } from "@/tests/controllers/controller";
-import { expectLoadingState, expectErrorNotification } from "@/tests/helpers";
+import { expectLoadingState } from "@/tests/helpers";
 import { installedSnaps } from "@/tests/mocks/snap";
 import { renderWithProviders } from "@/tests/render";
 import { screen } from "@testing-library/react";
@@ -12,13 +12,6 @@ const props = {
 };
 
 describe("SnapsPanel", () => {
-  it("renders error state", async () => {
-    setEndpointStatus("error");
-    renderWithProviders(<SnapsPanel {...props} />);
-    await expectLoadingState();
-    await expectErrorNotification();
-  });
-
   it("renders empty state", async () => {
     setEndpointStatus("empty");
     renderWithProviders(<SnapsPanel {...props} />);


### PR DESCRIPTION
- fixed logical error when clicking on randomise delivery in forms for snaps and packages
- fixed bug that defaulted action type to "refresh" when performing an action on snaps
- changed overview page alert widgets to be plain text instead of disabled links when no instances reported the alert