### PR TITLE
build: add package-lock.json to semantic release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,7 +9,7 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "package.json"],
+        "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]


### PR DESCRIPTION
This change should allow Semantic Release to also update the app version in `package-lock.json`.