### PR TITLE
feat: show default autoinstall file

### DIFF
--- a/src/features/autoinstall-files/components/AutoinstallFilesList/AutoinstallFilesList.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFilesList/AutoinstallFilesList.tsx
@@ -14,18 +14,22 @@ import ViewAutoinstallFileDetailsPanel from "../ViewAutoinstallFileDetailsPanel"
 
 interface AutoinstallFilesListProps {
   autoinstallFiles: AutoinstallFile[];
+  defaultFile: AutoinstallFile;
 }
 
 const AutoinstallFilesList: FC<AutoinstallFilesListProps> = ({
   autoinstallFiles,
+  defaultFile,
 }) => {
   const { search } = usePageParams();
   const { setSidePanelContent } = useSidePanel();
 
-  const handleAutoinstallFileDetailsOpen = (profile: AutoinstallFile) => {
+  const handleAutoinstallFileDetailsOpen = (file: AutoinstallFile) => {
+    const isDefault = file === defaultFile;
+
     setSidePanelContent(
-      profile.name,
-      <ViewAutoinstallFileDetailsPanel file={profile} />,
+      `${file.name}${isDefault ? " (default)" : ""}`,
+      <ViewAutoinstallFileDetailsPanel file={file} isDefault={isDefault} />,
       "large",
     );
   };
@@ -54,6 +58,7 @@ const AutoinstallFilesList: FC<AutoinstallFilesListProps> = ({
             onClick={() => handleAutoinstallFileDetailsOpen(original)}
           >
             {original.name}
+            {original === defaultFile && " (default)"}
           </Button>
         ),
       },

--- a/src/features/autoinstall-files/components/AutoinstallFilesPanel/AutoinstallFilesPanel.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFilesPanel/AutoinstallFilesPanel.tsx
@@ -7,7 +7,10 @@ const AutoinstallFilesPanel: FC = () => {
   return (
     <>
       <AutoinstallFilesHeader />
-      <AutoinstallFilesList autoinstallFiles={autoinstallFiles} />
+      <AutoinstallFilesList
+        autoinstallFiles={autoinstallFiles}
+        defaultFile={autoinstallFiles[0]}
+      />
     </>
   );
 };

--- a/src/features/autoinstall-files/components/ViewAutoinstallFileDetailsPanel/ViewAutoinstallFileDetailsPanel.tsx
+++ b/src/features/autoinstall-files/components/ViewAutoinstallFileDetailsPanel/ViewAutoinstallFileDetailsPanel.tsx
@@ -5,16 +5,17 @@ import classes from "./ViewAutoinstallFileDetailsPanel.module.scss";
 import ViewAutoinstallFileDetailsTabs from "../ViewAutoinstallFileDetailsTabs";
 import ViewAutoinstallFileDetailsEditButton from "../ViewAutoinstallFileDetailsEditButton";
 
-const ViewAutoinstallFileDetailsPanel: FC<{ file: AutoinstallFile }> = ({
-  file,
-}) => {
+const ViewAutoinstallFileDetailsPanel: FC<{
+  file: AutoinstallFile;
+  isDefault: boolean;
+}> = ({ file, isDefault }) => {
   return (
     <>
       <div className="p-segmented-control">
         <div className="p-segmented-control__list">
           <ViewAutoinstallFileDetailsEditButton fileName={file.name} />
 
-          <Button className="p-segmented-control__button" disabled>
+          <Button className="p-segmented-control__button" disabled={isDefault}>
             <Icon name="delete" />
             <span>Remove</span>
           </Button>

--- a/src/tests/mocks/autoinstallFiles.ts
+++ b/src/tests/mocks/autoinstallFiles.ts
@@ -2,7 +2,7 @@ import { AutoinstallFile } from "@/features/autoinstall-files";
 
 export const autoinstallFiles: AutoinstallFile[] = [
   {
-    name: "default.yaml",
+    name: "autoinstall.yaml",
     employeeGroupsAssociated: [
       "Employee group 1",
       "Employee group 2",
@@ -14,58 +14,58 @@ export const autoinstallFiles: AutoinstallFile[] = [
     version: 3,
     events: [
       {
-        description: "New version 10 of default.yaml created",
+        description: "New version 10 of autoinstall.yaml created",
         author: "Stephanie Domas",
         createdAt: "Nov 23, 2024, 10:16",
       },
       {
-        description: "New version 9 of default.yaml created",
+        description: "New version 9 of autoinstall.yaml created",
         author: "Stephanie Domas",
         createdAt: "Nov 23, 2024, 10:16",
       },
       {
-        description: "New version 8 of default.yaml created",
+        description: "New version 8 of autoinstall.yaml created",
         author: "Stephanie Domas",
         createdAt: "Nov 23, 2024, 10:16",
       },
       {
-        description: "New version 7 of default.yaml created",
+        description: "New version 7 of autoinstall.yaml created",
         author: "Stephanie Domas",
         createdAt: "Nov 23, 2024, 10:16",
       },
       {
-        description: "New version 6 of default.yaml created",
+        description: "New version 6 of autoinstall.yaml created",
         author: "Stephanie Domas",
         createdAt: "Nov 23, 2024, 10:16",
       },
       {
-        description: "New version 5 of default.yaml created",
+        description: "New version 5 of autoinstall.yaml created",
         author: "Stephanie Domas",
         createdAt: "Nov 23, 2024, 10:16",
       },
       {
-        description: "New version 4 of default.yaml created",
+        description: "New version 4 of autoinstall.yaml created",
         author: "Stephanie Domas",
         createdAt: "Nov 23, 2024, 10:16",
       },
       {
-        description: "New version 3 of default.yaml created",
+        description: "New version 3 of autoinstall.yaml created",
         author: "Stephanie Domas",
         createdAt: "Nov 23, 2024, 10:16",
       },
       {
-        description: "New version 2 of default.yaml created",
+        description: "New version 2 of autoinstall.yaml created",
         author: "Stephanie Domas",
         createdAt: "Nov 23, 2024, 10:16",
       },
       {
         description:
-          "Autoinstall file default.yaml associated with Asia-Pacific Team",
+          "Autoinstall file autoinstall.yaml associated with Asia-Pacific Team",
         author: "Stephanie Domas",
         createdAt: "Nov 23, 2024, 10:16",
       },
       {
-        description: "Autoinstall file default.yaml created",
+        description: "Autoinstall file autoinstall.yaml created",
         author: "Stephanie Domas",
         createdAt: "Nov 23, 2024, 10:16",
       },


### PR DESCRIPTION
I added an indicator for the default autoinstall file.

This request finishes [_Default autoinstall file_](https://warthogs.atlassian.net/browse/LNDENG-1970).

<details>
<summary>Screenshots</summary>

|![image](https://github.com/user-attachments/assets/eae65e78-2c78-4a61-9ca8-01cffbd22114)|
|-|

|![image](https://github.com/user-attachments/assets/30646b5a-b725-4dc7-b615-6917ca9b3987)|
|-|
</details>