### PR TITLE
feat: add counter for autoinstall file employee groups overflow

### DIFF
--- a/src/features/autoinstall-files/components/AutoinstallFileEmployeeGroupsList/AutoinstallFileEmployeeGroupsList.module.scss
+++ b/src/features/autoinstall-files/components/AutoinstallFileEmployeeGroupsList/AutoinstallFileEmployeeGroupsList.module.scss
@@ -1,0 +1,9 @@
+.truncated {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.container {
+  display: flex;
+}

--- a/src/features/autoinstall-files/components/AutoinstallFileEmployeeGroupsList/AutoinstallFileEmployeeGroupsList.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFileEmployeeGroupsList/AutoinstallFileEmployeeGroupsList.tsx
@@ -1,0 +1,49 @@
+import { FC, useEffect, useRef, useState } from "react";
+import classes from "./AutoinstallFileEmployeeGroupsList.module.scss";
+
+interface AutoinstallFileEmployeeGroupsListProps {
+  groups: string[];
+}
+
+const AutoinstallFileEmployeeGroupsList: FC<
+  AutoinstallFileEmployeeGroupsListProps
+> = ({ groups }) => {
+  const [hiddenGroupCount, setHiddenGroupCount] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (containerRef.current) {
+      const divElementBoundingClientRect =
+        containerRef.current.getBoundingClientRect();
+
+      setHiddenGroupCount(
+        [...containerRef.current.children].filter((element) => {
+          return (
+            element.getBoundingClientRect().right >
+            divElementBoundingClientRect.right
+          );
+        }).length,
+      );
+    }
+  }, []);
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.truncated} ref={containerRef}>
+        {groups.map((group, key) => {
+          return (
+            <span key={key}>
+              {group}
+              {key < groups.length - 1 && ", "}
+            </span>
+          );
+        })}
+      </div>
+      <span className="u-text--muted">
+        {hiddenGroupCount > 0 && `+${hiddenGroupCount}`}
+      </span>
+    </div>
+  );
+};
+
+export default AutoinstallFileEmployeeGroupsList;

--- a/src/features/autoinstall-files/components/AutoinstallFileEmployeeGroupsList/index.ts
+++ b/src/features/autoinstall-files/components/AutoinstallFileEmployeeGroupsList/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AutoinstallFileEmployeeGroupsList";

--- a/src/features/autoinstall-files/components/AutoinstallFilesList/AutoinstallFilesList.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFilesList/AutoinstallFilesList.tsx
@@ -11,6 +11,7 @@ import { usePageParams } from "@/hooks/usePageParams";
 import classes from "./AutoinstallFilesList.module.scss";
 import AutoinstallFilesListContextualMenu from "../AutoinstallFilesListContextualMenu";
 import ViewAutoinstallFileDetailsPanel from "../ViewAutoinstallFileDetailsPanel";
+import AutoinstallFileEmployeeGroupsList from "../AutoinstallFileEmployeeGroupsList";
 
 interface AutoinstallFilesListProps {
   autoinstallFiles: AutoinstallFile[];
@@ -66,9 +67,9 @@ const AutoinstallFilesList: FC<AutoinstallFilesListProps> = ({
             original: { employeeGroupsAssociated },
           },
         }: CellProps<AutoinstallFile>) => (
-          <div className={classes.truncated}>
-            {employeeGroupsAssociated.join(", ")}
-          </div>
+          <AutoinstallFileEmployeeGroupsList
+            groups={employeeGroupsAssociated}
+          />
         ),
       },
       {


### PR DESCRIPTION
I added the number that shows how many hidden employee groups there are. This request finishes [_Overflow counter for employee groups of autoinstall file_](https://warthogs.atlassian.net/browse/LNDENG-1968).

<details>
<summary>Screenshots</summary>

|![image](https://github.com/user-attachments/assets/9259d147-5c43-409c-a3e4-93563279f4d2)|
|-|
</details>