### PR TITLE
fix: add loading state during first render

### DIFF
--- a/src/pages/auth/login/LoginPage.tsx
+++ b/src/pages/auth/login/LoginPage.tsx
@@ -15,14 +15,14 @@ const LoginPage: FC = () => {
 
   return (
     <AuthTemplate title="Sign in to Landscape">
-      {isLoading ?? <LoadingState />}
-      {!isLoading && isError && (
+      {isLoading ? (
+        <LoadingState />
+      ) : isError ? (
         <div>
           <h1>Error</h1>
           <pre>{JSON.stringify(error, null, 2)}</pre>
         </div>
-      )}
-      {!isLoading && !isError && (
+      ) : (
         <LoginMethodsLayout
           methods={getLoginMethodsQueryResult?.data ?? null}
         />


### PR DESCRIPTION
When a `LoginPage` renders while `isLoading` is still `true`, it doesn't pass any children to the `AuthTemplate`. This causes the following error on the first render:

```
Warning: Failed prop type: Invalid prop `children` supplied to `LoginPageLayout`, expected a ReactNode.
```

The change ensures that a `LoadingState` is rendered in this case.