### PR TITLE
feat: add employee group filters for autoinstall files

### DIFF
--- a/src/components/filter/TableFilterChips/TableFilterChips.tsx
+++ b/src/components/filter/TableFilterChips/TableFilterChips.tsx
@@ -61,6 +61,7 @@ const TableFilterChips: FC<TableFilterChipsProps> = ({
     setPageParams({
       accessGroups: [],
       availabilityZones: [],
+      employeeGroups: [],
       fromDate: "",
       os: "",
       status: "",
@@ -112,6 +113,7 @@ const TableFilterChips: FC<TableFilterChipsProps> = ({
   }, [
     accessGroups.length,
     availabilityZones.length,
+    employeeGroups.length,
     fromDate,
     hiddenChipCount,
     os,

--- a/src/features/autoinstall-files/components/AutoinstallFilesHeader/AutoinstallFilesHeader.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFilesHeader/AutoinstallFilesHeader.tsx
@@ -13,7 +13,7 @@ import useSidePanel from "@/hooks/useSidePanel";
 import AutoinstallFileForm from "../AutoinstallFileForm";
 
 const AutoinstallFilesHeader: FC = () => {
-  const { setPageParams, status } = usePageParams();
+  const { setPageParams, employeeGroups } = usePageParams();
   const { setSidePanelContent } = useSidePanel();
 
   const handleSearch = (searchText: string) => {
@@ -27,13 +27,13 @@ const AutoinstallFilesHeader: FC = () => {
 
         <div className={classes.filters}>
           <TableFilter
-            multiple={false}
+            multiple
             label="Employee group"
             hasToggleIcon
             hasBadge
             options={AUTOINSTALL_FILE_EMPLOYEE_GROUP_OPTIONS}
-            onItemSelect={(item) => setPageParams({ status: item })}
-            selectedItem={status}
+            onItemsSelect={(items) => setPageParams({ employeeGroups: items })}
+            selectedItems={employeeGroups}
           />
         </div>
 
@@ -64,7 +64,7 @@ const AutoinstallFilesHeader: FC = () => {
       </div>
 
       <TableFilterChips
-        filtersToDisplay={["search", "status", "type", "fromDate", "toDate"]}
+        filtersToDisplay={["search", "employeeGroups"]}
         employeeGroupOptions={AUTOINSTALL_FILE_EMPLOYEE_GROUP_OPTIONS}
         useSearchAsQuery
       />

--- a/src/features/autoinstall-files/components/AutoinstallFilesHeader/constants.ts
+++ b/src/features/autoinstall-files/components/AutoinstallFilesHeader/constants.ts
@@ -1,8 +1,10 @@
 import { SelectOption } from "@/types/SelectOption";
 
 export const AUTOINSTALL_FILE_EMPLOYEE_GROUP_OPTIONS: SelectOption[] = [
-  { label: "All", value: "" },
-  { label: "Test", value: "test" },
+  { label: "Employee group 1", value: "employeeGroup1" },
+  { label: "Employee group 2", value: "employeeGroup2" },
+  { label: "Employee group 3", value: "employeeGroup3" },
+  { label: "Employee group 4", value: "employeeGroup4" },
 ];
 
 export const ADD_BUTTON_TEXT = "Add new";

--- a/src/features/autoinstall-files/components/AutoinstallFilesList/AutoinstallFilesList.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFilesList/AutoinstallFilesList.tsx
@@ -11,6 +11,7 @@ import { usePageParams } from "@/hooks/usePageParams";
 import classes from "./AutoinstallFilesList.module.scss";
 import AutoinstallFilesListContextualMenu from "../AutoinstallFilesListContextualMenu";
 import ViewAutoinstallFileDetailsPanel from "../ViewAutoinstallFileDetailsPanel";
+import { createEmployeeGroupString } from "../../helpers";
 
 interface AutoinstallFilesListProps {
   autoinstallFiles: AutoinstallFile[];
@@ -19,7 +20,7 @@ interface AutoinstallFilesListProps {
 const AutoinstallFilesList: FC<AutoinstallFilesListProps> = ({
   autoinstallFiles,
 }) => {
-  const { search } = usePageParams();
+  const { employeeGroups, search } = usePageParams();
   const { setSidePanelContent } = useSidePanel();
 
   const handleAutoinstallFileDetailsOpen = (profile: AutoinstallFile) => {
@@ -31,14 +32,15 @@ const AutoinstallFilesList: FC<AutoinstallFilesListProps> = ({
   };
 
   const files = useMemo(() => {
-    if (!search) {
-      return autoinstallFiles;
-    }
-
     return autoinstallFiles.filter((file) => {
-      return file.name.toLowerCase().includes(search.toLowerCase());
+      return (
+        file.name.toLowerCase().includes(search.toLowerCase()) &&
+        file.employeeGroupsAssociated.some((group) => {
+          return employeeGroups.length === 0 || employeeGroups.includes(group);
+        })
+      );
     });
-  }, [autoinstallFiles, search]);
+  }, [autoinstallFiles, employeeGroups, search]);
 
   const columns = useMemo<Column<AutoinstallFile>[]>(
     () => [
@@ -67,7 +69,7 @@ const AutoinstallFilesList: FC<AutoinstallFilesListProps> = ({
           },
         }: CellProps<AutoinstallFile>) => (
           <div className={classes.truncated}>
-            {employeeGroupsAssociated.join(", ")}
+            {createEmployeeGroupString(employeeGroupsAssociated)}
           </div>
         ),
       },

--- a/src/features/autoinstall-files/components/ViewAutoinstallFileDetailsTabs/ViewAutoinstallFileDetailsTabs.tsx
+++ b/src/features/autoinstall-files/components/ViewAutoinstallFileDetailsTabs/ViewAutoinstallFileDetailsTabs.tsx
@@ -4,6 +4,7 @@ import classes from "./ViewAutoinstallFileDetailsTabs.module.scss";
 import InfoItem from "@/components/layout/InfoItem";
 import { Tabs } from "@canonical/react-components";
 import ViewAutoinstallFileDetailsEventLog from "../ViewAutoinstallFileDetailsEventLog";
+import { createEmployeeGroupString } from "../../helpers";
 
 type TabId = "info" | "event-log";
 
@@ -54,7 +55,7 @@ const ViewAutoinstallFileDetailsTabs: FC<{ file: AutoinstallFile }> = ({
 
           <InfoItem
             label="Employee groups associated"
-            value={file.employeeGroupsAssociated.join(", ")}
+            value={createEmployeeGroupString(file.employeeGroupsAssociated)}
           />
         </div>
       )}

--- a/src/features/autoinstall-files/helpers.ts
+++ b/src/features/autoinstall-files/helpers.ts
@@ -1,0 +1,11 @@
+import { AUTOINSTALL_FILE_EMPLOYEE_GROUP_OPTIONS } from "./components/AutoinstallFilesHeader/constants";
+
+export const createEmployeeGroupString = (employeeGroups: string[]) => {
+  return employeeGroups
+    .map((employeeGroup) => {
+      return AUTOINSTALL_FILE_EMPLOYEE_GROUP_OPTIONS.find(({ value }) => {
+        return value === employeeGroup;
+      })?.label;
+    })
+    .join(", ");
+};

--- a/src/tests/mocks/autoinstallFiles.ts
+++ b/src/tests/mocks/autoinstallFiles.ts
@@ -3,12 +3,7 @@ import { AutoinstallFile } from "@/features/autoinstall-files";
 export const autoinstallFiles: AutoinstallFile[] = [
   {
     name: "default.yaml",
-    employeeGroupsAssociated: [
-      "Employee group 1",
-      "Employee group 2",
-      "Employee group 3",
-      "Employee group 4",
-    ],
+    employeeGroupsAssociated: ["employeeGroup1"],
     lastModified: "Nov 29, 2024, 16:00",
     dateCreated: "Nov 23, 2024, 10:16",
     version: 3,
@@ -74,10 +69,10 @@ export const autoinstallFiles: AutoinstallFile[] = [
   {
     name: "medium.yaml",
     employeeGroupsAssociated: [
-      "Employee group 1",
-      "Employee group 2",
-      "Employee group 3",
-      "Employee group 4",
+      "employeeGroup1",
+      "employeeGroup2",
+      "employeeGroup3",
+      "employeeGroup4",
     ],
     lastModified: "Nov 29, 2024, 16:00",
     dateCreated: "Nov 23, 2024, 10:16",
@@ -87,10 +82,10 @@ export const autoinstallFiles: AutoinstallFile[] = [
   {
     name: "strict.yaml",
     employeeGroupsAssociated: [
-      "Employee group 1",
-      "Employee group 2",
-      "Employee group 3",
-      "Employee group 4",
+      "employeeGroup1",
+      "employeeGroup2",
+      "employeeGroup3",
+      "employeeGroup4",
     ],
     lastModified: "Nov 29, 2024, 16:00",
     dateCreated: "Nov 23, 2024, 10:16",


### PR DESCRIPTION
I improved the filter by employee group for autoinstall files. You can now select multiple employee groups. This request finishes [_Filter for employee groups of autoinstall files_](https://warthogs.atlassian.net/browse/LNDENG-1965).

<details>
<summary>Screenshots</summary>

|![image](https://github.com/user-attachments/assets/f6610719-cc13-44a8-ab21-f7f90e2d19c8)|
|-|

|![image](https://github.com/user-attachments/assets/6c65ddb3-0375-42a8-bcd8-52cf10b4d868)|
|-|
</details>