### PR TITLE
feat: add Kernel tab in single instance view

### DIFF
--- a/src/components/form/SidePanelFormButtons.tsx
+++ b/src/components/form/SidePanelFormButtons.tsx
@@ -1,5 +1,5 @@
-import { FC, SyntheticEvent } from "react";
 import { Button } from "@canonical/react-components";
+import { FC, ReactElement, ReactNode, SyntheticEvent } from "react";
 import useSidePanel from "../../hooks/useSidePanel";
 import classes from "./SidePanelFormButtons.module.scss";
 
@@ -8,6 +8,8 @@ interface SidePanelFormButtonsProps {
   submitButtonText: string;
   submitButtonAppearance?: "positive" | "negative";
   submitButtonAriaLabel?: string;
+  secondaryActionButtonTitle?: ReactNode;
+  secondaryActionButtonSubmit?: (event: SyntheticEvent) => Promise<void> | void;
   cancelButtonDisabled?: boolean;
   onSubmit?: (event: SyntheticEvent) => Promise<void> | void;
 }
@@ -16,10 +18,12 @@ const SidePanelFormButtons: FC<SidePanelFormButtonsProps> = ({
   submitButtonDisabled,
   submitButtonText,
   submitButtonAriaLabel,
+  secondaryActionButtonTitle,
+  secondaryActionButtonSubmit,
   onSubmit,
   submitButtonAppearance = "positive",
   cancelButtonDisabled = false,
-}) => {
+}): ReactElement => {
   const { closeSidePanel } = useSidePanel();
   return (
     <div className={classes.buttons}>
@@ -32,6 +36,15 @@ const SidePanelFormButtons: FC<SidePanelFormButtonsProps> = ({
       >
         Cancel
       </Button>
+      {secondaryActionButtonTitle && secondaryActionButtonSubmit && (
+        <Button
+          type="button"
+          className="u-no-margin--bottom"
+          onClick={secondaryActionButtonSubmit}
+        >
+          {secondaryActionButtonTitle}
+        </Button>
+      )}
       <Button
         className="u-no-margin--bottom"
         type={onSubmit ? "button" : "submit"}

--- a/src/features/kernel/components/DowngradeKernelForm/DowngradeKernelForm.module.scss
+++ b/src/features/kernel/components/DowngradeKernelForm/DowngradeKernelForm.module.scss
@@ -1,0 +1,15 @@
+@import "vanilla-framework/scss/settings_spacing";
+
+.radioGroup {
+  column-gap: $sph--x-large;
+  display: flex;
+}
+
+.marginTop {
+  display: block;
+  margin-top: $spv--large;
+}
+
+.infoItem {
+  width: 100%;
+}

--- a/src/features/kernel/components/DowngradeKernelForm/DowngradeKernelForm.test.tsx
+++ b/src/features/kernel/components/DowngradeKernelForm/DowngradeKernelForm.test.tsx
@@ -1,0 +1,70 @@
+import { renderWithProviders } from "@/tests/render";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ComponentProps } from "react";
+import DowngradeKernelForm from "./DowngradeKernelForm";
+
+const props: ComponentProps<typeof DowngradeKernelForm> = {
+  currentKernelVersion: "5.11.0-27-generic",
+  downgradeKernelVersions: [
+    {
+      id: 75473,
+      name: "linux-image-virtual",
+      version: "5.15.0.25.27",
+      version_rounded: "5.15.0.25",
+    },
+    {
+      id: 75474,
+      name: "linux-image-virtual-2",
+      version: "5.15.0.25.27",
+      version_rounded: "5.15.0.25",
+    },
+  ],
+  instanceName: "test-instance",
+};
+
+describe("DowngradeKernelForm", () => {
+  it("renders notification message", () => {
+    renderWithProviders(<DowngradeKernelForm {...props} />);
+    expect(screen.getByText(/security warning/i)).toBeVisible();
+  });
+
+  it("radio button functionalities", async () => {
+    renderWithProviders(<DowngradeKernelForm {...props} />);
+
+    const instantDeliveryTimeRadioOption = screen.getByLabelText(
+      "As soon as possible",
+    );
+    expect(instantDeliveryTimeRadioOption).toBeChecked();
+
+    const scheduledDeliveryTimeRadioOption = screen.getByLabelText("Scheduled");
+    expect(scheduledDeliveryTimeRadioOption).not.toBeChecked();
+
+    const randomizeDeliveryTrueOption = screen.getByLabelText("Yes");
+    const randomizeDeliveryFalseOption = screen.getByLabelText("No");
+    expect(randomizeDeliveryTrueOption).not.toBeChecked();
+    expect(randomizeDeliveryFalseOption).toBeChecked();
+
+    await userEvent.click(randomizeDeliveryTrueOption);
+    expect(screen.getByText(/time in minutes/i)).toBeVisible();
+  });
+
+  it("renders form dropdown", async () => {
+    renderWithProviders(<DowngradeKernelForm {...props} />);
+
+    const kernelVersionsCombobox = await screen.findByRole("combobox");
+    expect(kernelVersionsCombobox).toBeInTheDocument();
+  });
+
+  it("switches between dropdown types", async () => {
+    renderWithProviders(<DowngradeKernelForm {...props} />);
+
+    const kernelVersionsCombobox = await screen.findByRole("combobox");
+    expect(kernelVersionsCombobox).toBeInTheDocument();
+
+    const options: HTMLOptionElement[] = await screen.findAllByRole("option");
+    await userEvent.selectOptions(kernelVersionsCombobox, options[1]);
+    expect(options[0].selected).toBeFalsy();
+    expect(options[1].selected).toBeTruthy();
+  });
+});

--- a/src/features/kernel/components/DowngradeKernelForm/DowngradeKernelForm.tsx
+++ b/src/features/kernel/components/DowngradeKernelForm/DowngradeKernelForm.tsx
@@ -1,0 +1,268 @@
+import InfoItem from "@/components/layout/InfoItem";
+import { useActivities } from "@/features/activities";
+import useDebug from "@/hooks/useDebug";
+import useNotify from "@/hooks/useNotify";
+import useSidePanel from "@/hooks/useSidePanel";
+import { SelectOption } from "@/types/SelectOption";
+import {
+  Button,
+  Col,
+  ConfirmationButton,
+  Form,
+  Input,
+  Notification,
+  Row,
+  Select,
+} from "@canonical/react-components";
+import { useFormik } from "formik";
+import moment from "moment";
+import { FC } from "react";
+import { useParams } from "react-router-dom";
+import { useKernel } from "../../hooks";
+import { Kernel } from "../../types";
+import {
+  DOWNGRADE_MESSAGE_WITH_REBOOT,
+  DOWNGRADE_MESSAGE_WITHOUT_REBOOT,
+  SECURITY_WARNING,
+  VALIDATION_SCHEMA,
+} from "./constants";
+import classes from "./DowngradeKernelForm.module.scss";
+import { FormProps } from "./types";
+import { UrlParams } from "@/types/UrlParams";
+
+interface DowngradeKernelFormProps {
+  currentKernelVersion: string;
+  downgradeKernelVersions: Kernel[];
+  instanceName: string;
+}
+
+const DowngradeKernelForm: FC<DowngradeKernelFormProps> = ({
+  currentKernelVersion,
+  downgradeKernelVersions,
+  instanceName,
+}) => {
+  const debug = useDebug();
+  const { instanceId } = useParams<UrlParams>();
+  const { closeSidePanel } = useSidePanel();
+  const { notify } = useNotify();
+  const { downgradeKernelQuery } = useKernel();
+  const { openActivityDetails } = useActivities();
+
+  const { mutateAsync: downgradeKernel, isPending: isDowngradingKernel } =
+    downgradeKernelQuery;
+
+  const KERNEL_VERSION_OPTIONS: SelectOption[] = [
+    {
+      label: "Select",
+      value: "",
+    },
+    ...downgradeKernelVersions.map((kernel) => ({
+      label: kernel.version_rounded,
+      value: kernel.id.toString(),
+    })),
+  ];
+
+  const initialValues: FormProps = {
+    deliver_immediately: true,
+    randomize_delivery: false,
+    deliver_delay_window: 0,
+    deliver_after: "",
+    new_kernel_version_id:
+      downgradeKernelVersions.length === 1
+        ? downgradeKernelVersions[0].id.toString()
+        : "",
+    reboot_after: false,
+  };
+
+  const formik = useFormik<FormProps>({
+    initialValues: initialValues,
+    validationSchema: VALIDATION_SCHEMA,
+    onSubmit: async (values) => {
+      try {
+        const { data: activity } = await downgradeKernel({
+          id: Number(instanceId),
+          kernel_package_id: Number(values.new_kernel_version_id),
+          reboot_after: values.reboot_after,
+        });
+
+        closeSidePanel();
+
+        const downgradeNotificationMessage = values.reboot_after
+          ? DOWNGRADE_MESSAGE_WITH_REBOOT
+          : DOWNGRADE_MESSAGE_WITHOUT_REBOOT;
+
+        notify.success({
+          title: `You queued kernel downgrade for instance "${instanceName}"`,
+          message: downgradeNotificationMessage,
+          actions: [
+            {
+              label: "View details",
+              onClick: () => openActivityDetails(activity),
+            },
+          ],
+        });
+      } catch (error) {
+        debug(error);
+      }
+    },
+  });
+
+  const handleDeliveryTimeChange = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const deliverImmediately = event.currentTarget.value === "true";
+    await formik.setFieldValue("deliver_immediately", deliverImmediately);
+    if (!deliverImmediately) {
+      await formik.setFieldValue(
+        "deliver_after",
+        moment().toISOString().slice(0, 16),
+      );
+    }
+  };
+
+  const handleRebootAndSubmit = async () => {
+    await formik.setFieldValue("reboot_after", true);
+    formik.handleSubmit();
+  };
+
+  return (
+    <Form onSubmit={formik.handleSubmit}>
+      <Notification severity="caution" title="Security warning">
+        <span>{SECURITY_WARNING}</span>
+      </Notification>
+      <Row className="u-no-padding--left u-no-padding--right">
+        <Col size={6}>
+          <InfoItem label="current version" value={currentKernelVersion} />
+        </Col>
+        <Col size={6}>
+          <InfoItem
+            label="kernel version"
+            className={classes.infoItem}
+            value={
+              downgradeKernelVersions.length === 1 ? (
+                <span>{downgradeKernelVersions[0].version_rounded}</span>
+              ) : (
+                <Select
+                  options={KERNEL_VERSION_OPTIONS}
+                  {...formik.getFieldProps("new_kernel_version_id")}
+                />
+              )
+            }
+          />
+        </Col>
+      </Row>
+      <strong className={classes.marginTop}>Delivery time</strong>
+      <div className={classes.radioGroup}>
+        <Input
+          type="radio"
+          label="As soon as possible"
+          name="deliver_immediately"
+          value="true"
+          onChange={handleDeliveryTimeChange}
+          checked={formik.values.deliver_immediately}
+        />
+        <Input
+          type="radio"
+          label="Scheduled"
+          name="deliver_immediately"
+          value="false"
+          onChange={handleDeliveryTimeChange}
+          checked={!formik.values.deliver_immediately}
+        />
+      </div>
+      {!formik.values.deliver_immediately && (
+        <Input
+          type="datetime-local"
+          label="Deliver after"
+          labelClassName="u-off-screen"
+          {...formik.getFieldProps("deliver_after")}
+          error={formik.touched.deliver_after && formik.errors.deliver_after}
+        />
+      )}
+      <strong className={classes.marginTop}>
+        Randomise delivery over a time window
+      </strong>
+      <div className={classes.radioGroup}>
+        <Input
+          type="radio"
+          label="No"
+          {...formik.getFieldProps("randomize_delivery")}
+          onChange={async () => {
+            await formik.setFieldValue("randomize_delivery", false);
+            await formik.setFieldValue("deliver_delay_window", 0);
+          }}
+          checked={!formik.values.randomize_delivery}
+        />
+        <Input
+          type="radio"
+          label="Yes"
+          {...formik.getFieldProps("randomize_delivery")}
+          onChange={async () =>
+            await formik.setFieldValue("randomize_delivery", true)
+          }
+          checked={formik.values.randomize_delivery}
+        />
+      </div>
+      {formik.values.randomize_delivery && (
+        <Input
+          type="number"
+          inputMode="numeric"
+          min={0}
+          label="Delivery delay window"
+          labelClassName="u-off-screen"
+          help="Time in minutes"
+          {...formik.getFieldProps("deliver_delay_window")}
+          error={
+            formik.touched.deliver_delay_window &&
+            formik.errors.deliver_delay_window
+              ? formik.errors.deliver_delay_window
+              : undefined
+          }
+        />
+      )}
+      <div className="form-buttons">
+        <Button type="button" appearance="base" onClick={closeSidePanel}>
+          Cancel
+        </Button>
+        <ConfirmationButton
+          type="button"
+          confirmationModalProps={{
+            title: "Downgrading kernel and restarting instance",
+            children: (
+              <p>
+                Are you sure? This action will downgrade the kernel and restart
+                the instance.
+              </p>
+            ),
+            confirmButtonLabel: "Downgrade and Restart",
+            confirmButtonAppearance: "negative",
+            confirmButtonLoading: isDowngradingKernel,
+            confirmButtonDisabled: isDowngradingKernel,
+            onConfirm: handleRebootAndSubmit,
+          }}
+        >
+          Downgrade and Restart
+        </ConfirmationButton>
+        <ConfirmationButton
+          type="button"
+          appearance="negative"
+          confirmationModalProps={{
+            title: "Downgrading kernel",
+            children: (
+              <p>Are you sure? This action will downgrade the kernel.</p>
+            ),
+            confirmButtonLabel: "Downgrade",
+            confirmButtonAppearance: "negative",
+            confirmButtonLoading: isDowngradingKernel,
+            confirmButtonDisabled: isDowngradingKernel,
+            onConfirm: () => formik.handleSubmit(),
+          }}
+        >
+          Downgrade kernel
+        </ConfirmationButton>
+      </div>
+    </Form>
+  );
+};
+
+export default DowngradeKernelForm;

--- a/src/features/kernel/components/DowngradeKernelForm/constants.ts
+++ b/src/features/kernel/components/DowngradeKernelForm/constants.ts
@@ -1,0 +1,29 @@
+import moment from "moment";
+import * as Yup from "yup";
+
+export const VALIDATION_SCHEMA = Yup.object().shape({
+  deliver_immediately: Yup.boolean(),
+  randomize_delivery: Yup.boolean(),
+  deliver_delay_window: Yup.number().min(
+    0,
+    "Delivery delay must be greater than or equal to 0",
+  ),
+  deliver_after: Yup.string().test({
+    test: (value) => {
+      if (!value) {
+        return true;
+      }
+      return moment(value).isValid();
+    },
+    message: "You have to enter a valid date and time",
+  }),
+  new_kernel_version_id: Yup.string().required("You have to select a kernel"),
+  reboot_after: Yup.boolean(),
+});
+
+export const DOWNGRADE_MESSAGE_WITH_REBOOT =
+  "The kernel will be downgraded and the instance will restart afterwards to apply the change.";
+export const DOWNGRADE_MESSAGE_WITHOUT_REBOOT =
+  "The kernel will be downgraded. You'll need to restart the instance to apply this change.";
+export const SECURITY_WARNING =
+  "Downgrading the kernel will expose your system to known security vulnerabilities AND reduce your Livepatch coverage.";

--- a/src/features/kernel/components/DowngradeKernelForm/index.ts
+++ b/src/features/kernel/components/DowngradeKernelForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DowngradeKernelForm";

--- a/src/features/kernel/components/DowngradeKernelForm/types.d.ts
+++ b/src/features/kernel/components/DowngradeKernelForm/types.d.ts
@@ -1,0 +1,8 @@
+export interface FormProps {
+  deliver_immediately: boolean;
+  randomize_delivery: boolean;
+  deliver_delay_window: number;
+  deliver_after: string;
+  new_kernel_version_id: string;
+  reboot_after: boolean;
+}

--- a/src/features/kernel/components/KernelOverview/KernelOverview.module.scss
+++ b/src/features/kernel/components/KernelOverview/KernelOverview.module.scss
@@ -1,0 +1,16 @@
+@import "vanilla-framework/scss/settings_spacing";
+@import "vanilla-framework/scss/settings_colors";
+
+.statusIcon {
+  margin-right: $sph--small;
+}
+
+.tooltipIcon {
+  margin-left: $sph--small;
+}
+
+.container {
+  border-bottom: 1px solid $color-mid-x-light;
+  margin-bottom: $spv--x-large;
+  padding-bottom: $spv--x-large;
+}

--- a/src/features/kernel/components/KernelOverview/KernelOverview.test.tsx
+++ b/src/features/kernel/components/KernelOverview/KernelOverview.test.tsx
@@ -1,0 +1,63 @@
+import { renderWithProviders } from "@/tests/render";
+import KernelOverview from "./KernelOverview";
+import { ComponentProps } from "react";
+import NoData from "@/components/layout/NoData";
+import {
+  getLivepatchCoverageDisplayValue,
+  getStatusTooltipMessage,
+} from "./helpers";
+import { Icon, Tooltip } from "@canonical/react-components";
+
+const props: ComponentProps<typeof KernelOverview> = {
+  kernelOverview: {
+    currentVersion: "5.4.0-101-generic",
+    status: "Fully patched",
+    expirationDate: "1723252324989",
+  },
+};
+
+describe("KernelHeader", () => {
+  it("should render info items", () => {
+    const { container } = renderWithProviders(<KernelOverview {...props} />);
+    const livepatchEnabled =
+      props.kernelOverview.status !== "Livepatch disabled";
+    const fields = [
+      {
+        label: "current kernel version",
+        value: props.kernelOverview.currentVersion ?? <NoData />,
+      },
+      {
+        label: "status",
+        value: (
+          <>
+            <span>
+              {props.kernelOverview.status === "Livepatch disabled"
+                ? "Not covered by Livepatch"
+                : (props.kernelOverview.status ?? <NoData />)}
+            </span>
+            <Tooltip
+              message={getStatusTooltipMessage(
+                props.kernelOverview.status,
+                props.kernelOverview.expirationDate,
+              )}
+            >
+              <Icon name="help" aria-hidden />
+              <span className="u-off-screen">Help</span>
+            </Tooltip>
+          </>
+        ),
+      },
+      {
+        label: "livepatch coverage",
+        value: getLivepatchCoverageDisplayValue(
+          livepatchEnabled,
+          props.kernelOverview.expirationDate,
+        ),
+      },
+    ];
+
+    for (const field of fields) {
+      expect(container).toHaveInfoItem(field.label, field.value);
+    }
+  });
+});

--- a/src/features/kernel/components/KernelOverview/KernelOverview.tsx
+++ b/src/features/kernel/components/KernelOverview/KernelOverview.tsx
@@ -1,0 +1,91 @@
+import { FC } from "react";
+import { KernelOverviewInfo } from "../../types";
+import { Col, Icon, Row, Tooltip } from "@canonical/react-components";
+import InfoItem from "@/components/layout/InfoItem";
+import {
+  getLivepatchCoverageDisplayValue,
+  getLivepatchCoverageIcon,
+  getStatusIcon,
+  getStatusTooltipMessage,
+} from "./helpers";
+import classes from "./KernelOverview.module.scss";
+import classNames from "classnames";
+import NoData from "@/components/layout/NoData";
+
+interface KernelHeaderProps {
+  kernelOverview: KernelOverviewInfo;
+}
+
+const KernelOverview: FC<KernelHeaderProps> = ({ kernelOverview }) => {
+  const livepatchEnabled = kernelOverview.status !== "Livepatch disabled";
+
+  const infoItems = [
+    {
+      label: "current kernel version",
+      value: kernelOverview.currentVersion || <NoData />,
+    },
+    {
+      label: "status",
+      value: (
+        <>
+          <span>
+            {!livepatchEnabled
+              ? "Not covered by Livepatch"
+              : kernelOverview.status || <NoData />}
+          </span>
+          <Tooltip
+            message={getStatusTooltipMessage(
+              kernelOverview.status,
+              kernelOverview.expirationDate,
+            )}
+            className={classes.tooltipIcon}
+          >
+            <Icon name="help" aria-hidden />
+            <span className="u-off-screen">Help</span>
+          </Tooltip>
+        </>
+      ),
+    },
+    {
+      label: "livepatch coverage",
+      value: getLivepatchCoverageDisplayValue(
+        livepatchEnabled,
+        kernelOverview.expirationDate,
+      ),
+    },
+  ];
+
+  return (
+    <Row
+      className={classNames(
+        "u-no-padding--left u-no-padding--right u-no-max-width",
+        classes.container,
+      )}
+    >
+      {infoItems.map(({ label, value }) => (
+        <Col size={3} key={label}>
+          {label === "status" && (
+            <Icon
+              name={getStatusIcon(kernelOverview.status)}
+              aria-hidden
+              className={classes.statusIcon}
+            />
+          )}
+          {label === "livepatch coverage" && (
+            <Icon
+              name={getLivepatchCoverageIcon(
+                livepatchEnabled,
+                kernelOverview.expirationDate,
+              )}
+              aria-hidden
+              className={classes.statusIcon}
+            />
+          )}
+          <InfoItem label={label} value={value} />
+        </Col>
+      ))}
+    </Row>
+  );
+};
+
+export default KernelOverview;

--- a/src/features/kernel/components/KernelOverview/helpers.ts
+++ b/src/features/kernel/components/KernelOverview/helpers.ts
@@ -1,0 +1,70 @@
+import { DISPLAY_DATE_FORMAT } from "@/constants";
+import moment from "moment";
+
+export const getStatusTooltipMessage = (type: string, expiryDate: string) => {
+  switch (type) {
+    case "Fully patched":
+      return "All available kernel security patches have been applied. You have no pending patches";
+    case "Kernel upgrade available":
+      return `A new kernel version is available. The current version is covered by Livepatch until ${moment(expiryDate).format(DISPLAY_DATE_FORMAT)}`;
+    case "Restart required":
+      return "Low and/or medium patches have been installed. You must restart to complete patching.";
+    case "End of life":
+      return "The kernel is no longer covered by Livepatch. It is not getting high and critical security patches.";
+    case "Livepatch disabled":
+      return "Livepatch is disabled. Kernel patches will not be applied automatically until you enabled Livepatch.";
+    default:
+      return "There was an error getting the status";
+  }
+};
+
+export const getStatusIcon = (type: string) => {
+  switch (type) {
+    case "Patched by Livepatch":
+    case "Fully patched":
+    case "Kernel upgrade available":
+      return "status-succeeded-small";
+    case "Restart required":
+      return "status-waiting-small";
+    case "End of life":
+      return "status-failed-small";
+    default:
+      return "status-failed-small";
+  }
+};
+
+export const getLivepatchCoverageIcon = (
+  livepatchEnabled: boolean,
+  expiryDate: string,
+): string => {
+  const expiry = moment(expiryDate);
+  const today = moment();
+  const diffDays = expiry.diff(today, "days");
+
+  if (diffDays < 0 || !livepatchEnabled) {
+    return "status-failed-small";
+  } else if (diffDays < 7) {
+    return "status-waiting-small";
+  } else {
+    return "status-succeeded-small";
+  }
+};
+
+export const getLivepatchCoverageDisplayValue = (
+  livepatchEnabled: boolean,
+  expiryDate: string,
+): string => {
+  if (!livepatchEnabled) {
+    return "Livepatch is disabled";
+  }
+
+  const expiry = moment(expiryDate);
+  const today = moment();
+  const diffDays = expiry.diff(today, "days");
+
+  if (diffDays < 0) {
+    return "Expired";
+  } else {
+    return `Expires on ${moment(expiryDate).format(DISPLAY_DATE_FORMAT)}`;
+  }
+};

--- a/src/features/kernel/components/KernelOverview/index.ts
+++ b/src/features/kernel/components/KernelOverview/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./KernelOverview";

--- a/src/features/kernel/components/KernelTableHeader/KernelTableHeader.module.scss
+++ b/src/features/kernel/components/KernelTableHeader/KernelTableHeader.module.scss
@@ -1,0 +1,5 @@
+.container {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/features/kernel/components/KernelTableHeader/KernelTableHeader.test.tsx
+++ b/src/features/kernel/components/KernelTableHeader/KernelTableHeader.test.tsx
@@ -1,0 +1,32 @@
+import { renderWithProviders } from "@/tests/render";
+import { ComponentProps } from "react";
+import KernelTableHeader from "./KernelTableHeader";
+
+const props: ComponentProps<typeof KernelTableHeader> = {
+  hasTableData: false,
+  instanceName: "test-instance",
+  kernelStatuses: {
+    message: "Kernel upgrade available",
+    installed: {
+      id: 1,
+      version: "test-version",
+      name: "test-name",
+      version_rounded: "test-version-rounded",
+    },
+    downgrades: [],
+    upgrades: [],
+    smart_status: "Kernel upgrade available",
+  },
+};
+
+describe("KernelTableHeader", () => {
+  it("renders KernelTableHeader", () => {
+    const { container } = renderWithProviders(<KernelTableHeader {...props} />);
+    expect(container).toHaveTexts([
+      "Patches discovered since last restart",
+      "Restart instance",
+      "Downgrade kernel",
+      "Upgrade kernel",
+    ]);
+  });
+});

--- a/src/features/kernel/components/KernelTableHeader/KernelTableHeader.tsx
+++ b/src/features/kernel/components/KernelTableHeader/KernelTableHeader.tsx
@@ -1,0 +1,111 @@
+import LoadingState from "@/components/layout/LoadingState";
+import useSidePanel from "@/hooks/useSidePanel";
+import { Button, Icon } from "@canonical/react-components";
+import { FC, lazy, Suspense } from "react";
+import { KernelManagementInfo } from "../../types";
+import classes from "./KernelTableHeader.module.scss";
+
+const DowngradeKernelForm = lazy(() => import("../DowngradeKernelForm"));
+const UpgradeKernelForm = lazy(() => import("../UpgradeKernelForm"));
+const RestartInstanceForm = lazy(() => import("../RestartInstanceForm"));
+
+interface KernelTableHeaderProps {
+  instanceName: string;
+  hasTableData: boolean;
+  kernelStatuses: KernelManagementInfo;
+}
+
+const KernelTableHeader: FC<KernelTableHeaderProps> = ({
+  instanceName,
+  hasTableData,
+  kernelStatuses,
+}) => {
+  const { setSidePanelContent } = useSidePanel();
+
+  const currentKernelVersion = kernelStatuses?.installed?.version_rounded ?? "";
+  const downgradeKernelVersions = kernelStatuses?.downgrades ?? [];
+  const upgradeKernelVersions = kernelStatuses?.upgrades ?? [];
+
+  const handleDowngradeKernel = () => {
+    setSidePanelContent(
+      "Downgrade kernel",
+      <Suspense fallback={<LoadingState />}>
+        <DowngradeKernelForm
+          instanceName={instanceName}
+          currentKernelVersion={currentKernelVersion}
+          downgradeKernelVersions={downgradeKernelVersions}
+        />
+      </Suspense>,
+    );
+  };
+
+  const handleUpgradeKernel = () => {
+    setSidePanelContent(
+      "Upgrade kernel",
+      <Suspense fallback={<LoadingState />}>
+        <UpgradeKernelForm
+          instanceName={instanceName}
+          currentKernelVersion={currentKernelVersion}
+          upgradeKernelVersions={upgradeKernelVersions}
+        />
+      </Suspense>,
+    );
+  };
+
+  const handleRestartInstance = () => {
+    setSidePanelContent(
+      `Restart ${instanceName}`,
+      <Suspense fallback={<LoadingState />}>
+        <RestartInstanceForm
+          instanceName={instanceName}
+          showNotification={hasTableData}
+          newKernelVersionId={upgradeKernelVersions[0]?.id}
+        />
+      </Suspense>,
+    );
+  };
+
+  return (
+    <div className={classes.container}>
+      <h5 className="u-no-padding u-no-margin">
+        Patches discovered since last restart
+      </h5>
+      <div key="buttons" className="p-segmented-control">
+        <div className="p-segmented-control__list">
+          <Button
+            hasIcon
+            className="p-segmented-control__button"
+            onClick={handleRestartInstance}
+          >
+            <Icon name="restart" />
+            <span>Restart instance</span>
+          </Button>
+
+          <Button
+            hasIcon
+            className="p-segmented-control__button"
+            type="button"
+            disabled={downgradeKernelVersions.length === 0}
+            onClick={handleDowngradeKernel}
+          >
+            <Icon name="begin-downloading" />
+            <span>Downgrade kernel</span>
+          </Button>
+
+          <Button
+            hasIcon
+            className="p-segmented-control__button"
+            type="button"
+            disabled={upgradeKernelVersions.length === 0}
+            onClick={handleUpgradeKernel}
+          >
+            <Icon name="change-version" />
+            <span>Upgrade kernel</span>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default KernelTableHeader;

--- a/src/features/kernel/components/KernelTableHeader/index.ts
+++ b/src/features/kernel/components/KernelTableHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./KernelTableHeader";

--- a/src/features/kernel/components/KernelTableList/KernelTableList.module.scss
+++ b/src/features/kernel/components/KernelTableList/KernelTableList.module.scss
@@ -1,0 +1,3 @@
+.description {
+  width: 40%;
+}

--- a/src/features/kernel/components/KernelTableList/KernelTableList.test.tsx
+++ b/src/features/kernel/components/KernelTableList/KernelTableList.test.tsx
@@ -1,0 +1,14 @@
+import { renderWithProviders } from "@/tests/render";
+import KernelTableList from "./KernelTableList";
+import { patches } from "@/tests/mocks/kernel";
+
+describe("KernelTableList", () => {
+  it("renders table columns", async () => {
+    const { container } = renderWithProviders(
+      <KernelTableList kernelData={patches} />,
+    );
+
+    const columns = ["CVE", "Status", "Description", "Bug"];
+    expect(container).toHaveTexts(columns);
+  });
+});

--- a/src/features/kernel/components/KernelTableList/KernelTableList.tsx
+++ b/src/features/kernel/components/KernelTableList/KernelTableList.tsx
@@ -1,0 +1,87 @@
+import EmptyState from "@/components/layout/EmptyState";
+import NoData from "@/components/layout/NoData";
+import { Link, ModularTable } from "@canonical/react-components";
+import {
+  CellProps,
+  Column,
+} from "@canonical/react-components/node_modules/@types/react-table";
+import { FC, useMemo } from "react";
+import { Fix } from "../../types";
+import { generateCveLink, handleCellProps } from "./helpers";
+import classes from "./KernelTableList.module.scss";
+import { EMPTY_TABLE_MESSAGE } from "./constants";
+
+interface KernelTableListProps {
+  kernelData: Fix[];
+}
+
+const KernelTableList: FC<KernelTableListProps> = ({ kernelData }) => {
+  const columns = useMemo<Column<Fix>[]>(
+    () => [
+      {
+        Header: <span>CVE</span>,
+        accessor: "Name",
+        Cell: ({ row }: CellProps<Fix>) => (
+          <Link
+            href={generateCveLink(row.original.Name)}
+            target="_blank"
+            rel="nofollow noopener noreferrer"
+            className="u-no-margin--bottom u-no-padding--top"
+          >
+            {row.original.Name}
+          </Link>
+        ),
+      },
+      {
+        Header: "Status",
+        accessor: "Patched",
+        Cell: ({ row: { original } }: CellProps<Fix>) =>
+          original.Patched ? "Patched by Livepatch" : "Unpatched",
+        getCellIcon: ({ row: { original } }: CellProps<Fix>) => {
+          if (original.Patched) {
+            return "status-succeeded-small";
+          } else {
+            return "status-failed-small";
+          }
+        },
+        disableSortBy: true,
+      },
+      {
+        Header: "Description",
+        accessor: "Description",
+        className: classes.description,
+        Cell: ({ row }: CellProps<Fix>) =>
+          row.original.Description || <NoData />,
+        disableSortBy: true,
+      },
+      {
+        Header: "Bug",
+        accessor: "Bug",
+        Cell: ({ row }: CellProps<Fix>) => row.original.Bug || <NoData />,
+        disableSortBy: true,
+      },
+    ],
+    [],
+  );
+
+  return (
+    <>
+      <ModularTable
+        columns={columns}
+        data={kernelData}
+        getCellProps={handleCellProps}
+        sortable
+        initialSortColumn="Name"
+        initialSortDirection="ascending"
+      />
+      {kernelData.length === 0 && (
+        <EmptyState
+          title="No outstanding kernel patches"
+          body={EMPTY_TABLE_MESSAGE}
+        />
+      )}
+    </>
+  );
+};
+
+export default KernelTableList;

--- a/src/features/kernel/components/KernelTableList/constants.ts
+++ b/src/features/kernel/components/KernelTableList/constants.ts
@@ -1,0 +1,3 @@
+export const EMPTY_TABLE_MESSAGE = `There are no pending kernel security patches to apply at this time.
+                Livepatch applies critical and high security patches in the background without requiring a system restart.
+                Patches found since last restart and their status will be shown here.`;

--- a/src/features/kernel/components/KernelTableList/helpers.ts
+++ b/src/features/kernel/components/KernelTableList/helpers.ts
@@ -1,0 +1,31 @@
+import { HTMLProps } from "react";
+import { Fix } from "../../types";
+import {
+  Cell,
+  TableCellProps,
+} from "@canonical/react-components/node_modules/@types/react-table";
+
+export const generateCveLink = (cve: string): string => {
+  return `https://cve.mitre.org/cgi-bin/cvename.cgi?name=${cve}`;
+};
+
+export const handleCellProps = (cell: Cell<Fix>) => {
+  const cellProps: Partial<TableCellProps & HTMLProps<HTMLTableCellElement>> =
+    {};
+  switch (cell.column.id) {
+    case "Name":
+      cellProps.role = "rowheader";
+      break;
+    case "Patched":
+      cellProps["aria-label"] = "Status";
+      break;
+    case "Description":
+      cellProps["aria-label"] = "Description";
+      break;
+    case "Bug":
+      cellProps["aria-label"] = "Bug";
+      break;
+  }
+
+  return cellProps;
+};

--- a/src/features/kernel/components/KernelTableList/index.ts
+++ b/src/features/kernel/components/KernelTableList/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./KernelTableList";

--- a/src/features/kernel/components/RestartInstanceForm/RestartInstanceForm.module.scss
+++ b/src/features/kernel/components/RestartInstanceForm/RestartInstanceForm.module.scss
@@ -1,0 +1,11 @@
+@import "vanilla-framework/scss/settings_spacing";
+
+.radioGroup {
+  column-gap: $sph--x-large;
+  display: flex;
+}
+
+.marginTop {
+  display: block;
+  margin-top: $spv--large;
+}

--- a/src/features/kernel/components/RestartInstanceForm/RestartInstanceForm.test.tsx
+++ b/src/features/kernel/components/RestartInstanceForm/RestartInstanceForm.test.tsx
@@ -1,0 +1,48 @@
+import { renderWithProviders } from "@/tests/render";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import RestartInstanceForm from "./RestartInstanceForm";
+
+describe("UpgradeKernelForm", () => {
+  it("renders notification message", () => {
+    renderWithProviders(
+      <RestartInstanceForm showNotification instanceName="test-instance" />,
+    );
+    expect(screen.getByText(/restart recommended/i)).toBeVisible();
+  });
+
+  it("renders notification message", () => {
+    renderWithProviders(
+      <RestartInstanceForm
+        showNotification={false}
+        instanceName="test-instance"
+      />,
+    );
+    expect(screen.queryByText(/restart recommended/i)).toBeNull();
+  });
+
+  it("radio button functionalities", async () => {
+    renderWithProviders(
+      <RestartInstanceForm
+        showNotification={false}
+        instanceName="test-instance"
+      />,
+    );
+
+    const instantDeliveryTimeRadioOption = screen.getByLabelText(
+      "As soon as possible",
+    );
+    expect(instantDeliveryTimeRadioOption).toBeChecked();
+
+    const scheduledDeliveryTimeRadioOption = screen.getByLabelText("Scheduled");
+    expect(scheduledDeliveryTimeRadioOption).not.toBeChecked();
+
+    const randomizeDeliveryTrueOption = screen.getByLabelText("Yes");
+    const randomizeDeliveryFalseOption = screen.getByLabelText("No");
+    expect(randomizeDeliveryTrueOption).not.toBeChecked();
+    expect(randomizeDeliveryFalseOption).toBeChecked();
+
+    await userEvent.click(randomizeDeliveryTrueOption);
+    expect(screen.getByText(/time in minutes/i)).toBeVisible();
+  });
+});

--- a/src/features/kernel/components/RestartInstanceForm/RestartInstanceForm.tsx
+++ b/src/features/kernel/components/RestartInstanceForm/RestartInstanceForm.tsx
@@ -1,0 +1,253 @@
+import { useActivities } from "@/features/activities";
+import useDebug from "@/hooks/useDebug";
+import useInstances from "@/hooks/useInstances";
+import useNotify from "@/hooks/useNotify";
+import useSidePanel from "@/hooks/useSidePanel";
+import {
+  Button,
+  ConfirmationButton,
+  Form,
+  Input,
+  Notification,
+} from "@canonical/react-components";
+import classNames from "classnames";
+import { useFormik } from "formik";
+import moment from "moment";
+import { FC } from "react";
+import { useParams } from "react-router-dom";
+import {
+  INITIAL_VALUES,
+  NOTIFICATION_MESSAGE,
+  VALIDATION_SCHEMA,
+} from "./constants";
+import classes from "./RestartInstanceForm.module.scss";
+import { FormProps } from "./types";
+import { useKernel } from "../../hooks";
+import { UPGRADE_MESSAGE_WITH_REBOOT } from "../UpgradeKernelForm/constants";
+import { UrlParams } from "@/types/UrlParams";
+
+interface RestartInstanceFormProps {
+  showNotification: boolean;
+  instanceName: string;
+  newKernelVersionId?: number;
+}
+
+const RestartInstanceForm: FC<RestartInstanceFormProps> = ({
+  showNotification,
+  instanceName,
+  newKernelVersionId,
+}) => {
+  const debug = useDebug();
+  const { instanceId } = useParams<UrlParams>();
+  const { closeSidePanel } = useSidePanel();
+  const { notify } = useNotify();
+  const { restartInstanceQuery } = useInstances();
+  const { upgradeKernelQuery } = useKernel();
+  const { openActivityDetails } = useActivities();
+
+  const { mutateAsync: restartInstance, isPending: isRestartingInstance } =
+    restartInstanceQuery;
+  const { mutateAsync: upgradeKernel, isPending: isUpgradingAndRestarting } =
+    upgradeKernelQuery;
+
+  const formik = useFormik<FormProps>({
+    initialValues: INITIAL_VALUES,
+    validationSchema: VALIDATION_SCHEMA,
+    onSubmit: async (values) => {
+      try {
+        if (values.upgrade_and_restart) {
+          await handleUpgradeAndRestartSubmit();
+        } else {
+          await handleRestartSubmit(values);
+        }
+      } catch (error) {
+        debug(error);
+      }
+    },
+  });
+
+  const handleDeliveryTimeChange = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const deliverImmediately = event.currentTarget.value === "true";
+    await formik.setFieldValue("deliver_immediately", deliverImmediately);
+    if (!deliverImmediately) {
+      await formik.setFieldValue(
+        "deliver_after",
+        moment().toISOString().slice(0, 16),
+      );
+    }
+  };
+
+  const handleUpgradeAndRestart = async () => {
+    await formik.setFieldValue("upgrade_and_restart", true);
+    formik.handleSubmit();
+  };
+
+  const handleUpgradeAndRestartSubmit = async () => {
+    const { data: activity } = await upgradeKernel({
+      id: Number(instanceId),
+      kernel_package_id: Number(newKernelVersionId),
+      reboot_after: true,
+    });
+
+    closeSidePanel();
+
+    notify.success({
+      title: `You queued kernel upgrade for "${instanceName}"`,
+      message: UPGRADE_MESSAGE_WITH_REBOOT,
+      actions: [
+        {
+          label: "View details",
+          onClick: () => openActivityDetails(activity),
+        },
+      ],
+    });
+  };
+
+  const handleRestartSubmit = async (values: FormProps) => {
+    const { data: activity } = await restartInstance({
+      id: Number(instanceId),
+      deliver_after: values.deliver_after,
+      deliver_delay_window: values.deliver_delay_window,
+    });
+
+    closeSidePanel();
+
+    notify.success({
+      title: `You queued "${instanceName}" to be restarted.`,
+      message: `Instance "${instanceName}" will be restarted and is queued in Activities`,
+      actions: [
+        {
+          label: "View details",
+          onClick: () => openActivityDetails(activity),
+        },
+      ],
+    });
+  };
+
+  return (
+    <Form onSubmit={formik.handleSubmit}>
+      {showNotification && (
+        <Notification title="Restart recommended" severity="caution">
+          {NOTIFICATION_MESSAGE}
+        </Notification>
+      )}
+
+      <strong>Delivery time</strong>
+      <div className={classes.radioGroup}>
+        <Input
+          type="radio"
+          label="As soon as possible"
+          name="deliver_immediately"
+          value="true"
+          onChange={handleDeliveryTimeChange}
+          checked={formik.values.deliver_immediately}
+        />
+        <Input
+          type="radio"
+          label="Scheduled"
+          name="deliver_immediately"
+          value="false"
+          onChange={handleDeliveryTimeChange}
+          checked={!formik.values.deliver_immediately}
+        />
+      </div>
+      {!formik.values.deliver_immediately && (
+        <Input
+          type="datetime-local"
+          label="Deliver after"
+          labelClassName="u-off-screen"
+          {...formik.getFieldProps("deliver_after")}
+          error={formik.touched.deliver_after && formik.errors.deliver_after}
+        />
+      )}
+      <strong className={classNames(classes.marginTop)}>
+        Randomise delivery over a time window
+      </strong>
+      <div className={classes.radioGroup}>
+        <Input
+          type="radio"
+          label="No"
+          {...formik.getFieldProps("randomize_delivery")}
+          onChange={async () => {
+            await formik.setFieldValue("randomize_delivery", false);
+            await formik.setFieldValue("deliver_delay_window", 0);
+          }}
+          checked={!formik.values.randomize_delivery}
+        />
+        <Input
+          type="radio"
+          label="Yes"
+          {...formik.getFieldProps("randomize_delivery")}
+          onChange={async () =>
+            await formik.setFieldValue("randomize_delivery", true)
+          }
+          checked={formik.values.randomize_delivery}
+        />
+      </div>
+      {formik.values.randomize_delivery && (
+        <Input
+          type="number"
+          inputMode="numeric"
+          min={0}
+          label="Delivery delay window"
+          labelClassName="u-off-screen"
+          help="Time in minutes"
+          {...formik.getFieldProps("deliver_delay_window")}
+          error={
+            formik.touched.deliver_delay_window &&
+            formik.errors.deliver_delay_window
+              ? formik.errors.deliver_delay_window
+              : undefined
+          }
+        />
+      )}
+      <div className="form-buttons">
+        <Button type="button" appearance="base" onClick={closeSidePanel}>
+          Cancel
+        </Button>
+        {showNotification && newKernelVersionId && (
+          <ConfirmationButton
+            type="button"
+            confirmationModalProps={{
+              title: "Upgrading kernel and restarting instance",
+              children: (
+                <p>
+                  Are you sure? This action will upgrade the kernel and restart
+                  the instance.
+                </p>
+              ),
+              confirmButtonLabel: "Upgrade and Restart",
+              confirmButtonAppearance: "negative",
+              confirmButtonLoading: isUpgradingAndRestarting,
+              confirmButtonDisabled: isUpgradingAndRestarting,
+              onConfirm: handleUpgradeAndRestart,
+            }}
+          >
+            Upgrade and Restart
+          </ConfirmationButton>
+        )}
+        <ConfirmationButton
+          type="button"
+          appearance="negative"
+          confirmationModalProps={{
+            title: "Restarting instance",
+            children: (
+              <p>Are you sure? This action will restart the instance.</p>
+            ),
+            confirmButtonLabel: "Restart",
+            confirmButtonAppearance: "negative",
+            confirmButtonLoading: isRestartingInstance,
+            confirmButtonDisabled: isRestartingInstance,
+            onConfirm: () => formik.handleSubmit(),
+          }}
+        >
+          Restart
+        </ConfirmationButton>
+      </div>
+    </Form>
+  );
+};
+
+export default RestartInstanceForm;

--- a/src/features/kernel/components/RestartInstanceForm/constants.ts
+++ b/src/features/kernel/components/RestartInstanceForm/constants.ts
@@ -1,0 +1,33 @@
+import moment from "moment";
+import * as Yup from "yup";
+import { FormProps } from "./types";
+
+export const VALIDATION_SCHEMA = Yup.object().shape({
+  deliver_immediately: Yup.boolean(),
+  randomize_delivery: Yup.boolean(),
+  deliver_delay_window: Yup.number().min(
+    0,
+    "Delivery delay must be greater than or equal to 0",
+  ),
+  deliver_after: Yup.string().test({
+    test: (value) => {
+      if (!value) {
+        return true;
+      }
+      return moment(value).isValid();
+    },
+    message: "You have to enter a valid date and time",
+  }),
+  upgrade_and_restart: Yup.boolean(),
+});
+
+export const INITIAL_VALUES: FormProps = {
+  deliver_immediately: true,
+  randomize_delivery: false,
+  deliver_delay_window: 0,
+  deliver_after: "",
+  upgrade_and_restart: false,
+};
+
+export const NOTIFICATION_MESSAGE =
+  "To save patches, upgrade your kernel and then Restart. If you Restart without upgrading, you will lose patches until Livepatch automatically applies them again.";

--- a/src/features/kernel/components/RestartInstanceForm/index.ts
+++ b/src/features/kernel/components/RestartInstanceForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RestartInstanceForm";

--- a/src/features/kernel/components/RestartInstanceForm/types.d.ts
+++ b/src/features/kernel/components/RestartInstanceForm/types.d.ts
@@ -1,0 +1,7 @@
+export interface FormProps {
+  deliver_immediately: boolean;
+  randomize_delivery: boolean;
+  deliver_delay_window: number;
+  deliver_after: string;
+  upgrade_and_restart: boolean;
+}

--- a/src/features/kernel/components/UpgradeKernelForm/UpgradeKernelForm.module.scss
+++ b/src/features/kernel/components/UpgradeKernelForm/UpgradeKernelForm.module.scss
@@ -1,0 +1,11 @@
+@import "vanilla-framework/scss/settings_spacing";
+
+.radioGroup {
+  column-gap: $sph--x-large;
+  display: flex;
+}
+
+.marginTop {
+  display: block;
+  margin-top: $spv--large;
+}

--- a/src/features/kernel/components/UpgradeKernelForm/UpgradeKernelForm.test.tsx
+++ b/src/features/kernel/components/UpgradeKernelForm/UpgradeKernelForm.test.tsx
@@ -1,0 +1,51 @@
+import { renderWithProviders } from "@/tests/render";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ComponentProps } from "react";
+import UpgradeKernelForm from "./UpgradeKernelForm";
+
+const props: ComponentProps<typeof UpgradeKernelForm> = {
+  currentKernelVersion: "5.11.0-27-generic",
+  upgradeKernelVersions: [
+    {
+      id: 75473,
+      name: "linux-image-virtual",
+      version: "5.15.0.25.28",
+      version_rounded: "5.15.0.30",
+    },
+    {
+      id: 75474,
+      name: "linux-image-virtual-2",
+      version: "5.15.0.25.29",
+      version_rounded: "5.15.0.30",
+    },
+  ],
+  instanceName: "test-instance",
+};
+
+describe("UpgradeKernelForm", () => {
+  it("renders notification message", () => {
+    renderWithProviders(<UpgradeKernelForm {...props} />);
+    expect(screen.getByText(/restart recommended/i)).toBeVisible();
+  });
+
+  it("radio button functionalities", async () => {
+    renderWithProviders(<UpgradeKernelForm {...props} />);
+
+    const instantDeliveryTimeRadioOption = screen.getByLabelText(
+      "As soon as possible",
+    );
+    expect(instantDeliveryTimeRadioOption).toBeChecked();
+
+    const scheduledDeliveryTimeRadioOption = screen.getByLabelText("Scheduled");
+    expect(scheduledDeliveryTimeRadioOption).not.toBeChecked();
+
+    const randomizeDeliveryTrueOption = screen.getByLabelText("Yes");
+    const randomizeDeliveryFalseOption = screen.getByLabelText("No");
+    expect(randomizeDeliveryTrueOption).not.toBeChecked();
+    expect(randomizeDeliveryFalseOption).toBeChecked();
+
+    await userEvent.click(randomizeDeliveryTrueOption);
+    expect(screen.getByText(/time in minutes/i)).toBeVisible();
+  });
+});

--- a/src/features/kernel/components/UpgradeKernelForm/UpgradeKernelForm.tsx
+++ b/src/features/kernel/components/UpgradeKernelForm/UpgradeKernelForm.tsx
@@ -1,0 +1,266 @@
+import InfoItem from "@/components/layout/InfoItem";
+import { useActivities } from "@/features/activities";
+import useDebug from "@/hooks/useDebug";
+import useNotify from "@/hooks/useNotify";
+import useSidePanel from "@/hooks/useSidePanel";
+import { SelectOption } from "@/types/SelectOption";
+import {
+  Button,
+  Col,
+  ConfirmationButton,
+  Form,
+  Input,
+  Notification,
+  Row,
+  Select,
+} from "@canonical/react-components";
+import { useFormik } from "formik";
+import moment from "moment";
+import { FC } from "react";
+import { useParams } from "react-router-dom";
+import { useKernel } from "../../hooks";
+import { Kernel } from "../../types";
+import {
+  NOTIFICATION_MESSAGE,
+  UPGRADE_MESSAGE_WITH_REBOOT,
+  UPGRADE_MESSAGE_WITHOUT_REBOOT,
+  VALIDATION_SCHEMA,
+} from "./constants";
+import { FormProps } from "./types";
+import classes from "./UpgradeKernelForm.module.scss";
+import { UrlParams } from "@/types/UrlParams";
+
+interface UpgradeKernelFormProps {
+  currentKernelVersion: string;
+  upgradeKernelVersions: Kernel[];
+  instanceName: string;
+}
+
+const UpgradeKernelForm: FC<UpgradeKernelFormProps> = ({
+  currentKernelVersion,
+  upgradeKernelVersions,
+  instanceName,
+}) => {
+  const debug = useDebug();
+  const { instanceId } = useParams<UrlParams>();
+  const { closeSidePanel } = useSidePanel();
+  const { notify } = useNotify();
+  const { upgradeKernelQuery } = useKernel();
+  const { openActivityDetails } = useActivities();
+
+  const { mutateAsync: upgradeKernel, isPending: isUpgradingKernel } =
+    upgradeKernelQuery;
+
+  const KERNEL_VERSION_OPTIONS: SelectOption[] = [
+    {
+      label: "Select",
+      value: "",
+    },
+    ...upgradeKernelVersions.map((kernel) => ({
+      label: kernel.version_rounded,
+      value: kernel.id.toString(),
+    })),
+  ];
+
+  const initialValues: FormProps = {
+    deliver_immediately: true,
+    randomize_delivery: false,
+    deliver_delay_window: 0,
+    deliver_after: "",
+    new_kernel_version_id:
+      upgradeKernelVersions.length === 1
+        ? upgradeKernelVersions[0].id.toString()
+        : "",
+    reboot_after: false,
+  };
+
+  const formik = useFormik<FormProps>({
+    initialValues: initialValues,
+    validationSchema: VALIDATION_SCHEMA,
+    onSubmit: async (values) => {
+      try {
+        const { data: activity } = await upgradeKernel({
+          id: Number(instanceId),
+          kernel_package_id: Number(values.new_kernel_version_id),
+          reboot_after: values.reboot_after,
+        });
+
+        closeSidePanel();
+
+        const upgradeNotificationMessage = values.reboot_after
+          ? UPGRADE_MESSAGE_WITH_REBOOT
+          : UPGRADE_MESSAGE_WITHOUT_REBOOT;
+
+        notify.success({
+          title: `You queued kernel upgrade for "${instanceName}"`,
+          message: upgradeNotificationMessage,
+          actions: [
+            {
+              label: "View details",
+              onClick: () => openActivityDetails(activity),
+            },
+          ],
+        });
+      } catch (error) {
+        debug(error);
+      }
+    },
+  });
+
+  const handleDeliveryTimeChange = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const deliverImmediately = event.currentTarget.value === "true";
+    await formik.setFieldValue("deliver_immediately", deliverImmediately);
+    if (!deliverImmediately) {
+      await formik.setFieldValue(
+        "deliver_after",
+        moment().toISOString().slice(0, 16),
+      );
+    }
+  };
+
+  const handleRebootAndSubmit = async () => {
+    await formik.setFieldValue("reboot_after", true);
+    formik.handleSubmit();
+  };
+
+  return (
+    <Form onSubmit={formik.handleSubmit}>
+      <Notification severity="information" title="Restart recommended">
+        <span>{NOTIFICATION_MESSAGE}</span>
+      </Notification>
+      <Row className="u-no-padding--left u-no-padding--right">
+        <Col size={6}>
+          <InfoItem label="current version" value={currentKernelVersion} />
+        </Col>
+        <Col size={6}>
+          <InfoItem
+            label="new version"
+            value={
+              upgradeKernelVersions.length === 1 ? (
+                <span>{upgradeKernelVersions[0].version_rounded}</span>
+              ) : (
+                <Select
+                  options={KERNEL_VERSION_OPTIONS}
+                  {...formik.getFieldProps("new_kernel_version")}
+                />
+              )
+            }
+          />
+        </Col>
+      </Row>
+      <strong className={classes.marginTop}>Delivery time</strong>
+      <div className={classes.radioGroup}>
+        <Input
+          type="radio"
+          label="As soon as possible"
+          name="deliver_immediately"
+          value="true"
+          onChange={handleDeliveryTimeChange}
+          checked={formik.values.deliver_immediately}
+        />
+        <Input
+          type="radio"
+          label="Scheduled"
+          name="deliver_immediately"
+          value="false"
+          onChange={handleDeliveryTimeChange}
+          checked={!formik.values.deliver_immediately}
+        />
+      </div>
+      {!formik.values.deliver_immediately && (
+        <Input
+          type="datetime-local"
+          label="Deliver after"
+          labelClassName="u-off-screen"
+          {...formik.getFieldProps("deliver_after")}
+          error={formik.touched.deliver_after && formik.errors.deliver_after}
+        />
+      )}
+      <strong className={classes.marginTop}>
+        Randomise delivery over a time window
+      </strong>
+      <div className={classes.radioGroup}>
+        <Input
+          type="radio"
+          label="No"
+          {...formik.getFieldProps("randomize_delivery")}
+          onChange={async () => {
+            await formik.setFieldValue("randomize_delivery", false);
+            await formik.setFieldValue("deliver_delay_window", 0);
+          }}
+          checked={!formik.values.randomize_delivery}
+        />
+        <Input
+          type="radio"
+          label="Yes"
+          {...formik.getFieldProps("randomize_delivery")}
+          onChange={async () =>
+            await formik.setFieldValue("randomize_delivery", true)
+          }
+          checked={formik.values.randomize_delivery}
+        />
+      </div>
+      {formik.values.randomize_delivery && (
+        <Input
+          type="number"
+          inputMode="numeric"
+          min={0}
+          label="Delivery delay window"
+          labelClassName="u-off-screen"
+          help="Time in minutes"
+          {...formik.getFieldProps("deliver_delay_window")}
+          error={
+            formik.touched.deliver_delay_window &&
+            formik.errors.deliver_delay_window
+              ? formik.errors.deliver_delay_window
+              : undefined
+          }
+        />
+      )}
+      <div className="form-buttons">
+        <Button type="button" appearance="base" onClick={closeSidePanel}>
+          Cancel
+        </Button>
+        <ConfirmationButton
+          type="button"
+          confirmationModalProps={{
+            title: "Upgrading kernel and restarting instance",
+            children: (
+              <p>
+                Are you sure? This action will upgrade the kernel and restart
+                the instance.
+              </p>
+            ),
+            confirmButtonLabel: "Upgrade and Restart",
+            confirmButtonAppearance: "positive",
+            confirmButtonLoading: isUpgradingKernel,
+            confirmButtonDisabled: isUpgradingKernel,
+            onConfirm: handleRebootAndSubmit,
+          }}
+        >
+          Upgrade and Restart
+        </ConfirmationButton>
+        <ConfirmationButton
+          type="button"
+          appearance="positive"
+          confirmationModalProps={{
+            title: "Upgrading kernel",
+            children: <p>Are you sure? This action will upgrade the kernel.</p>,
+            confirmButtonLabel: "Upgrade",
+            confirmButtonAppearance: "positive",
+            confirmButtonLoading: isUpgradingKernel,
+            confirmButtonDisabled: isUpgradingKernel,
+            type: "submit",
+            onConfirm: () => formik.handleSubmit(),
+          }}
+        >
+          Upgrade kernel
+        </ConfirmationButton>
+      </div>
+    </Form>
+  );
+};
+
+export default UpgradeKernelForm;

--- a/src/features/kernel/components/UpgradeKernelForm/constants.ts
+++ b/src/features/kernel/components/UpgradeKernelForm/constants.ts
@@ -1,0 +1,29 @@
+import * as Yup from "yup";
+import moment from "moment";
+
+export const VALIDATION_SCHEMA = Yup.object().shape({
+  deliver_immediately: Yup.boolean(),
+  randomize_delivery: Yup.boolean(),
+  deliver_delay_window: Yup.number().min(
+    0,
+    "Delivery delay must be greater than or equal to 0",
+  ),
+  deliver_after: Yup.string().test({
+    test: (value) => {
+      if (!value) {
+        return true;
+      }
+      return moment(value).isValid();
+    },
+    message: "You have to enter a valid date and time",
+  }),
+  new_kernel_version_id: Yup.string().required("You have to select a kernel"),
+  reboot_after: Yup.boolean(),
+});
+
+export const UPGRADE_MESSAGE_WITH_REBOOT =
+  "The kernel will be upgraded and the instance will restart afterwards to apply the change and any associated patches.";
+export const UPGRADE_MESSAGE_WITHOUT_REBOOT =
+  "The kernel will be upgraded. You'll need to restart the instance to apply this change and any associated patches.";
+export const NOTIFICATION_MESSAGE =
+  "Restart after upgrade to apply the patches";

--- a/src/features/kernel/components/UpgradeKernelForm/index.ts
+++ b/src/features/kernel/components/UpgradeKernelForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./UpgradeKernelForm";

--- a/src/features/kernel/components/UpgradeKernelForm/types.d.ts
+++ b/src/features/kernel/components/UpgradeKernelForm/types.d.ts
@@ -1,0 +1,8 @@
+export interface FormProps {
+  deliver_immediately: boolean;
+  randomize_delivery: boolean;
+  deliver_delay_window: number;
+  deliver_after: string;
+  new_kernel_version_id: string;
+  reboot_after: boolean;
+}

--- a/src/features/kernel/hooks/index.ts
+++ b/src/features/kernel/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useKernel } from "./useKernel";

--- a/src/features/kernel/hooks/useKernel.ts
+++ b/src/features/kernel/hooks/useKernel.ts
@@ -1,0 +1,98 @@
+import useFetch from "@/hooks/useFetch";
+import { ApiError } from "@/types/ApiError";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  UseQueryOptions,
+} from "@tanstack/react-query";
+import { AxiosError, AxiosResponse } from "axios";
+import { KernelManagementInfo } from "../types/Kernel";
+import { Activity } from "@/features/activities";
+import { LivepatchInformation } from "../types";
+
+export interface GetKernelInformationParams {
+  id: number;
+}
+
+interface GetLivepatchInfoParams {
+  id: number;
+  sort_by?: string;
+}
+
+interface KernelActionParams {
+  id: number;
+  kernel_package_id: number;
+  reboot_after: boolean;
+}
+
+export default function useKernel() {
+  const authFetch = useFetch();
+  const queryClient = useQueryClient();
+
+  const getKernelQuery = (
+    { id }: GetKernelInformationParams,
+    config: Omit<
+      UseQueryOptions<
+        AxiosResponse<KernelManagementInfo>,
+        AxiosError<ApiError>
+      >,
+      "queryKey" | "queryFn"
+    > = {},
+  ) => {
+    return useQuery<AxiosResponse<KernelManagementInfo>, AxiosError<ApiError>>({
+      queryKey: ["kernel", id],
+      queryFn: () => authFetch!.get(`computers/${id}/livepatch/kernel`),
+      ...config,
+    });
+  };
+
+  const getLivepatchInfoQuery = (
+    { id, ...queryParams }: GetLivepatchInfoParams,
+    config: Omit<
+      UseQueryOptions<
+        AxiosResponse<LivepatchInformation>,
+        AxiosError<ApiError>
+      >,
+      "queryKey" | "queryFn"
+    > = {},
+  ) => {
+    return useQuery<AxiosResponse<LivepatchInformation>, AxiosError<ApiError>>({
+      queryKey: ["kernel", { id, ...queryParams }],
+      queryFn: () =>
+        authFetch!.get(`computers/${id}/livepatch/info`, {
+          params: queryParams,
+        }),
+      ...config,
+    });
+  };
+
+  const downgradeKernelQuery = useMutation<
+    AxiosResponse<Activity>,
+    AxiosError<ApiError>,
+    KernelActionParams
+  >({
+    mutationKey: ["kernel", "downgrade"],
+    mutationFn: ({ id, ...queryParams }) =>
+      authFetch!.post(`computers/${id}/kernel/downgrade`, queryParams),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["kernel"] }),
+  });
+
+  const upgradeKernelQuery = useMutation<
+    AxiosResponse<Activity>,
+    AxiosError<ApiError>,
+    KernelActionParams
+  >({
+    mutationKey: ["kernel", "upgrade"],
+    mutationFn: ({ id, ...queryParams }) =>
+      authFetch!.post(`computers/${id}/kernel/upgrade`, queryParams),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["kernel"] }),
+  });
+
+  return {
+    getKernelQuery,
+    getLivepatchInfoQuery,
+    downgradeKernelQuery,
+    upgradeKernelQuery,
+  };
+}

