### PR TITLE
fix: make apt sources pages available for self-hosted env only

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -179,6 +179,10 @@ const App: FC = () => {
                   path="repositories/mirrors"
                   element={<DistributionsPage />}
                 />
+                <Route
+                  path="repositories/apt-sources"
+                  element={<APTSourcesPage />}
+                />
                 <Route path="profiles/wsl" element={<WslProfilesPage />} />
               </Route>
               <Route
@@ -194,10 +198,6 @@ const App: FC = () => {
                   element={<RepositoryProfilesPage />}
                 />
                 <Route path="repositories/gpg-keys" element={<GPGKeysPage />} />
-                <Route
-                  path="repositories/apt-sources"
-                  element={<APTSourcesPage />}
-                />
                 <Route path="instances" element={<InstancesPage />} />
                 <Route
                   path="instances/:instanceId"
@@ -230,6 +230,7 @@ const App: FC = () => {
                     element={<IdentityProvidersPage />}
                   />
                 )}
+                <Route path="settings/gpg-keys" element={<GPGKeysPage />} />
                 <Route path="profiles" element={<ProfilesPage />} />
                 <Route
                   path="profiles/package"

--- a/src/pages/dashboard/repositories/gpg-keys/GPGKeysPage.tsx
+++ b/src/pages/dashboard/repositories/gpg-keys/GPGKeysPage.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import PageHeader from "@/components/layout/PageHeader";
 import PageMain from "@/components/layout/PageMain";
 import PageContent from "@/components/layout/PageContent";
@@ -8,6 +8,8 @@ import LoadingState from "@/components/layout/LoadingState";
 import EmptyState from "@/components/layout/EmptyState";
 import useSidePanel from "@/hooks/useSidePanel";
 import { GPGKeysList, useGPGKeys } from "@/features/gpg-keys";
+import { useLocation, useNavigate } from "react-router";
+import useEnv from "@/hooks/useEnv";
 
 const NewGPGKeyForm = lazy(() =>
   import("@/features/gpg-keys").then((module) => ({
@@ -18,6 +20,19 @@ const NewGPGKeyForm = lazy(() =>
 const GPGKeysPage: FC = () => {
   const { setSidePanelContent } = useSidePanel();
   const { getGPGKeysQuery } = useGPGKeys();
+  const { isSelfHosted, isSaas } = useEnv();
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    if ("/repositories/gpg-keys" === pathname && isSaas) {
+      navigate("/settings/gpg-keys", { replace: true });
+    }
+
+    if ("/settings/gpg-keys" === pathname && isSelfHosted) {
+      navigate("/repositories/gpg-keys", { replace: true });
+    }
+  }, [pathname]);
 
   const { data, isLoading } = getGPGKeysQuery();
 

--- a/src/templates/dashboard/Navigation/constants.ts
+++ b/src/templates/dashboard/Navigation/constants.ts
@@ -58,11 +58,11 @@ export const MENU_ITEMS: MenuItem[] = [
     label: "Repositories",
     path: "/repositories",
     icon: "fork",
+    env: "selfHosted",
     items: [
       {
         label: "Mirrors",
         path: "/repositories/mirrors",
-        env: "selfHosted",
       },
       {
         label: "GPG Keys",
@@ -98,6 +98,11 @@ export const MENU_ITEMS: MenuItem[] = [
       {
         label: "Identity providers",
         path: "/settings/identity-providers",
+      },
+      {
+        label: "GPG Keys",
+        path: "/repositories/gpg-keys",
+        env: "saas",
       },
     ],
   },


### PR DESCRIPTION
- Added routes from settings/gpg-keys to repositories/gpg-keys and vice versa.
- Moved GPG Keys to Org. Settings for Saas env only. 
- Removed APTSources and Mirrors from Repositories menu item, consequently removing Repositories tab from Navigation.
- We worked on this together. Merge when ready.