### PR TITLE
feat: add ability to assign tags to the selected instances

### DIFF
--- a/src/features/instances/components/InstancesPageActions/InstancesPageActions.test.tsx
+++ b/src/features/instances/components/InstancesPageActions/InstancesPageActions.test.tsx
@@ -14,7 +14,7 @@ const BUTTON_LABELS = [
   "View report",
   "Run script",
   "Upgrade",
-  "Assign access group",
+  "Assign",
 ];
 
 describe("InstancesPageActions", () => {
@@ -149,13 +149,34 @@ describe("InstancesPageActions", () => {
       ).toBeInTheDocument();
     });
 
+    it("'Assign' button", async () => {
+      await userEvent.click(screen.getByRole("button", { name: /assign/i }));
+
+      expect(
+        screen.getByRole("button", { name: /access group/i }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /tags/i })).toBeInTheDocument();
+    });
+
     it("'Assign access group' button", async () => {
+      await userEvent.click(screen.getByRole("button", { name: /assign/i }));
+
       await userEvent.click(
-        screen.getByRole("button", { name: /Assign access group/i }),
+        screen.getByRole("button", { name: /access group/i }),
       );
 
       expect(
-        screen.getByRole("heading", { name: /Assign access group/i }),
+        screen.getByRole("heading", { name: /assign access group/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("'Assign tags' button", async () => {
+      await userEvent.click(screen.getByRole("button", { name: /assign/i }));
+
+      await userEvent.click(screen.getByRole("button", { name: /tags/i }));
+
+      expect(
+        screen.getByRole("heading", { name: /assign tags/i }),
       ).toBeInTheDocument();
     });
   });

--- a/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
+++ b/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
@@ -1,5 +1,10 @@
 import { FC, lazy, Suspense } from "react";
-import { Button, ConfirmationButton, Icon } from "@canonical/react-components";
+import {
+  Button,
+  ConfirmationButton,
+  ContextualMenu,
+  Icon,
+} from "@canonical/react-components";
 import LoadingState from "@/components/layout/LoadingState";
 import useDebug from "@/hooks/useDebug";
 import useSidePanel from "@/hooks/useSidePanel";
@@ -22,6 +27,7 @@ const Upgrades = lazy(() =>
 );
 const ReportView = lazy(() => import("@/pages/dashboard/instances/ReportView"));
 const AccessGroupChange = lazy(() => import("../AccessGroupChange"));
+const TagsAddForm = lazy(() => import("../TagsAddForm"));
 
 interface InstancesPageActionsProps {
   selected: Instance[];
@@ -118,99 +124,124 @@ const InstancesPageActions: FC<InstancesPageActionsProps> = ({ selected }) => {
     );
   };
 
+  const handleTagsAssign = () => {
+    setSidePanelContent(
+      "Assign tags",
+      <Suspense fallback={<LoadingState />}>
+        <TagsAddForm selected={selected} />
+      </Suspense>,
+    );
+  };
+
   return (
-    <div className="p-segmented-control">
-      <div className="p-segmented-control__list">
-        <ConfirmationButton
-          className="p-segmented-control__button has-icon"
-          type="button"
-          disabled={shutdownInstancesLoading || 0 === selected.length}
-          confirmationModalProps={{
-            title: "Shutting down selected instances",
-            children: (
-              <p>
-                Are you sure you want to shutdown {selected.length} instance
-                {selected.length === 1 ? "" : "s"}?
-              </p>
-            ),
-            confirmButtonLabel: "Shutdown",
-            confirmButtonAppearance: "negative",
-            confirmButtonLoading: shutdownInstancesLoading,
-            confirmButtonDisabled: shutdownInstancesLoading,
-            onConfirm: handleShutdownInstance,
-          }}
-        >
-          <Icon name="power-off" />
-          <span>Shutdown</span>
-        </ConfirmationButton>
-        <ConfirmationButton
-          className="p-segmented-control__button has-icon"
-          type="button"
-          disabled={rebootInstancesLoading || 0 === selected.length}
-          confirmationModalProps={{
-            title: "Restarting selected instances",
-            children: (
-              <p>
-                Are you sure you want to restart {selected.length} instance
-                {selected.length === 1 ? "" : "s"}?
-              </p>
-            ),
-            confirmButtonLabel: "Restart",
-            confirmButtonAppearance: "negative",
-            confirmButtonLoading: rebootInstancesLoading,
-            confirmButtonDisabled: rebootInstancesLoading,
-            onConfirm: handleRebootInstance,
-          }}
-        >
-          <Icon name="restart" />
-          <span>Restart</span>
-        </ConfirmationButton>
-        {REPORT_VIEW_ENABLED && (
+    <>
+      <div className="p-segmented-control">
+        <div className="p-segmented-control__list">
+          <ConfirmationButton
+            className="p-segmented-control__button has-icon"
+            type="button"
+            disabled={shutdownInstancesLoading || 0 === selected.length}
+            confirmationModalProps={{
+              title: "Shutting down selected instances",
+              children: (
+                <p>
+                  Are you sure you want to shutdown {selected.length} instance
+                  {selected.length === 1 ? "" : "s"}?
+                </p>
+              ),
+              confirmButtonLabel: "Shutdown",
+              confirmButtonAppearance: "negative",
+              confirmButtonLoading: shutdownInstancesLoading,
+              confirmButtonDisabled: shutdownInstancesLoading,
+              onConfirm: handleShutdownInstance,
+            }}
+          >
+            <Icon name="power-off" />
+            <span>Shutdown</span>
+          </ConfirmationButton>
+          <ConfirmationButton
+            className="p-segmented-control__button has-icon"
+            type="button"
+            disabled={rebootInstancesLoading || 0 === selected.length}
+            confirmationModalProps={{
+              title: "Restarting selected instances",
+              children: (
+                <p>
+                  Are you sure you want to restart {selected.length} instance
+                  {selected.length === 1 ? "" : "s"}?
+                </p>
+              ),
+              confirmButtonLabel: "Restart",
+              confirmButtonAppearance: "negative",
+              confirmButtonLoading: rebootInstancesLoading,
+              confirmButtonDisabled: rebootInstancesLoading,
+              onConfirm: handleRebootInstance,
+            }}
+          >
+            <Icon name="restart" />
+            <span>Restart</span>
+          </ConfirmationButton>
+          {REPORT_VIEW_ENABLED && (
+            <Button
+              className="p-segmented-control__button"
+              type="button"
+              onClick={handleReportView}
+              disabled={0 === selected.length}
+            >
+              <Icon name="status" />
+              <span>View report</span>
+            </Button>
+          )}
           <Button
             className="p-segmented-control__button"
             type="button"
-            onClick={handleReportView}
+            onClick={handleRunScript}
             disabled={0 === selected.length}
           >
-            <Icon name="status" />
-            <span>View report</span>
+            <Icon name="code" />
+            <span>Run script</span>
           </Button>
-        )}
-        <Button
-          className="p-segmented-control__button"
-          type="button"
-          onClick={handleRunScript}
-          disabled={0 === selected.length}
-        >
-          <Icon name="code" />
-          <span>Run script</span>
-        </Button>
-        <Button
-          className="p-segmented-control__button"
-          type="button"
-          onClick={handleUpgradesRequest}
-          disabled={
-            0 === selected.length ||
-            selected.every(
-              ({ upgrades }) =>
-                !upgrades || (!upgrades.regular && !upgrades.security),
-            )
-          }
-        >
-          <Icon name="change-version" />
-          <span>Upgrade</span>
-        </Button>
-        <Button
-          className="p-segmented-control__button"
-          type="button"
-          onClick={handleAccessGroupChange}
-          disabled={0 === selected.length}
-        >
-          <Icon name="settings" />
-          <span>Assign access group</span>
-        </Button>
+          <Button
+            className="p-segmented-control__button"
+            type="button"
+            onClick={handleUpgradesRequest}
+            disabled={
+              0 === selected.length ||
+              selected.every(
+                ({ upgrades }) =>
+                  !upgrades || (!upgrades.regular && !upgrades.security),
+              )
+            }
+          >
+            <Icon name="change-version" />
+            <span>Upgrade</span>
+          </Button>
+        </div>
       </div>
-    </div>
+
+      <ContextualMenu
+        hasToggleIcon
+        links={[
+          {
+            children: "Access group",
+            onClick: handleAccessGroupChange,
+          },
+          {
+            children: "Tags",
+            onClick: handleTagsAssign,
+          },
+        ]}
+        position="right"
+        toggleLabel={
+          <>
+            <Icon name="plus" />
+            <span>Assign</span>
+          </>
+        }
+        toggleDisabled={0 === selected.length}
+        dropdownProps={{ style: { zIndex: 10 } }}
+      />
+    </>
   );
 };
 

--- a/src/features/instances/components/TagsAddForm/TagsAddForm.test.tsx
+++ b/src/features/instances/components/TagsAddForm/TagsAddForm.test.tsx
@@ -1,0 +1,119 @@
+import { renderWithProviders } from "@/tests/render";
+import TagsAddForm from "./TagsAddForm";
+import { instances } from "@/tests/mocks/instance";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { getTestErrorParams } from "@/tests/mocks/error";
+
+describe("TagsAddForm", async () => {
+  const addTagsToInstances = vi.hoisted(() =>
+    vi.fn(({ tags }: { tags: string[] }) => {
+      if (tags.includes("error")) {
+        const { testError } = getTestErrorParams();
+
+        throw testError;
+      }
+    }),
+  );
+  const selected = instances;
+
+  vi.mock("@/hooks/useInstances", async (importOriginal) => {
+    const original =
+      await importOriginal<typeof import("@/hooks/useInstances")>();
+
+    return {
+      ...original,
+      default: () => ({
+        ...original.default(),
+        addTagsToInstancesQuery: {
+          mutateAsync: addTagsToInstances,
+        },
+      }),
+    };
+  });
+
+  describe("multiple instances", () => {
+    beforeEach(() => {
+      renderWithProviders(<TagsAddForm selected={selected} />);
+    });
+
+    it("should render form", () => {
+      expect(
+        screen.getByRole("combobox", { name: /tags/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /assign/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("should validate form", async () => {
+      await userEvent.click(screen.getByRole("button", { name: /assign/i }));
+
+      expect(addTagsToInstances).not.toHaveBeenCalled();
+
+      expect(
+        screen.getByText(/At least one tag is required/i),
+      ).toBeInTheDocument();
+    });
+
+    it("should add selected tags to the selected instances", async () => {
+      const tags = ["tag1", "tag2"];
+      const query = selected.map(({ id }) => `id:${id}`).join(" OR ");
+
+      await userEvent.click(screen.getByRole("combobox", { name: /tags/i }));
+
+      for (const tag of tags) {
+        await userEvent.click(screen.getByText(tag));
+      }
+
+      await userEvent.click(screen.getByRole("button", { name: /assign/i }));
+
+      expect(addTagsToInstances).toHaveBeenCalledWith({ query, tags });
+      expect(
+        screen.getByText(
+          `Tags successfully assigned to ${selected.length} instances`,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("should handle error", async () => {
+      const tags = ["error"];
+      const { testErrorMessage } = getTestErrorParams();
+
+      await userEvent.click(screen.getByRole("combobox", { name: /tags/i }));
+
+      for (const tag of tags) {
+        await userEvent.click(screen.getByText(tag));
+      }
+
+      await userEvent.click(screen.getByRole("button", { name: /assign/i }));
+
+      expect(screen.getByText(testErrorMessage)).toBeInTheDocument();
+    });
+  });
+
+  it("should add selected tags to the single instances", async () => {
+    renderWithProviders(<TagsAddForm selected={selected.slice(-1)} />);
+
+    const tags = ["tag1", "tag2"];
+    const query = selected
+      .slice(-1)
+      .map(({ id }) => `id:${id}`)
+      .join(" OR ");
+
+    await userEvent.click(screen.getByRole("combobox", { name: /tags/i }));
+
+    for (const tag of tags) {
+      await userEvent.click(screen.getByText(tag));
+    }
+
+    await userEvent.click(screen.getByRole("button", { name: /assign/i }));
+
+    expect(addTagsToInstances).toHaveBeenCalledWith({ query, tags });
+    expect(
+      screen.getByText(
+        `Tags successfully assigned to "${selected[selected.length - 1].title}" instance`,
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/features/instances/components/TagsAddForm/TagsAddForm.tsx
+++ b/src/features/instances/components/TagsAddForm/TagsAddForm.tsx
@@ -1,0 +1,95 @@
+import { FC } from "react";
+import { Instance } from "@/types/Instance";
+import { Form } from "@canonical/react-components";
+import { useFormik } from "formik";
+import MultiSelectField from "@/components/form/MultiSelectField";
+import {
+  INITIAL_TAGS_ADD_FORM_VALUES,
+  TAGS_ADD_FORM_VALIDATION_SCHEMA,
+} from "./constants";
+import { TagsAddFormValues } from "./types";
+import useInstances from "@/hooks/useInstances";
+import useDebug from "@/hooks/useDebug";
+import { getFormikError } from "@/utils/formikErrors";
+import SidePanelFormButtons from "@/components/form/SidePanelFormButtons";
+import useSidePanel from "@/hooks/useSidePanel";
+import useNotify from "@/hooks/useNotify";
+
+interface TagsAddFormProps {
+  selected: Instance[];
+}
+
+const TagsAddForm: FC<TagsAddFormProps> = ({ selected }) => {
+  const debug = useDebug();
+  const { notify } = useNotify();
+  const { closeSidePanel } = useSidePanel();
+  const { addTagsToInstancesQuery, getAllInstanceTagsQuery } = useInstances();
+
+  const { data: getAllInstanceTagsQueryResult } = getAllInstanceTagsQuery();
+
+  const tagOptions =
+    getAllInstanceTagsQueryResult?.data.results.map((tag) => ({
+      label: tag,
+      value: tag,
+    })) ?? [];
+
+  const { mutateAsync: addTagsToInstances } = addTagsToInstancesQuery;
+
+  const handleSubmit = async ({ tags }: TagsAddFormValues) => {
+    try {
+      await addTagsToInstances({
+        query: selected.map(({ id }) => `id:${id}`).join(" OR "),
+        tags,
+      });
+
+      closeSidePanel();
+
+      notify.success({
+        title: "Tags assigned",
+        message: `Tags successfully assigned to ${
+          selected.length > 1
+            ? `${selected.length} instances`
+            : `"${selected[0].title}" instance`
+        }`,
+      });
+    } catch (error) {
+      debug(error);
+    }
+  };
+
+  const formik = useFormik({
+    initialValues: INITIAL_TAGS_ADD_FORM_VALUES,
+    onSubmit: handleSubmit,
+    validationSchema: TAGS_ADD_FORM_VALIDATION_SCHEMA,
+  });
+
+  return (
+    <Form onSubmit={formik.handleSubmit} noValidate>
+      <MultiSelectField
+        variant="condensed"
+        label="Tags"
+        required
+        items={tagOptions}
+        selectedItems={formik.values.tags.map((tag) => ({
+          label: tag,
+          value: tag,
+        }))}
+        onItemsUpdate={(items) => {
+          formik.setFieldValue(
+            "tags",
+            items.map(({ value }) => value),
+          );
+        }}
+        {...formik.getFieldProps("tags")}
+        error={getFormikError(formik, "tags")}
+      />
+
+      <SidePanelFormButtons
+        submitButtonDisabled={formik.isSubmitting}
+        submitButtonText="Assign"
+      />
+    </Form>
+  );
+};
+
+export default TagsAddForm;

--- a/src/features/instances/components/TagsAddForm/constants.ts
+++ b/src/features/instances/components/TagsAddForm/constants.ts
@@ -1,0 +1,10 @@
+import { TagsAddFormValues } from "./types";
+import * as Yup from "yup";
+
+export const INITIAL_TAGS_ADD_FORM_VALUES: TagsAddFormValues = {
+  tags: [],
+};
+
+export const TAGS_ADD_FORM_VALIDATION_SCHEMA = Yup.object({
+  tags: Yup.array().of(Yup.string()).min(1, "At least one tag is required"),
+});

--- a/src/features/instances/components/TagsAddForm/index.ts
+++ b/src/features/instances/components/TagsAddForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TagsAddForm";

--- a/src/features/instances/components/TagsAddForm/types.d.ts
+++ b/src/features/instances/components/TagsAddForm/types.d.ts
@@ -1,0 +1,3 @@
+export interface TagsAddFormValues {
+  tags: string[];
+}

--- a/src/features/mirrors/components/DistributionCard/DistributionCard.tsx
+++ b/src/features/mirrors/components/DistributionCard/DistributionCard.tsx
@@ -144,6 +144,7 @@ const DistributionCard: FC<DistributionCardProps> = ({
           ) : (
             <ContextualMenu
               position="left"
+              hasToggleIcon
               toggleLabel="Actions"
               toggleProps={{
                 "aria-label": `${distribution.name} distribution actions`,

--- a/src/features/mirrors/components/SeriesCard/SeriesCard.tsx
+++ b/src/features/mirrors/components/SeriesCard/SeriesCard.tsx
@@ -192,6 +192,7 @@ const SeriesCard: FC<SeriesCardProps> = ({
           ) : (
             <ContextualMenu
               position="left"
+              hasToggleIcon
               toggleLabel="Actions"
               toggleClassName="u-no-margin--bottom"
               links={contextualMenuLinks}

--- a/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.tsx
@@ -1,16 +1,16 @@
 import classNames from "classnames";
-import { FC, lazy, Suspense, useState } from "react";
+import { FC, lazy, Suspense, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Button,
   CheckboxInput,
   Col,
   ConfirmationButton,
+  Form,
   Icon,
   ICONS,
-  Row,
   Input,
-  Form,
+  Row,
 } from "@canonical/react-components";
 import TagMultiSelect from "@/components/form/TagMultiSelect";
 import InfoItem from "@/components/layout/InfoItem";
@@ -58,7 +58,9 @@ const InfoPanel: FC<InfoPanelProps> = ({ instance }) => {
   const { deleteChildInstancesQuery } = useWsl();
   const { editInstanceQuery } = useInstances();
 
-  const { mutateAsync: editInstance } = editInstanceQuery;
+  useEffect(() => {
+    setInstanceTags(instance.tags);
+  }, [instance.tags]);
 
   const { data: getAccessGroupQueryResult } = getAccessGroupQuery();
 
@@ -68,6 +70,7 @@ const InfoPanel: FC<InfoPanelProps> = ({ instance }) => {
       value: name,
     })) ?? [];
 
+  const { mutateAsync: editInstance } = editInstanceQuery;
   const { mutateAsync: removeInstances, isPending: isRemoving } =
     removeInstancesQuery;
   const { mutateAsync: rebootInstances, isPending: isRebooting } =

--- a/src/pages/dashboard/repositories/mirrors/DistributionsPage.tsx
+++ b/src/pages/dashboard/repositories/mirrors/DistributionsPage.tsx
@@ -92,6 +92,7 @@ const DistributionsPage: FC = () => {
             : [
                 <ContextualMenu
                   key="menu"
+                  hasToggleIcon
                   toggleLabel="Actions"
                   toggleClassName="u-no-margin--bottom"
                   links={contextualMenuLinks}

--- a/src/tests/mocks/tag.ts
+++ b/src/tests/mocks/tag.ts
@@ -5,6 +5,7 @@ export const tags = [
   "dapper",
   "edgy",
   "empty",
+  "error",
   "feisty",
   "focal",
   "gutsy",


### PR DESCRIPTION
With a long tag list, the multiselect is buggy because you can't scroll it when opened in the side panel.
I created a small PR to react-components to fix that. Waiting for approval.