--- a/src/features/kernel/index.ts
+++ b/src/features/kernel/index.ts
@@ -1,0 +1,5 @@
+export { default as KernelOverview } from "./components/KernelOverview";
+export { default as KernelTableHeader } from "./components/KernelTableHeader";
+export { default as KernelTableList } from "./components/KernelTableList";
+export type { KernelOverviewInfo, Fix } from "./types";
+export { useKernel } from "./hooks";

--- a/src/features/kernel/types/Kernel.d.ts
+++ b/src/features/kernel/types/Kernel.d.ts
@@ -1,0 +1,20 @@
+export interface KernelOverviewInfo {
+  currentVersion: string;
+  expirationDate: string;
+  status: string;
+}
+
+export interface KernelManagementInfo {
+  downgrades: Kernel[];
+  installed: Kernel | null;
+  message: string;
+  smart_status: string;
+  upgrades: Kernel[];
+}
+
+export interface Kernel {
+  id: number;
+  name: string;
+  version_rounded: string;
+  version: string;
+}

--- a/src/features/kernel/types/LivepatchInformation.d.ts
+++ b/src/features/kernel/types/LivepatchInformation.d.ts
@@ -1,0 +1,58 @@
+export interface LivepatchInformation {
+  livepatch_info: LivepatchInfo | null;
+  ubuntu_pro_livepatch_service_info: UbuntuProLivepatchServiceInfo | null;
+  ubuntu_pro_reboot_required_info: UbuntuProRebootRequiredInfo | null;
+}
+
+interface LivepatchInfo {
+  json: LivepatchContainer;
+}
+
+interface LivepatchContainer {
+  error: string;
+  output: InstanceInformation;
+  return_code: number;
+}
+
+interface InstanceInformation {
+  Status: Status[];
+  tier: string;
+}
+
+interface Status {
+  Kernel: string;
+  Livepatch: Livepatch;
+  Running: boolean;
+  Supported: string;
+  UpgradeRequiredDate: string;
+}
+
+interface Livepatch {
+  CheckState: string;
+  Fixes: Fix[];
+  State: string;
+  Version: string;
+}
+
+export interface Fix extends Record<string, unknown> {
+  Bug: string;
+  Description: string;
+  Name: string;
+  Patched: boolean;
+}
+
+interface UbuntuProLivepatchServiceInfo {
+  available: string;
+  entitled: string;
+  name: string;
+  status: string;
+  status_details: string;
+}
+
+interface UbuntuProRebootRequiredInfo {
+  output: LivepatchEnabled;
+}
+
+interface LivepatchEnabled {
+  livepatch_enabled: boolean;
+}

