### PR TITLE
build: Update React Router DOM to 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "react": "18.3.1",
         "react-chartjs-2": "5.3.0",
         "react-dom": "18.3.1",
-        "react-router-dom": "6.26.2",
+        "react-router": "7.1.3",
         "usehooks-ts": "3.1.0",
         "vanilla-framework": "4.20.1",
         "yup": "1.6.1"
@@ -2396,15 +2396,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.2.tgz",
-      "integrity": "sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rollup/pluginutils": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
@@ -3421,7 +3412,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/eslint": {
@@ -9238,6 +9228,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
@@ -13676,35 +13667,36 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.26.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.2.tgz",
-      "integrity": "sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.3.tgz",
+      "integrity": "sha512-EezYymLY6Guk/zLQ2vRA8WvdUhWFEj5fcE3RfWihhxXBW7+cd1LsIiA3lmx+KCmneAGQuyBv820o44L2+TtkSA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.19.2"
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
-    "node_modules/react-router-dom": {
-      "version": "6.26.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.2.tgz",
-      "integrity": "sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==",
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
       "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.19.2",
-        "react-router": "6.26.2"
-      },
       "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "node": ">=18"
       }
     },
     "node_modules/react-table": {
@@ -14548,6 +14540,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -16129,6 +16127,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react": "18.3.1",
     "react-chartjs-2": "5.3.0",
     "react-dom": "18.3.1",
-    "react-router-dom": "6.26.2",
+    "react-router": "7.1.3",
     "usehooks-ts": "3.1.0",
     "vanilla-framework": "4.20.1",
     "yup": "1.6.1"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,5 @@
 import { FC, lazy, ReactNode, Suspense, useEffect } from "react";
-import {
-  Outlet,
-  Route,
-  Routes,
-  useLocation,
-  useNavigate,
-} from "react-router-dom";
+import { Outlet, Route, Routes, useLocation, useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import AppNotification from "@/components/layout/AppNotification";
 import LoadingState from "@/components/layout/LoadingState";

--- a/src/components/layout/PageHeader/PageHeader.tsx
+++ b/src/components/layout/PageHeader/PageHeader.tsx
@@ -1,7 +1,7 @@
 import { FC, ReactNode } from "react";
 import classes from "./PageHeader.module.scss";
 import classNames from "classnames";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { Breadcrumb } from "../../../types/Breadcrumb";
 import { useMediaQuery } from "usehooks-ts";
 

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -7,7 +7,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { ROOT_PATH } from "@/constants";
 import useNotify from "@/hooks/useNotify";

--- a/src/context/notify.tsx
+++ b/src/context/notify.tsx
@@ -5,7 +5,7 @@ import React, {
   useEffect,
   useState,
 } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 import { ROOT_PATH } from "@/constants";
 import useNotificationHelper from "@/hooks/useNotificationHelper";
 import { NotificationHelper } from "@/types/Notification";

--- a/src/context/sidePanel.tsx
+++ b/src/context/sidePanel.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from "react";
 import classNames from "classnames";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 import AppNotification from "@/components/layout/AppNotification";
 import useNotify from "@/hooks/useNotify";
 import classes from "./SidePanelProvider.module.scss";

--- a/src/features/access-groups/components/AccessGroupInstanceCountCell/AccessGroupInstanceCountCell.tsx
+++ b/src/features/access-groups/components/AccessGroupInstanceCountCell/AccessGroupInstanceCountCell.tsx
@@ -2,7 +2,7 @@ import { ROOT_PATH } from "@/constants";
 import useInstances from "@/hooks/useInstances";
 import { Spinner } from "@canonical/react-components";
 import { FC } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { AccessGroupWithInstancesCount } from "../../types/AccessGroup";
 import classes from "./AccessGroupInstanceCountCell.module.scss";
 

--- a/src/features/activities/components/Activities/Activities.tsx
+++ b/src/features/activities/components/Activities/Activities.tsx
@@ -21,7 +21,7 @@ import { ActivityCommon } from "../../types";
 import classes from "./Activities.module.scss";
 import usePageParams from "@/hooks/usePageParams";
 import NoData from "@/components/layout/NoData";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { getDateQuery, getStatusQuery, getTypeQuery } from "./helpers";
 
 const ActivityDetails = lazy(

--- a/src/features/activities/components/ActivitiesHeader/ActivitiesHeader.tsx
+++ b/src/features/activities/components/ActivitiesHeader/ActivitiesHeader.tsx
@@ -12,7 +12,7 @@ import { StatusFilter, TableFilterChips } from "@/components/filter";
 import ActivityTypeFilter from "../ActivityTypeFilter";
 import { useActivities } from "../../hooks";
 import ActivitiesDateFilter from "../ActivitiesDateFilter";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { UrlParams } from "@/types/UrlParams";
 import classNames from "classnames";
 

--- a/src/features/activities/hooks/useOpenActivityDetails.ts
+++ b/src/features/activities/hooks/useOpenActivityDetails.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { Activity, ActivityCommon } from "../types";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 
 export default function useOpenActivityDetails(
   handleActivityDetailsOpen: (activity: ActivityCommon) => void,

--- a/src/features/alert-notifications/components/AlertNotificationsList/AlertNotificationsList.tsx
+++ b/src/features/alert-notifications/components/AlertNotificationsList/AlertNotificationsList.tsx
@@ -6,7 +6,7 @@ import { PendingInstance } from "@/types/Instance";
 import { Button, Icon, List } from "@canonical/react-components";
 import classNames from "classnames";
 import { FC, lazy, Suspense } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { AlertSummary } from "../../types";
 import classes from "./AlertNotificationsList.module.scss";
 

--- a/src/features/auth/components/AvailableProviderList/AvailableProviderList.tsx
+++ b/src/features/auth/components/AvailableProviderList/AvailableProviderList.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { Button, Icon } from "@canonical/react-components";
 import { IdentityProvider } from "../../types";
 import {

--- a/src/features/auth/components/LoginForm/LoginForm.test.tsx
+++ b/src/features/auth/components/LoginForm/LoginForm.test.tsx
@@ -19,8 +19,8 @@ const signInWithEmailAndPassword = vi
   .mockRejectedValueOnce(new Error("Invalid credentials"));
 
 const mockTestParams = (searchParams?: Record<string, string>) => {
-  vi.doMock("react-router-dom", async () => ({
-    ...(await vi.importActual("react-router-dom")),
+  vi.doMock("react-router", async () => ({
+    ...(await vi.importActual("react-router")),
     useSearchParams: () => [new URLSearchParams(searchParams)],
     useNavigate: () => navigate,
   }));
@@ -41,7 +41,7 @@ const mockTestParams = (searchParams?: Record<string, string>) => {
 describe("LoginForm", () => {
   describe("without additional test params", () => {
     beforeEach(async ({ task: { id } }) => {
-      vi.doUnmock("react-router-dom");
+      vi.doUnmock("react-router");
       vi.doUnmock("@/hooks/useAuth");
       vi.resetModules();
 
@@ -96,7 +96,7 @@ describe("LoginForm", () => {
     ];
 
     beforeEach(async ({ task: { id } }) => {
-      vi.doUnmock("react-router-dom");
+      vi.doUnmock("react-router");
       vi.doUnmock("@/hooks/useAuth");
       vi.resetModules();
 

--- a/src/features/auth/components/LoginForm/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm/LoginForm.tsx
@@ -10,7 +10,7 @@ import {
 } from "@canonical/react-components";
 import { ROOT_PATH } from "@/constants";
 import useAuth from "@/hooks/useAuth";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router";
 import classes from "./LoginForm.module.scss";
 import { useUnsigned } from "../../hooks";
 

--- a/src/features/auth/hooks/useInvitation.ts
+++ b/src/features/auth/hooks/useInvitation.ts
@@ -1,4 +1,4 @@
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { useUnsigned } from "@/features/auth";
 
 export default function useInvitation() {

--- a/src/features/instances/components/InstanceList/InstanceList.tsx
+++ b/src/features/instances/components/InstanceList/InstanceList.tsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import moment from "moment";
 import { FC, useEffect, useMemo } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import {
   CellProps,
   Column,

--- a/src/features/kernel/components/DowngradeKernelForm/DowngradeKernelForm.tsx
+++ b/src/features/kernel/components/DowngradeKernelForm/DowngradeKernelForm.tsx
@@ -17,7 +17,7 @@ import {
 import { useFormik } from "formik";
 import moment from "moment";
 import { FC } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { useKernel } from "../../hooks";
 import { Kernel } from "../../types";
 import {

--- a/src/features/kernel/components/RestartInstanceForm/RestartInstanceForm.tsx
+++ b/src/features/kernel/components/RestartInstanceForm/RestartInstanceForm.tsx
@@ -14,7 +14,7 @@ import classNames from "classnames";
 import { useFormik } from "formik";
 import moment from "moment";
 import { FC } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import {
   INITIAL_VALUES,
   NOTIFICATION_MESSAGE,

--- a/src/features/kernel/components/UpgradeKernelForm/UpgradeKernelForm.tsx
+++ b/src/features/kernel/components/UpgradeKernelForm/UpgradeKernelForm.tsx
@@ -17,7 +17,7 @@ import {
 import { useFormik } from "formik";
 import moment from "moment";
 import { FC } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { useKernel } from "../../hooks";
 import { Kernel } from "../../types";
 import {

--- a/src/features/overview/components/AlertCard/AlertCard.tsx
+++ b/src/features/overview/components/AlertCard/AlertCard.tsx
@@ -2,7 +2,7 @@ import { FC, lazy, Suspense } from "react";
 import classes from "./AlertCard.module.scss";
 import classNames from "classnames";
 import useInstances from "@/hooks/useInstances";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { ROOT_PATH } from "@/constants";
 import { Status } from "@/features/instances";
 import LoadingState from "@/components/layout/LoadingState";

--- a/src/features/overview/components/InfoTablesContainer/InfoTablesContainer.tsx
+++ b/src/features/overview/components/InfoTablesContainer/InfoTablesContainer.tsx
@@ -15,7 +15,7 @@ import {
 import classNames from "classnames";
 import moment from "moment";
 import { FC, useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router";
 import {
   CellProps,
   Column,

--- a/src/features/overview/components/Legend/Legend.tsx
+++ b/src/features/overview/components/Legend/Legend.tsx
@@ -1,7 +1,7 @@
 import { Chart, ChartData, LegendItem } from "chart.js";
 import classNames from "classnames";
 import { FC } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { handleChartMouseLeave, handleChartMouseOver } from "../../helpers";
 import classes from "./Legend.module.scss";
 import { STATUSES } from "@/features/instances";

--- a/src/features/packages/components/InstalledPackagesActionForm/InstalledPackagesActionForm.tsx
+++ b/src/features/packages/components/InstalledPackagesActionForm/InstalledPackagesActionForm.tsx
@@ -3,7 +3,7 @@ import classNames from "classnames";
 import { useFormik } from "formik";
 import moment from "moment";
 import { FC } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { Col, Form, Input, Row, Select } from "@canonical/react-components";
 import SidePanelFormButtons from "@/components/form/SidePanelFormButtons";
 import InfoItem from "@/components/layout/InfoItem";

--- a/src/features/packages/components/PackageDropdownSearch/PackageDropdownSearch.tsx
+++ b/src/features/packages/components/PackageDropdownSearch/PackageDropdownSearch.tsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import Downshift from "downshift";
 import React, { FC, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { useDebounceCallback } from "usehooks-ts";
 import { Button, Icon, ICONS, SearchBox } from "@canonical/react-components";
 import LoadingState from "@/components/layout/LoadingState";

--- a/src/features/packages/components/PackageList/PackageList.tsx
+++ b/src/features/packages/components/PackageList/PackageList.tsx
@@ -1,5 +1,5 @@
 import { FC, lazy, Suspense, useEffect, useMemo, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import {
   CellProps,
   Column,

--- a/src/features/packages/components/PackagesInstallForm/PackagesInstallForm.tsx
+++ b/src/features/packages/components/PackagesInstallForm/PackagesInstallForm.tsx
@@ -1,5 +1,5 @@
 import { FC, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import SidePanelFormButtons from "@/components/form/SidePanelFormButtons";
 import { useActivities } from "@/features/activities";
 import useDebug from "@/hooks/useDebug";

--- a/src/features/packages/components/UbuntuProNotification/UbuntuProNotification.tsx
+++ b/src/features/packages/components/UbuntuProNotification/UbuntuProNotification.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { Button, Notification } from "@canonical/react-components";
 import { ROOT_PATH } from "@/constants";
 import { UrlParams } from "@/types/UrlParams";

--- a/src/features/processes/components/ProcessesHeader/ProcessesHeader.tsx
+++ b/src/features/processes/components/ProcessesHeader/ProcessesHeader.tsx
@@ -7,7 +7,7 @@ import { UrlParams } from "@/types/UrlParams";
 import { Button } from "@canonical/react-components";
 import classNames from "classnames";
 import { FC } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import classes from "./ProcessesHeader.module.scss";
 
 interface ProcessesHeaderProps {

--- a/src/features/snaps/components/EditSnap/EditSnap.tsx
+++ b/src/features/snaps/components/EditSnap/EditSnap.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import { useFormik } from "formik";
 import moment from "moment";
 import { ChangeEvent, FC, useEffect, useMemo } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import * as Yup from "yup";
 import { EditSnapType } from "../../helpers";
 import { useSnaps } from "../../hooks";

--- a/src/features/snaps/components/InstallSnaps/InstallSnaps.tsx
+++ b/src/features/snaps/components/InstallSnaps/InstallSnaps.tsx
@@ -4,7 +4,7 @@ import useNotify from "@/hooks/useNotify";
 import useSidePanel from "@/hooks/useSidePanel";
 import { UrlParams } from "@/types/UrlParams";
 import { FC, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { useSnaps } from "../../hooks";
 import { SelectedSnaps } from "../../types";
 import SnapDropdownSearch from "../SnapDropdownSearch";

--- a/src/features/snaps/components/SnapDropdownSearch/SnapDropdownSearch.tsx
+++ b/src/features/snaps/components/SnapDropdownSearch/SnapDropdownSearch.tsx
@@ -5,7 +5,7 @@ import { Button, Icon, ICONS, SearchBox } from "@canonical/react-components";
 import classNames from "classnames";
 import Downshift from "downshift";
 import React, { FC, useEffect, useRef, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { useDebounceCallback } from "usehooks-ts";
 import { useSnaps } from "../../hooks";
 import { AvailableSnap, SelectedSnaps } from "../../types";

--- a/src/features/usns/components/UsnPackagesContainer/UsnPackagesContainer.tsx
+++ b/src/features/usns/components/UsnPackagesContainer/UsnPackagesContainer.tsx
@@ -1,5 +1,5 @@
 import { FC, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import LoadingState from "@/components/layout/LoadingState";
 import { useUsns } from "@/features/usns";
 import { Instance } from "@/types/Instance";

--- a/src/features/usns/components/UsnPackagesRemoveButton/UsnPackagesRemoveButton.tsx
+++ b/src/features/usns/components/UsnPackagesRemoveButton/UsnPackagesRemoveButton.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { ConfirmationButton, Icon } from "@canonical/react-components";
 import { ROOT_PATH } from "@/constants";
 import useDebug from "@/hooks/useDebug";

--- a/src/features/wsl/components/WslInstanceInstallForm/WslInstanceInstallForm.tsx
+++ b/src/features/wsl/components/WslInstanceInstallForm/WslInstanceInstallForm.tsx
@@ -1,6 +1,6 @@
 import { useFormik } from "formik";
 import { FC } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import * as Yup from "yup";
 import { Form, Input, Select } from "@canonical/react-components";
 import FileInput from "@/components/form/FileInput";

--- a/src/features/wsl/components/WslInstanceList/WslInstanceList.tsx
+++ b/src/features/wsl/components/WslInstanceList/WslInstanceList.tsx
@@ -1,5 +1,5 @@
 import { FC, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import {
   CellProps,
   Column,

--- a/src/hooks/usePageParams/usePageParams.ts
+++ b/src/hooks/usePageParams/usePageParams.ts
@@ -1,4 +1,4 @@
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { PARAMS } from "./constants";
 import {
   getParsedParams,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import "./styles/index.scss";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router";
 import AuthProvider from "@/context/auth";
 import EnvProvider from "@/context/env";
 import NotifyProvider from "@/context/notify";

--- a/src/pages/EnvError.tsx
+++ b/src/pages/EnvError.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import EmptyState from "@/components/layout/EmptyState";
 import { ROOT_PATH } from "@/constants";
 import useEnv from "@/hooks/useEnv";

--- a/src/pages/PageNotFound.tsx
+++ b/src/pages/PageNotFound.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import AuthTemplate from "../templates/auth";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { ROOT_PATH } from "../constants";
 
 const PageNotFound: FC = () => {

--- a/src/pages/auth/handle/oidc/OidcAuthPage/OidcAuthPage.test.tsx
+++ b/src/pages/auth/handle/oidc/OidcAuthPage/OidcAuthPage.test.tsx
@@ -9,8 +9,8 @@ const redirectToExternalUrl = vi.fn();
 const navigate = vi.fn();
 
 const mockTestParams = (response: AuthStateResponse | Error) => {
-  vi.doMock("react-router-dom", async () => ({
-    ...(await vi.importActual("react-router-dom")),
+  vi.doMock("react-router", async () => ({
+    ...(await vi.importActual("react-router")),
     useSearchParams: () => [new URLSearchParams({ enabled: "true" })],
     useNavigate: () => navigate,
   }));
@@ -81,7 +81,7 @@ describe("OidcAuthPage", () => {
     ];
 
     beforeEach(async ({ task: { id } }) => {
-      vi.doUnmock("react-router-dom");
+      vi.doUnmock("react-router");
       vi.doUnmock("@/features/auth");
       vi.doUnmock("@/hooks/useAuth");
       vi.resetModules();

--- a/src/pages/auth/handle/oidc/OidcAuthPage/OidcAuthPage.tsx
+++ b/src/pages/auth/handle/oidc/OidcAuthPage/OidcAuthPage.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect } from "react";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router";
 import { CONTACT_SUPPORT_TEAM_MESSAGE, ROOT_PATH } from "@/constants";
 import { useUnsigned } from "@/features/auth";
 import useAuth from "@/hooks/useAuth";

--- a/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.test.tsx
+++ b/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.test.tsx
@@ -9,8 +9,8 @@ const redirectToExternalUrl = vi.fn();
 const navigate = vi.fn();
 
 const mockTestParams = (response: AuthStateResponse | Error) => {
-  vi.doMock("react-router-dom", async () => ({
-    ...(await vi.importActual("react-router-dom")),
+  vi.doMock("react-router", async () => ({
+    ...(await vi.importActual("react-router")),
     useSearchParams: () => [new URLSearchParams({ enabled: "true" })],
     useNavigate: () => navigate,
   }));
@@ -81,7 +81,7 @@ describe("UbuntuOneAuthPage", () => {
     ];
 
     beforeEach(async ({ task: { id } }) => {
-      vi.doUnmock("react-router-dom");
+      vi.doUnmock("react-router");
       vi.doUnmock("@/features/auth");
       vi.doUnmock("@/hooks/useAuth");
       vi.resetModules();

--- a/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.tsx
+++ b/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect } from "react";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router";
 import { CONTACT_SUPPORT_TEAM_MESSAGE, ROOT_PATH } from "@/constants";
 import { useUnsigned } from "@/features/auth";
 import useAuth from "@/hooks/useAuth";

--- a/src/pages/dashboard/DashboardPage/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import { FC, Suspense, useEffect } from "react";
 import DashboardTemplate from "@/templates/dashboard";
-import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { Outlet, useLocation, useNavigate } from "react-router";
 import LoadingState from "@/components/layout/LoadingState";
 import { ROOT_PATH } from "@/constants";
 import { maybeRemoveTrailingSlash } from "./helpers";

--- a/src/pages/dashboard/account/AccountPage.tsx
+++ b/src/pages/dashboard/account/AccountPage.tsx
@@ -1,6 +1,6 @@
 import { ROOT_PATH } from "@/constants";
 import { FC, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 const AccountPage: FC = () => {
   const navigate = useNavigate();

--- a/src/pages/dashboard/alert-notifications/AlertNotificationsPage.tsx
+++ b/src/pages/dashboard/alert-notifications/AlertNotificationsPage.tsx
@@ -11,7 +11,7 @@ import {
 import useInstances from "@/hooks/useInstances";
 import { Button } from "@canonical/react-components";
 import { FC } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 const AlertNotificationsPage: FC = () => {
   const navigate = useNavigate();

--- a/src/pages/dashboard/instances/PendingInstancesForm/PendingInstancesForm.tsx
+++ b/src/pages/dashboard/instances/PendingInstancesForm/PendingInstancesForm.tsx
@@ -1,5 +1,5 @@
 import { FC, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import {
   Button,
   ConfirmationButton,

--- a/src/pages/dashboard/instances/[single]/SingleInstanceContainer/SingleInstanceContainer.tsx
+++ b/src/pages/dashboard/instances/[single]/SingleInstanceContainer/SingleInstanceContainer.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect, useRef } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import LoadingState from "@/components/layout/LoadingState";
 import PageContent from "@/components/layout/PageContent";
 import PageHeader from "@/components/layout/PageHeader";

--- a/src/pages/dashboard/instances/[single]/SingleInstanceEmptyState/SingleInstanceEmptyState.tsx
+++ b/src/pages/dashboard/instances/[single]/SingleInstanceEmptyState/SingleInstanceEmptyState.tsx
@@ -2,7 +2,7 @@ import { FC } from "react";
 import EmptyState from "@/components/layout/EmptyState";
 import { Button } from "@canonical/react-components";
 import { ROOT_PATH } from "@/constants";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 interface SingleInstanceEmptyStateProps {
   childInstanceId: string | undefined;

--- a/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import { FC, lazy, Suspense, useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import {
   Button,
   CheckboxInput,

--- a/src/pages/dashboard/instances/[single]/tabs/kernel/KernelPanel/KernelPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/kernel/KernelPanel/KernelPanel.tsx
@@ -12,7 +12,7 @@ import usePageParams from "@/hooks/usePageParams";
 import { UrlParams } from "@/types/UrlParams";
 import moment from "moment";
 import { FC, useMemo } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 
 interface KernelPanelProps {
   instanceTitle: string;

--- a/src/pages/dashboard/instances/[single]/tabs/packages/PackagesPanel/PackagesPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/packages/PackagesPanel/PackagesPanel.tsx
@@ -1,5 +1,5 @@
 import { FC, useState } from "react";
-import { useLocation, useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router";
 import LoadingState from "@/components/layout/LoadingState";
 import { TablePagination } from "@/components/layout/TablePagination";
 import {

--- a/src/pages/dashboard/instances/[single]/tabs/processes/ProcessesPanel/ProcessesPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/processes/ProcessesPanel/ProcessesPanel.tsx
@@ -9,7 +9,7 @@ import {
 import usePageParams from "@/hooks/usePageParams";
 import { UrlParams } from "@/types/UrlParams";
 import { FC, useMemo, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 
 const ProcessesPanel: FC = () => {
   const [selectedPids, setSelectedPids] = useState<number[]>([]);

--- a/src/pages/dashboard/instances/[single]/tabs/security-issues/SecurityIssuesPanelHeader/SecurityIssuesPanelHeader.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/security-issues/SecurityIssuesPanelHeader/SecurityIssuesPanelHeader.tsx
@@ -1,5 +1,5 @@
 import { FC, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import {
   ConfirmationButton,
   Form,

--- a/src/pages/dashboard/instances/[single]/tabs/snaps/SnapsPanel/SnapsPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/snaps/SnapsPanel/SnapsPanel.tsx
@@ -12,7 +12,7 @@ import useSidePanel from "@/hooks/useSidePanel";
 import { UrlParams } from "@/types/UrlParams";
 import { Button } from "@canonical/react-components";
 import { FC, useMemo, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 
 const SnapsPanel: FC = () => {
   const [selectedSnapIds, setSelectedSnapIds] = useState<string[]>([]);

--- a/src/pages/dashboard/instances/[single]/tabs/users/EditUserForm/EditUserForm.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/EditUserForm/EditUserForm.tsx
@@ -9,7 +9,7 @@ import useNotify from "@/hooks/useNotify";
 import useSidePanel from "@/hooks/useSidePanel";
 import useUsers from "@/hooks/useUsers";
 import { User } from "@/types/User";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { UrlParams } from "@/types/UrlParams";
 
 interface FormProps {

--- a/src/pages/dashboard/instances/[single]/tabs/users/NewUserForm/NewUserForm.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/NewUserForm/NewUserForm.tsx
@@ -6,7 +6,7 @@ import SidePanelFormButtons from "@/components/form/SidePanelFormButtons";
 import useDebug from "@/hooks/useDebug";
 import useSidePanel from "@/hooks/useSidePanel";
 import useUsers from "@/hooks/useUsers";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { UrlParams } from "@/types/UrlParams";
 
 interface FormProps {

--- a/src/pages/dashboard/instances/[single]/tabs/users/UserDetails/UserDetails.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/UserDetails/UserDetails.tsx
@@ -4,7 +4,7 @@ import { User } from "@/types/User";
 import UserPanelActionButtons from "../UserPanelActionButtons";
 import useUsers from "@/hooks/useUsers";
 import { NOT_AVAILABLE } from "@/constants";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import NoData from "@/components/layout/NoData";
 import { UrlParams } from "@/types/UrlParams";
 

--- a/src/pages/dashboard/instances/[single]/tabs/users/UserPanel/UserPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/UserPanel/UserPanel.tsx
@@ -10,7 +10,7 @@ import { UrlParams } from "@/types/UrlParams";
 import { User } from "@/types/User";
 import { Button, Notification } from "@canonical/react-components";
 import { FC, useMemo, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import { SORT_FUNCTIONS } from "../constants";
 import NewUserForm from "../NewUserForm";
 import UserList from "../UserList";

--- a/src/pages/dashboard/instances/[single]/tabs/users/UserPanelActionButtons/UserPanelActionButtons.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/UserPanelActionButtons/UserPanelActionButtons.tsx
@@ -20,7 +20,7 @@ import {
   renderModalBody,
 } from "./helpers";
 import LoadingState from "@/components/layout/LoadingState";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { UrlParams } from "@/types/UrlParams";
 
 const EditUserForm = lazy(

--- a/src/pages/dashboard/profiles/ProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/ProfilesPage.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { ROOT_PATH } from "../../../constants";
 
 const ProfilesPage: FC = () => {

--- a/src/pages/dashboard/repositories/RepositoryPage.tsx
+++ b/src/pages/dashboard/repositories/RepositoryPage.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { ROOT_PATH } from "@/constants";
 
 const RepositoryPage: FC = () => {

--- a/src/pages/dashboard/settings/SettingsPage.tsx
+++ b/src/pages/dashboard/settings/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { ROOT_PATH } from "../../../constants";
 
 const SettingsPage: FC = () => {

--- a/src/templates/dashboard/DashboardTemplate.tsx
+++ b/src/templates/dashboard/DashboardTemplate.tsx
@@ -1,7 +1,7 @@
 import { FC, ReactNode } from "react";
 import Sidebar from "./Sidebar";
 import SidePanelProvider from "../../context/sidePanel";
-import { matchPath, useLocation } from "react-router-dom";
+import { matchPath, useLocation } from "react-router";
 import SecondaryNavigation from "./SecondaryNavigation";
 import classes from "./DashboardTemplate.module.scss";
 import classNames from "classnames";

--- a/src/templates/dashboard/DesktopHeader.tsx
+++ b/src/templates/dashboard/DesktopHeader.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { Button, Icon } from "@canonical/react-components";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import Logo from "../../assets/images/logo-white-full.svg";
 import LogoIcon from "../../assets/images/logo-white-icon.svg";
 import { APP_TITLE, ROOT_PATH } from "../../constants";

--- a/src/templates/dashboard/MobileHeader.tsx
+++ b/src/templates/dashboard/MobileHeader.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { Button } from "@canonical/react-components";
 import Logo from "../../assets/images/logo-white-full.svg";
 import { APP_TITLE, ROOT_PATH } from "../../constants";

--- a/src/templates/dashboard/Navigation/Navigation.tsx
+++ b/src/templates/dashboard/Navigation/Navigation.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import { FC, useEffect, useState } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router";
 import useEnv from "@/hooks/useEnv";
 import { getFilteredByEnvMenuItems, getPathToExpand } from "./helpers";
 import classes from "./Navigation.module.scss";

--- a/src/templates/dashboard/SecondaryNavigation/SecondaryNavigation.tsx
+++ b/src/templates/dashboard/SecondaryNavigation/SecondaryNavigation.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { Link, matchPath, useLocation } from "react-router-dom";
+import { Link, matchPath, useLocation } from "react-router";
 import classes from "./SecondaryNavigation.module.scss";
 import { ACCOUNT_SETTINGS } from "./constants";
 

--- a/src/templates/dashboard/UserInfo/UserInfo.tsx
+++ b/src/templates/dashboard/UserInfo/UserInfo.tsx
@@ -3,7 +3,7 @@ import useAuth from "../../../hooks/useAuth";
 import { Button, Icon } from "@canonical/react-components";
 import classes from "./UserInfo.module.scss";
 import classNames from "classnames";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router";
 import { ROOT_PATH } from "@/constants";
 import { useMediaQuery } from "usehooks-ts";
 import { ACCOUNT_SETTINGS } from "../SecondaryNavigation/constants";

--- a/src/tests/render.tsx
+++ b/src/tests/render.tsx
@@ -1,6 +1,6 @@
 import { render, RenderOptions } from "@testing-library/react";
 import { FC, ReactNode } from "react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router";
 import NotifyProvider, { NotifyContext } from "@/context/notify";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import AuthProvider from "@/context/auth";


### PR DESCRIPTION
I updated React Router DOM to version 7 by following [the official guide](https://reactrouter.com/upgrading/v6). As a part of the guide, the `react-router-dom` package has been replaced with `react-router`. The only actual change is replacing all instances of "`react-router-dom`" with "`react-router`", for imports.