### PR TITLE
build: Change Vitest pool to "vmForks"

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
         },
       },
     },
-    pool: "vmThreads",
+    pool: "vmForks",
     testTimeout: 30000,
     coverage: {
       provider: "v8",


### PR DESCRIPTION
This change should fix Vitest for newer versions of Node. I tested it with 22.13.1. I just want to know whether there was a reason for having "vmThreads" before.