--- a/src/features/kernel/types/index.d.ts
+++ b/src/features/kernel/types/index.d.ts
@@ -1,0 +1,3 @@
+export { Kernel, KernelManagementInfo, KernelOverviewInfo } from "./Kernel";
+
+export { Fix, LivepatchInformation } from "./LivepatchInformation";

--- a/src/features/packages/components/InstalledPackagesActionForm/InstalledPackagesActionForm.tsx
+++ b/src/features/packages/components/InstalledPackagesActionForm/InstalledPackagesActionForm.tsx
@@ -23,6 +23,7 @@ import {
 } from "./helpers";
 import { FormProps } from "./types";
 import classes from "./InstalledPackagesActionForm.module.scss";
+import { UrlParams } from "@/types/UrlParams";
 
 interface InstalledPackagesActionFormProps {
   action: InstalledPackageAction;
@@ -33,7 +34,7 @@ const InstalledPackagesActionForm: FC<InstalledPackagesActionFormProps> = ({
   action,
   packages,
 }) => {
-  const { instanceId: urlInstanceId, childInstanceId } = useParams();
+  const { instanceId: urlInstanceId, childInstanceId } = useParams<UrlParams>();
   const debug = useDebug();
   const { notify } = useNotify();
   const { openActivityDetails } = useActivities();

--- a/src/features/packages/components/PackageDropdownSearch/PackageDropdownSearch.tsx
+++ b/src/features/packages/components/PackageDropdownSearch/PackageDropdownSearch.tsx
@@ -10,6 +10,7 @@ import { usePackages } from "../../hooks";
 import { InstancePackage } from "../../types";
 import { boldSubstring, DEBOUNCE_DELAY } from "./helpers";
 import classes from "./PackageDropdownSearch.module.scss";
+import { UrlParams } from "@/types/UrlParams";
 
 interface PackageDropdownSearchProps {
   selectedItems: InstancePackage[];
@@ -24,7 +25,7 @@ const PackageDropdownSearch: FC<PackageDropdownSearchProps> = ({
   const [open, setOpen] = useState(false);
   const [inputValue, setInputValue] = useState<string>("");
 
-  const { instanceId: urlInstanceId } = useParams();
+  const { instanceId: urlInstanceId } = useParams<UrlParams>();
   const debug = useDebug();
   const { getInstancePackagesQuery } = usePackages();
 

--- a/src/features/packages/components/PackageList/PackageList.tsx
+++ b/src/features/packages/components/PackageList/PackageList.tsx
@@ -23,6 +23,7 @@ import {
   isUbuntuProRequired,
 } from "./helpers";
 import classes from "./PackageList.module.scss";
+import { UrlParams } from "@/types/UrlParams";
 
 const PackageDetails = lazy(() => import("../PackageDetails"));
 
@@ -46,7 +47,7 @@ const PackageList: FC<PackageListProps> = ({
   const [selectedByTabState, setSelectedByTabState] = useState(false);
   const [hideUbuntuProInfo, setHideUbuntuProInfo] = useState(false);
 
-  const { instanceId, childInstanceId } = useParams();
+  const { instanceId, childInstanceId } = useParams<UrlParams>();
   const { setSidePanelContent } = useSidePanel();
 
   const packagesToShow = useMemo(() => {

--- a/src/features/packages/components/PackagesInstallForm/PackagesInstallForm.tsx
+++ b/src/features/packages/components/PackagesInstallForm/PackagesInstallForm.tsx
@@ -8,11 +8,12 @@ import useSidePanel from "@/hooks/useSidePanel";
 import { usePackages } from "../../hooks";
 import { InstancePackage } from "../../types";
 import PackageDropdownSearch from "../PackageDropdownSearch";
+import { UrlParams } from "@/types/UrlParams";
 
 const PackagesInstallForm: FC = () => {
   const [selected, setSelected] = useState<InstancePackage[]>([]);
 
-  const { instanceId: urlInstanceId, childInstanceId } = useParams();
+  const { instanceId: urlInstanceId, childInstanceId } = useParams<UrlParams>();
   const debug = useDebug();
   const { notify } = useNotify();
   const { packagesActionQuery } = usePackages();

--- a/src/features/packages/components/UbuntuProNotification/UbuntuProNotification.tsx
+++ b/src/features/packages/components/UbuntuProNotification/UbuntuProNotification.tsx
@@ -2,6 +2,7 @@ import { FC } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Button, Notification } from "@canonical/react-components";
 import { ROOT_PATH } from "@/constants";
+import { UrlParams } from "@/types/UrlParams";
 
 interface UbuntuProNotificationProps {
   onDismiss: () => void;
@@ -11,7 +12,7 @@ const UbuntuProNotification: FC<UbuntuProNotificationProps> = ({
   onDismiss,
 }) => {
   const navigate = useNavigate();
-  const { instanceId, childInstanceId } = useParams();
+  const { instanceId, childInstanceId } = useParams<UrlParams>();
   return (
     <Notification severity="caution" onDismiss={onDismiss}>
       <strong>Some upgrades require Ubuntu Pro: </strong>

--- a/src/features/processes/components/ProcessesHeader/ProcessesHeader.tsx
+++ b/src/features/processes/components/ProcessesHeader/ProcessesHeader.tsx
@@ -8,6 +8,7 @@ import { usePageParams } from "@/hooks/usePageParams";
 import { useParams } from "react-router-dom";
 import HeaderWithSearch from "@/components/form/HeaderWithSearch";
 import classNames from "classnames";
+import { UrlParams } from "@/types/UrlParams";
 
 interface ProcessesHeaderProps {
   handleClearSelection: () => void;
@@ -18,7 +19,7 @@ const ProcessesHeader: FC<ProcessesHeaderProps> = ({
   selectedPids,
   handleClearSelection,
 }) => {
-  const { instanceId: urlInstanceId } = useParams();
+  const { instanceId: urlInstanceId } = useParams<UrlParams>();
   const { setPageParams } = usePageParams();
   const { notify } = useNotify();
   const debug = useDebug();

--- a/src/features/snaps/components/EditSnap/EditSnap.tsx
+++ b/src/features/snaps/components/EditSnap/EditSnap.tsx
@@ -18,6 +18,7 @@ import { InstalledSnap } from "@/types/Snap";
 import { EditSnapType } from "../../helpers";
 import useSidePanel from "@/hooks/useSidePanel";
 import { useParams } from "react-router-dom";
+import { UrlParams } from "@/types/UrlParams";
 
 interface EditSnapProps {
   type: EditSnapType;
@@ -25,7 +26,7 @@ interface EditSnapProps {
 }
 
 const EditSnap: FC<EditSnapProps> = ({ installedSnaps, type }) => {
-  const { instanceId: urlInstanceId } = useParams();
+  const { instanceId: urlInstanceId } = useParams<UrlParams>();
   const debug = useDebug();
   const { notify } = useNotify();
   const { closeSidePanel } = useSidePanel();

--- a/src/features/snaps/components/InstallSnaps/InstallSnaps.tsx
+++ b/src/features/snaps/components/InstallSnaps/InstallSnaps.tsx
@@ -7,6 +7,7 @@ import useNotify from "@/hooks/useNotify";
 import useSidePanel from "@/hooks/useSidePanel";
 import SnapDropdownSearch from "../SnapDropdownSearch";
 import { useParams } from "react-router-dom";
+import { UrlParams } from "@/types/UrlParams";
 
 const InstallSnaps: FC = () => {
   const [selectedSnaps, setSelectedSnaps] = useState<SelectedSnaps[]>([]);
@@ -16,7 +17,7 @@ const InstallSnaps: FC = () => {
   const { notify } = useNotify();
   const { closeSidePanel } = useSidePanel();
   const { snapsActionQuery } = useSnaps();
-  const { instanceId: urlInstanceId } = useParams();
+  const { instanceId: urlInstanceId } = useParams<UrlParams>();
 
   const instanceId = Number(urlInstanceId);
   const { mutateAsync: installSnaps, isPending: installSnapsLoading } =

--- a/src/features/snaps/components/SnapDropdownSearch/SnapDropdownSearch.tsx
+++ b/src/features/snaps/components/SnapDropdownSearch/SnapDropdownSearch.tsx
@@ -11,6 +11,7 @@ import { useDebounceCallback } from "usehooks-ts";
 import classes from "./SnapDropdownSearch.module.scss";
 import { boldSubstring, DEBOUNCE_DELAY } from "./helpers";
 import { useParams } from "react-router-dom";
+import { UrlParams } from "@/types/UrlParams";
 
 interface SnapDropdownSearchProps {
   selectedItems: SelectedSnaps[];
@@ -23,7 +24,7 @@ const SnapDropdownSearch: FC<SnapDropdownSearchProps> = ({
   setSelectedItems,
   setConfirming,
 }) => {
-  const { instanceId: urlInstanceId } = useParams();
+  const { instanceId: urlInstanceId } = useParams<UrlParams>();
   const debug = useDebug();
   const { getAvailableSnaps } = useSnaps();
 

--- a/src/features/usns/components/UsnPackagesContainer/UsnPackagesContainer.tsx
+++ b/src/features/usns/components/UsnPackagesContainer/UsnPackagesContainer.tsx
@@ -5,6 +5,7 @@ import { useUsns } from "@/features/usns";
 import { Instance } from "@/types/Instance";
 import UsnInstanceList from "../UsnInstanceList";
 import UsnPackageList from "../UsnPackageList";
+import { UrlParams } from "@/types/UrlParams";
 
 type UsnPackagesContainerProps = {
   instances: Instance[];
@@ -21,7 +22,7 @@ const UsnPackagesContainer: FC<UsnPackagesContainerProps> = ({
 }) => {
   const [limit, setLimit] = useState(5);
   const { getAffectedPackagesQuery } = useUsns();
-  const { instanceId: urlInstanceId } = useParams();
+  const { instanceId: urlInstanceId } = useParams<UrlParams>();
 
   const instanceId = Number(urlInstanceId);
 

--- a/src/features/usns/components/UsnPackagesRemoveButton/UsnPackagesRemoveButton.tsx
+++ b/src/features/usns/components/UsnPackagesRemoveButton/UsnPackagesRemoveButton.tsx
@@ -7,6 +7,7 @@ import useDebug from "@/hooks/useDebug";
 import useNotify from "@/hooks/useNotify";
 import { usePageParams } from "@/hooks/usePageParams";
 import { useUsns } from "@/features/usns";
+import { UrlParams } from "@/types/UrlParams";
 
 interface UsnPackagesRemoveButtonProps {
   instanceTitle: string;
@@ -23,7 +24,7 @@ const UsnPackagesRemoveButton: FC<UsnPackagesRemoveButtonProps> = ({
   const { confirmModal, closeConfirmModal } = useConfirm();
   const { removeUsnPackagesQuery } = useUsns();
   const { setPageParams } = usePageParams();
-  const { instanceId: urlInstanceId, childInstanceId } = useParams();
+  const { instanceId: urlInstanceId, childInstanceId } = useParams<UrlParams>();
 
   const instanceId = Number(urlInstanceId);
   const { mutateAsync: removeUsnPackages } = removeUsnPackagesQuery;

--- a/src/features/wsl/components/WslInstanceInstallForm/WslInstanceInstallForm.tsx
+++ b/src/features/wsl/components/WslInstanceInstallForm/WslInstanceInstallForm.tsx
@@ -12,6 +12,7 @@ import useSidePanel from "@/hooks/useSidePanel";
 import { useWsl } from "../../hooks";
 import { MAX_FILE_SIZE_MB, RESERVED_PATTERNS } from "./constants";
 import { fileToBase64 } from "./helpers";
+import { UrlParams } from "@/types/UrlParams";
 
 interface FormProps {
   instanceType: string;
@@ -21,7 +22,7 @@ interface FormProps {
 }
 
 const WslInstanceInstallForm: FC = () => {
-  const { instanceId } = useParams();
+  const { instanceId } = useParams<UrlParams>();
   const debug = useDebug();
   const { closeSidePanel } = useSidePanel();
   const { notify } = useNotify();

--- a/src/hooks/useInstances.ts
+++ b/src/hooks/useInstances.ts
@@ -92,6 +92,12 @@ interface InstancesPowerManageParams {
   deliver_after?: string;
 }
 
+interface RestartInstanceParams {
+  id: number;
+  deliver_after?: string;
+  deliver_delay_window?: number;
+}
+
 interface RenameInstancesParams {
   // `"<instance_id>:<new_title>"[]`
   computer_titles: string[];
@@ -252,6 +258,16 @@ export default function useInstances() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["instances"] }),
   });
 
+  const restartInstanceQuery = useMutation<
+    AxiosResponse<Activity>,
+    AxiosError<ApiError>,
+    RestartInstanceParams
+  >({
+    mutationFn: ({ id, ...queryParams }) =>
+      authFetch!.post(`computers/${id}/restart`, queryParams),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["instances"] }),
+  });
+
   const shutdownInstancesQuery = useMutation<
     AxiosResponse<Activity>,
     AxiosError<ApiError>,
@@ -297,6 +313,7 @@ export default function useInstances() {
     rejectPendingInstancesQuery,
     createCloudOtpsQuery,
     rebootInstancesQuery,
+    restartInstanceQuery,
     shutdownInstancesQuery,
     renameInstancesQuery,
     getAllInstanceTagsQuery,

--- a/src/pages/dashboard/instances/[single]/SingleInstanceContainer/SingleInstanceContainer.tsx
+++ b/src/pages/dashboard/instances/[single]/SingleInstanceContainer/SingleInstanceContainer.tsx
@@ -12,9 +12,10 @@ import { useUsns } from "@/features/usns";
 import SingleInstanceEmptyState from "@/pages/dashboard/instances/[single]/SingleInstanceEmptyState";
 import SingleInstanceTabs from "@/pages/dashboard/instances/[single]/SingleInstanceTabs";
 import { getBreadcrumbs } from "./helpers";
+import { UrlParams } from "@/types/UrlParams";
 
 const SingleInstanceContainer: FC = () => {
-  const { instanceId, childInstanceId } = useParams();
+  const { instanceId, childInstanceId } = useParams<UrlParams>();
   const { user } = useAuth();
   const navigate = useNavigate();
   const { getSingleInstanceQuery } = useInstances();

--- a/src/pages/dashboard/instances/[single]/SingleInstanceTabs/SingleInstanceTabs.tsx
+++ b/src/pages/dashboard/instances/[single]/SingleInstanceTabs/SingleInstanceTabs.tsx
@@ -22,6 +22,9 @@ const PackagesPanel = lazy(
 const ActivityPanel = lazy(
   () => import("@/pages/dashboard/instances/[single]/tabs/activities"),
 );
+const KernelPanel = lazy(
+  () => import("@/pages/dashboard/instances/[single]/tabs/kernel"),
+);
 const WslPanel = lazy(
   () => import("@/pages/dashboard/instances/[single]/tabs/wsl"),
 );
@@ -89,6 +92,9 @@ const SingleInstanceTabs: FC<SingleInstanceTabsProps> = ({
           )}
           {"tab-link-activities" === currentTabLinkId && (
             <ActivityPanel instanceId={instance.id} />
+          )}
+          {"tab-link-kernel" === currentTabLinkId && (
+            <KernelPanel instanceTitle={instance.title} />
           )}
           {"tab-link-security-issues" === currentTabLinkId && (
             <SecurityIssuesPanel instance={instance} />

--- a/src/pages/dashboard/instances/[single]/SingleInstanceTabs/constants.ts
+++ b/src/pages/dashboard/instances/[single]/SingleInstanceTabs/constants.ts
@@ -12,6 +12,10 @@ export const TAB_LINKS = [
     id: "tab-link-activities",
   },
   {
+    label: "Kernel",
+    id: "tab-link-kernel",
+  },
+  {
     label: "Security issues",
     id: "tab-link-security-issues",
   },

--- a/src/pages/dashboard/instances/[single]/tabs/kernel/KernelPanel/KernelPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/kernel/KernelPanel/KernelPanel.tsx
@@ -1,0 +1,89 @@
+import EmptyState from "@/components/layout/EmptyState";
+import LoadingState from "@/components/layout/LoadingState";
+import { TablePagination } from "@/components/layout/TablePagination";
+import {
+  KernelOverview,
+  KernelOverviewInfo,
+  KernelTableHeader,
+  KernelTableList,
+  useKernel,
+} from "@/features/kernel";
+import { usePageParams } from "@/hooks/usePageParams";
+import { UrlParams } from "@/types/UrlParams";
+import { FC, useMemo } from "react";
+import { useParams } from "react-router-dom";
+
+interface KernelPanelProps {
+  instanceTitle: string;
+}
+
+const KernelPanel: FC<KernelPanelProps> = ({ instanceTitle }) => {
+  const { instanceId } = useParams<UrlParams>();
+  const { pageSize, currentPage } = usePageParams();
+  const { getKernelQuery, getLivepatchInfoQuery } = useKernel();
+
+  const { data: kernelStatuses, isPending: isLoadingKernelStatuses } =
+    getKernelQuery({
+      id: parseInt(instanceId ?? ""),
+    });
+
+  const { data: getLivepatchInfoResult } = getLivepatchInfoQuery({
+    id: parseInt(instanceId ?? ""),
+  });
+
+  const allLivepatchFixes =
+    getLivepatchInfoResult?.data.livepatch_info?.json.output.Status[0].Livepatch
+      .Fixes ?? [];
+
+  const getLivepatchFixes = (limit: number, offset: number) => {
+    return allLivepatchFixes.slice(offset, offset + limit);
+  };
+
+  const livepatchFixes = useMemo(
+    () => getLivepatchFixes(pageSize, (currentPage - 1) * pageSize),
+    [allLivepatchFixes, currentPage, pageSize],
+  );
+
+  const kernelOverviewData: KernelOverviewInfo = {
+    currentVersion:
+      getLivepatchInfoResult?.data.livepatch_info?.json.output.Status[0]
+        .Kernel ??
+      kernelStatuses?.data.installed?.version_rounded ??
+      "",
+    expirationDate:
+      getLivepatchInfoResult?.data.livepatch_info?.json.output.Status[0]
+        .UpgradeRequiredDate ?? "",
+    status: kernelStatuses?.data.smart_status ?? "",
+  };
+
+  return (
+    <>
+      {isLoadingKernelStatuses && <LoadingState />}
+      {!isLoadingKernelStatuses && !kernelStatuses?.data.installed && (
+        <EmptyState
+          title="Kernel Information Unavailable"
+          body={
+            kernelStatuses?.data.message || "No kernel information available"
+          }
+        />
+      )}
+      {!isLoadingKernelStatuses && kernelStatuses?.data.installed && (
+        <>
+          <KernelOverview kernelOverview={kernelOverviewData} />
+          <KernelTableHeader
+            instanceName={instanceTitle}
+            hasTableData={livepatchFixes.length > 0}
+            kernelStatuses={kernelStatuses.data}
+          />
+          <KernelTableList kernelData={livepatchFixes} />
+          <TablePagination
+            totalItems={allLivepatchFixes.length}
+            currentItemCount={livepatchFixes.length}
+          />
+        </>
+      )}
+    </>
+  );
+};
+
+export default KernelPanel;

--- a/src/pages/dashboard/instances/[single]/tabs/kernel/KernelPanel/index.ts
+++ b/src/pages/dashboard/instances/[single]/tabs/kernel/KernelPanel/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./KernelPanel";

--- a/src/pages/dashboard/instances/[single]/tabs/kernel/index.ts
+++ b/src/pages/dashboard/instances/[single]/tabs/kernel/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./KernelPanel";

--- a/src/pages/dashboard/instances/[single]/tabs/packages/PackagesPanel/PackagesPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/packages/PackagesPanel/PackagesPanel.tsx
@@ -10,11 +10,12 @@ import {
 } from "@/features/packages";
 import { usePageParams } from "@/hooks/usePageParams";
 import { getEmptyMessage } from "./helpers";
+import { UrlParams } from "@/types/UrlParams";
 
 const PackagesPanel: FC = () => {
   const [selected, setSelected] = useState<InstancePackage[]>([]);
 
-  const { instanceId: urlInstanceId, childInstanceId } = useParams();
+  const { instanceId: urlInstanceId, childInstanceId } = useParams<UrlParams>();
   const { status, search, currentPage, pageSize } = usePageParams();
   const { getInstancePackagesQuery } = usePackages();
   const { state } = useLocation() as { state: { selectAll?: boolean } };

--- a/src/pages/dashboard/instances/[single]/tabs/processes/ProcessesPanel/ProcessesPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/processes/ProcessesPanel/ProcessesPanel.tsx
@@ -4,13 +4,14 @@ import { TablePagination } from "@/components/layout/TablePagination";
 import { ProcessesHeader, ProcessesList } from "@/features/processes";
 import { usePageParams } from "@/hooks/usePageParams";
 import { useProcesses } from "@/hooks/useProcesses";
+import { UrlParams } from "@/types/UrlParams";
 import { FC, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 
 const ProcessesPanel: FC = () => {
   const [selectedPids, setSelectedPids] = useState<number[]>([]);
 
-  const { instanceId: urlInstanceId, childInstanceId } = useParams();
+  const { instanceId: urlInstanceId, childInstanceId } = useParams<UrlParams>();
   const { search, currentPage, pageSize } = usePageParams();
   const { getProcessesQuery } = useProcesses();
 

--- a/src/pages/dashboard/instances/[single]/tabs/security-issues/SecurityIssuesPanelHeader/SecurityIssuesPanelHeader.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/security-issues/SecurityIssuesPanelHeader/SecurityIssuesPanelHeader.tsx
@@ -9,6 +9,7 @@ import useNotify from "@/hooks/useNotify";
 import { useUsns } from "@/features/usns";
 import classes from "./SecurityIssuesPanelHeader.module.scss";
 import { usePageParams } from "@/hooks/usePageParams";
+import { UrlParams } from "@/types/UrlParams";
 
 interface SecurityIssuesPanelHeaderProps {
   onSearch: (searchText: string) => void;
@@ -21,7 +22,7 @@ const SecurityIssuesPanelHeader: FC<SecurityIssuesPanelHeaderProps> = ({
 }) => {
   const [inputText, setInputText] = useState("");
 
-  const { instanceId: urlInstanceId, childInstanceId } = useParams();
+  const { instanceId: urlInstanceId, childInstanceId } = useParams<UrlParams>();
   const { setPageParams } = usePageParams();
   const navigate = useNavigate();
   const debug = useDebug();

--- a/src/pages/dashboard/instances/[single]/tabs/snaps/SnapsPanel/SnapsPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/snaps/SnapsPanel/SnapsPanel.tsx
@@ -8,11 +8,12 @@ import useSidePanel from "@/hooks/useSidePanel";
 import { InstallSnaps, SnapsHeader, SnapsList } from "@/features/snaps";
 import { usePageParams } from "@/hooks/usePageParams";
 import { useParams } from "react-router-dom";
+import { UrlParams } from "@/types/UrlParams";
 
 const SnapsPanel: FC = () => {
   const [selectedSnapIds, setSelectedSnapIds] = useState<string[]>([]);
 
-  const { instanceId: urlInstanceId, childInstanceId } = useParams();
+  const { instanceId: urlInstanceId, childInstanceId } = useParams<UrlParams>();
   const { search, currentPage, pageSize } = usePageParams();
   const { getSnapsQuery } = useSnaps();
   const { setSidePanelContent } = useSidePanel();

--- a/src/pages/dashboard/instances/[single]/tabs/users/EditUserForm/EditUserForm.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/EditUserForm/EditUserForm.tsx
@@ -10,6 +10,7 @@ import useSidePanel from "@/hooks/useSidePanel";
 import useUsers from "@/hooks/useUsers";
 import { User } from "@/types/User";
 import { useParams } from "react-router-dom";
+import { UrlParams } from "@/types/UrlParams";
 
 interface FormProps {
   name: string;
@@ -28,7 +29,7 @@ interface EditUserFormProps {
 }
 
 const EditUserForm: FC<EditUserFormProps> = ({ user }) => {
-  const { instanceId: urlInstanceId } = useParams();
+  const { instanceId: urlInstanceId } = useParams<UrlParams>();
   const debug = useDebug();
   const { notify } = useNotify();
   const { closeSidePanel } = useSidePanel();

--- a/src/pages/dashboard/instances/[single]/tabs/users/NewUserForm/NewUserForm.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/NewUserForm/NewUserForm.tsx
@@ -7,6 +7,7 @@ import useDebug from "@/hooks/useDebug";
 import useSidePanel from "@/hooks/useSidePanel";
 import useUsers from "@/hooks/useUsers";
 import { useParams } from "react-router-dom";
+import { UrlParams } from "@/types/UrlParams";
 
 interface FormProps {
   name: string;
@@ -21,7 +22,7 @@ interface FormProps {
 }
 
 const NewUserForm: FC = () => {
-  const { instanceId: urlInstanceId } = useParams();
+  const { instanceId: urlInstanceId } = useParams<UrlParams>();
   const debug = useDebug();
   const { closeSidePanel } = useSidePanel();
   const { createUserQuery, getGroupsQuery } = useUsers();

--- a/src/pages/dashboard/instances/[single]/tabs/users/UserDetails/UserDetails.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/UserDetails/UserDetails.tsx
@@ -6,13 +6,14 @@ import useUsers from "@/hooks/useUsers";
 import { NOT_AVAILABLE } from "@/constants";
 import { useParams } from "react-router-dom";
 import NoData from "@/components/layout/NoData";
+import { UrlParams } from "@/types/UrlParams";
 
 interface UserDetailsProps {
   user: User;
 }
 
 const UserDetails: FC<UserDetailsProps> = ({ user }) => {
-  const { instanceId: urlInstanceId } = useParams();
+  const { instanceId: urlInstanceId } = useParams<UrlParams>();
   const { getGroupsQuery, getUserGroupsQuery } = useUsers();
 
   const instanceId = Number(urlInstanceId);

--- a/src/pages/dashboard/instances/[single]/tabs/users/UserPanel/UserPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/UserPanel/UserPanel.tsx
@@ -12,13 +12,14 @@ import NewUserForm from "../NewUserForm";
 import { Button } from "@canonical/react-components";
 import { usePageParams } from "@/hooks/usePageParams";
 import { useParams } from "react-router-dom";
+import { UrlParams } from "@/types/UrlParams";
 
 const MAX_USERS_LIMIT = 1000;
 
 const UserPanel: FC = () => {
   const [selected, setSelected] = useState<number[]>([]);
 
-  const { instanceId: urlInstanceId, childInstanceId } = useParams();
+  const { instanceId: urlInstanceId, childInstanceId } = useParams<UrlParams>();
   const { search, currentPage, pageSize } = usePageParams();
   const { setSidePanelContent } = useSidePanel();
   const { getUsersQuery } = useUsers();

--- a/src/pages/dashboard/instances/[single]/tabs/users/UserPanelActionButtons/UserPanelActionButtons.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/UserPanelActionButtons/UserPanelActionButtons.tsx
@@ -16,6 +16,7 @@ import {
 } from "./helpers";
 import LoadingState from "@/components/layout/LoadingState";
 import { useParams } from "react-router-dom";
+import { UrlParams } from "@/types/UrlParams";
 
 const EditUserForm = lazy(
   () => import("@/pages/dashboard/instances/[single]/tabs/users/EditUserForm"),
@@ -35,7 +36,7 @@ const UserPanelActionButtons: FC<UserPanelActionButtonsProps> = ({
   const [confirmDeleteHomeFolders, setConfirmDeleteHomeFolders] =
     useState(false);
 
-  const { instanceId: urlInstanceId } = useParams();
+  const { instanceId: urlInstanceId } = useParams<UrlParams>();
   const debug = useDebug();
   const { notify } = useNotify();
   const { setSidePanelContent, closeSidePanel } = useSidePanel();

--- a/src/tests/mocks/kernel.ts
+++ b/src/tests/mocks/kernel.ts
@@ -1,0 +1,46 @@
+import { Fix } from "@/features/kernel";
+
+export const patches: Fix[] = [
+  {
+    Name: "cve-2013-1797",
+    Patched: false,
+    Bug: "bug-1",
+    Description: "Test description 1",
+  },
+  {
+    Name: "cve-2013-1798",
+    Patched: false,
+    Bug: "bug-2",
+    Description: "Test description 2",
+  },
+  {
+    Name: "cve-2013-1799",
+    Patched: false,
+    Bug: "bug-3",
+    Description: "Test description 3",
+  },
+  {
+    Name: "cve-2013-1800",
+    Patched: true,
+    Bug: "bug-4",
+    Description: "Test description 4",
+  },
+  {
+    Name: "cve-2013-1801",
+    Patched: true,
+    Bug: "bug-5",
+    Description: "Test description 5",
+  },
+  {
+    Name: "cve-2013-1802",
+    Patched: true,
+    Bug: "bug-6",
+    Description: "Test description 6",
+  },
+  {
+    Name: "cve-2013-1803",
+    Patched: false,
+    Bug: "bug-7",
+    Description: "Test description 7",
+  },
+];

--- a/src/types/UrlParams.d.ts
+++ b/src/types/UrlParams.d.ts
@@ -1,0 +1,4 @@
+export type UrlParams = {
+  instanceId: string;
+  childInstanceId: string;
+};


### PR DESCRIPTION
Related to JIRA tickets:
[Ticket 1 - Patches list discovered since last reboot](https://warthogs.atlassian.net/browse/LNDENG-1353)
[Ticket 2 - Kernel overview information](https://warthogs.atlassian.net/browse/LNDENG-1354)
[Ticket 3 - Upgrade / Downgrade kernel forms](https://warthogs.atlassian.net/browse/LNDENG-1355)
[Ticket 4 - List of Kernel versions to downgrade](https://warthogs.atlassian.net/browse/LNDENG-1356)

Related to Figma:
[Kernel tab](https://www.figma.com/design/AghsVBfSCn3qbv23TyFibk/%F0%9F%9B%A1%EF%B8%8F-Livepatch-in-Landscape-24.10?node-id=500-42857&t=74SonKtlP9TnASjF-4)

Done so far:
- Created mock data for Kernels in order to draft a general layout of the Kernel tab.
- Implemented Kernel Header
- Implemented Livepatch fixes list
- Implemented 3 forms required for this feature (Restart, Upgrade, Downgrade)
- Added secondary button action to Sidepanel form buttons to accomodate the new forms
- Added corresponding unit tests for each created component for this feature
- Implemented API endpoints


I am documenting the communication with the backend team via the Jira tickets. The comments, status, and description of those tickets should represent the current state of this feature.