### PR TITLE
feat: github workflow managing PPA build branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,47 @@
+name: PPA build commit
+on:
+  push:
+    branches: [ main ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm install
+      - name: Create PPA Build
+        run: npm run build
+        env:
+          VITE_API_URL: /api/v2/
+          VITE_API_URL_OLD: /api/
+          VITE_ROOT_PATH: /new_dashboard/
+      - name: Archive dist for PPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-for-ppa
+          path: dist
+  commit:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ppa-build
+      - name: Download dist for PPA
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-for-ppa
+          path: dist
+      - name: Commit and Push
+        run: |
+          git config --global user.name 'Mitch Burton'
+          git config --global user.email 'mitch.burton@canonical.com'
+          mv ./dist ../
+          rm -rf ./*
+          mv ../dist/* ./
+          git add .
+          git commit -am 'automated build'
+          git push origin


### PR DESCRIPTION
This adds a github workflow that manages a new branch `ppa-build`. This branch will consist of build artifacts and will be used by Launchpad (or the back-end devs) to build the .deb packages for deployment.

Once this is in place and verified to work, I'll create another job that will produce the .deb artifacts from this branch.

We do need to make a decision on version numbering. I noticed that the version in `package.json` is, and always has been `0.0.0`. It'd be nice to automatically derive the version from this file, but it's not strictly necessary. We can do versioning another way if we want.