### PR TITLE
build: fix sass deprecation warnings

### DIFF
--- a/src/features/activities/components/Activities/Activities.module.scss
+++ b/src/features/activities/components/Activities/Activities.module.scss
@@ -1,5 +1,5 @@
-@import "node_modules/vanilla-framework/scss/settings_spacing";
-@import "node_modules/vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/settings_spacing";
+@import "vanilla-framework/scss/settings_colors";
 
 .checkbox {
   width: $sp-x-large;

--- a/src/features/activities/components/ActivityDetails/ActivityDetails.module.scss
+++ b/src/features/activities/components/ActivityDetails/ActivityDetails.module.scss
@@ -1,4 +1,4 @@
-@import "node_modules/vanilla-framework/scss/settings_spacing";
+@import "vanilla-framework/scss/settings_spacing";
 
 .statusIcon {
   margin-right: $sph--small !important;

--- a/src/features/alerts/components/AlertTagsCell/AlertTagsCell.module.scss
+++ b/src/features/alerts/components/AlertTagsCell/AlertTagsCell.module.scss
@@ -1,5 +1,5 @@
-@import "node_modules/vanilla-framework/scss/settings_colors";
-@import "node_modules/vanilla-framework/scss/settings_spacing";
+@import "vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/settings_spacing";
 
 .footer {
   margin-bottom: $spv--small;

--- a/src/features/alerts/components/AlertsTable/AlertsTable.module.scss
+++ b/src/features/alerts/components/AlertsTable/AlertsTable.module.scss
@@ -1,6 +1,6 @@
-@import "node_modules/vanilla-framework/scss/settings_colors";
-@import "node_modules/vanilla-framework/scss/settings_spacing";
-@import "node_modules/vanilla-framework/scss/utilities_off-screen";
+@import "vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/settings_spacing";
+@import "vanilla-framework/scss/utilities_off-screen";
 @include vf-u-off-screen;
 
 .switch {

--- a/src/features/events-log/components/EventsLogHeader/EventsLogHeader.module.scss
+++ b/src/features/events-log/components/EventsLogHeader/EventsLogHeader.module.scss
@@ -1,4 +1,4 @@
-@import "node_modules/vanilla-framework/scss/settings_spacing";
+@import "vanilla-framework/scss/settings_spacing";
 
 .container {
   align-items: center;

--- a/src/features/events-log/components/EventsLogList/EventsLogList.module.scss
+++ b/src/features/events-log/components/EventsLogList/EventsLogList.module.scss
@@ -1,4 +1,4 @@
-@import "node_modules/vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/settings_colors";
 
 .message {
   width: 30%;

--- a/src/features/general-settings/components/ChangePasswordForm/ChangePasswordForm.module.scss
+++ b/src/features/general-settings/components/ChangePasswordForm/ChangePasswordForm.module.scss
@@ -1,5 +1,5 @@
-@import "node_modules/vanilla-framework/scss/settings_colors";
-@import "node_modules/vanilla-framework/scss/settings_spacing";
+@import "vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/settings_spacing";
 
 .passwordConstraint {
   align-items: center;

--- a/src/features/general-settings/components/EditUserForm/EditUserForm.module.scss
+++ b/src/features/general-settings/components/EditUserForm/EditUserForm.module.scss
@@ -1,5 +1,5 @@
-@import "node_modules/vanilla-framework/scss/settings_colors";
-@import "node_modules/vanilla-framework/scss/settings_spacing";
+@import "vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/settings_spacing";
 
 .link {
   &:visited {

--- a/src/features/processes/components/ProcessesList/ProcessesList.module.scss
+++ b/src/features/processes/components/ProcessesList/ProcessesList.module.scss
@@ -1,4 +1,4 @@
-@import "node_modules/vanilla-framework/scss/settings_spacing";
+@import "vanilla-framework/scss/settings_spacing";
 
 .header {
   column-gap: $sph--large;

--- a/src/features/ubuntupro/components/UbuntuProHeader/UbuntuProHeader.module.scss
+++ b/src/features/ubuntupro/components/UbuntuProHeader/UbuntuProHeader.module.scss
@@ -1,5 +1,5 @@
-@import "node_modules/vanilla-framework/scss/settings_colors";
-@import "node_modules/vanilla-framework/scss/settings_spacing";
+@import "vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/settings_spacing";
 
 .infoRow {
   border-bottom: 1px solid $color-mid-light;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,4 +16,12 @@ export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(packageJson.version),
   },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: "modern",
+        quietDeps: true,
+      },
+    },
+  },
 });


### PR DESCRIPTION
Vite 5 uses the legacy Sass API by default, which is now deprecated. Switching to the modern API fixes most of the deprecation warnings that fill the terminal.

Enabling `quietDeps` also hides warnings from Vanilla Framework.