### PR TITLE
fix: disable invalid activity actions

### DIFF
--- a/src/features/activities/components/Activities/Activities.tsx
+++ b/src/features/activities/components/Activities/Activities.tsx
@@ -27,15 +27,15 @@ const ActivityDetails = lazy(
 );
 
 interface ActivitiesProps {
-  readonly selectedIds: number[];
-  readonly setSelectedIds: (ids: number[]) => void;
+  readonly selected: ActivityCommon[];
+  readonly setSelected: (activities: ActivityCommon[]) => void;
   readonly instanceId?: number;
 }
 
 const Activities: FC<ActivitiesProps> = ({
   instanceId,
-  selectedIds,
-  setSelectedIds,
+  selected,
+  setSelected,
 }) => {
   const {
     query,
@@ -67,7 +67,7 @@ const Activities: FC<ActivitiesProps> = ({
   useOpenActivityDetails(handleActivityDetailsOpen);
 
   const handleClearSelection = () => {
-    setSelectedIds([]);
+    setSelected([]);
   };
 
   const {
@@ -86,16 +86,14 @@ const Activities: FC<ActivitiesProps> = ({
   );
 
   const toggleAll = () => {
-    setSelectedIds(
-      selectedIds.length !== 0 ? [] : activities.map(({ id }) => id),
-    );
+    setSelected(selected.length !== 0 ? [] : activities);
   };
 
-  const handleToggleActivity = (activityId: number) => {
-    setSelectedIds(
-      selectedIds.includes(activityId)
-        ? selectedIds.filter((selectedId) => selectedId !== activityId)
-        : [...selectedIds, activityId],
+  const handleToggleActivity = (activity: ActivityCommon) => {
+    setSelected(
+      selected.includes(activity)
+        ? selected.filter((selectedActivity) => selectedActivity !== activity)
+        : [...selected, activity],
     );
   };
 
@@ -111,11 +109,10 @@ const Activities: FC<ActivitiesProps> = ({
               inline
               onChange={toggleAll}
               checked={
-                activities.length > 0 &&
-                selectedIds.length === activities.length
+                activities.length > 0 && selected.length === activities.length
               }
               indeterminate={
-                selectedIds.length > 0 && selectedIds.length < activities.length
+                selected.length > 0 && selected.length < activities.length
               }
             />
           ),
@@ -126,9 +123,9 @@ const Activities: FC<ActivitiesProps> = ({
               }
               inline
               labelClassName="u-no-margin--bottom u-no-padding--top"
-              checked={selectedIds.includes(row.original.id)}
+              checked={selected.includes(row.original)}
               onChange={() => {
-                handleToggleActivity(row.original.id);
+                handleToggleActivity(row.original);
               }}
             />
           ),
@@ -200,7 +197,7 @@ const Activities: FC<ActivitiesProps> = ({
           ),
         },
       ].filter((col) => !instanceId || col.accessor !== "computer_id"),
-    [activities, selectedIds],
+    [activities, selected],
   );
 
   return (

--- a/src/pages/dashboard/activities/ActivitiesPage.tsx
+++ b/src/pages/dashboard/activities/ActivitiesPage.tsx
@@ -3,13 +3,14 @@ import { useState } from "react";
 import PageContent from "@/components/layout/PageContent";
 import PageHeader from "@/components/layout/PageHeader";
 import PageMain from "@/components/layout/PageMain";
+import type { ActivityCommon } from "@/features/activities";
 import { Activities, useActivities } from "@/features/activities";
 import { ConfirmationButton } from "@canonical/react-components";
 import useDebug from "@/hooks/useDebug";
 import classes from "./ActivitiesPage.module.scss";
 
 const ActivitiesPage: FC = () => {
-  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [selected, setSelected] = useState<ActivityCommon[]>([]);
 
   const debug = useDebug();
   const {
@@ -29,6 +30,8 @@ const ActivitiesPage: FC = () => {
     redoActivitiesQuery;
   const { mutateAsync: undoActivities, isPending: undoActivitiesLoading } =
     undoActivitiesQuery;
+
+  const selectedIds = selected.map((activity) => activity.id);
 
   const handleApproveActivities = async () => {
     try {
@@ -73,13 +76,17 @@ const ActivitiesPage: FC = () => {
               <ConfirmationButton
                 className="p-segmented-control__button"
                 type="button"
-                disabled={selectedIds.length === 0 || approveActivitiesLoading}
+                disabled={
+                  !selected.length ||
+                  approveActivitiesLoading ||
+                  selected.some((activity) => !activity.actions?.approvable)
+                }
                 confirmationModalProps={{
-                  title: `Approve ${selectedIds.length === 1 ? "activity" : "activities"}`,
+                  title: `Approve ${selected.length === 1 ? "activity" : "activities"}`,
                   children: (
                     <p>
                       Are you sure you want to approve selected{" "}
-                      {selectedIds.length === 1 ? "activity" : "activities"}?
+                      {selected.length === 1 ? "activity" : "activities"}?
                     </p>
                   ),
                   confirmButtonLabel: "Approve",
@@ -94,13 +101,17 @@ const ActivitiesPage: FC = () => {
               <ConfirmationButton
                 className="p-segmented-control__button"
                 type="button"
-                disabled={selectedIds.length === 0 || cancelActivitiesLoading}
+                disabled={
+                  !selected.length ||
+                  cancelActivitiesLoading ||
+                  selected.some((activity) => !activity.actions?.cancelable)
+                }
                 confirmationModalProps={{
-                  title: `Cancel ${selectedIds.length === 1 ? "activity" : "activities"}`,
+                  title: `Cancel ${selected.length === 1 ? "activity" : "activities"}`,
                   children: (
                     <p>
                       Are you sure you want to cancel selected{" "}
-                      {selectedIds.length === 1 ? "activity" : "activities"}?
+                      {selected.length === 1 ? "activity" : "activities"}?
                     </p>
                   ),
                   confirmButtonLabel: "Apply",
@@ -115,13 +126,17 @@ const ActivitiesPage: FC = () => {
               <ConfirmationButton
                 className="p-segmented-control__button"
                 type="button"
-                disabled={selectedIds.length === 0 || undoActivitiesLoading}
+                disabled={
+                  !selected.length ||
+                  undoActivitiesLoading ||
+                  selected.some((activity) => !activity.actions?.revertable)
+                }
                 confirmationModalProps={{
-                  title: `Undo ${selectedIds.length === 1 ? "activity" : "activities"}`,
+                  title: `Undo ${selected.length === 1 ? "activity" : "activities"}`,
                   children: (
                     <p>
                       Are you sure you want to undo selected{" "}
-                      {selectedIds.length === 1 ? "activity" : "activities"}?
+                      {selected.length === 1 ? "activity" : "activities"}?
                     </p>
                   ),
                   confirmButtonLabel: "Undo",
@@ -136,13 +151,17 @@ const ActivitiesPage: FC = () => {
               <ConfirmationButton
                 className="p-segmented-control__button"
                 type="button"
-                disabled={selectedIds.length === 0 || redoActivitiesLoading}
+                disabled={
+                  !selected.length ||
+                  redoActivitiesLoading ||
+                  selected.some((activity) => !activity.actions?.reappliable)
+                }
                 confirmationModalProps={{
-                  title: `Redo ${selectedIds.length === 1 ? "activity" : "activities"}`,
+                  title: `Redo ${selected.length === 1 ? "activity" : "activities"}`,
                   children: (
                     <p>
                       Are you sure you want to redo selected{" "}
-                      {selectedIds.length === 1 ? "activity" : "activities"}?
+                      {selected.length === 1 ? "activity" : "activities"}?
                     </p>
                   ),
                   confirmButtonLabel: "Redo",
@@ -159,10 +178,7 @@ const ActivitiesPage: FC = () => {
         ]}
       />
       <PageContent>
-        <Activities
-          selectedIds={selectedIds}
-          setSelectedIds={(items) => setSelectedIds(items)}
-        />
+        <Activities selected={selected} setSelected={setSelected} />
       </PageContent>
     </PageMain>
   );

--- a/src/pages/dashboard/instances/[single]/tabs/activities/ActivityPanel/ActivityPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/activities/ActivityPanel/ActivityPanel.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react";
 import { useState } from "react";
+import type { ActivityCommon } from "@/features/activities";
 import { Activities } from "@/features/activities";
 
 interface ActivityPanelProps {
@@ -7,13 +8,13 @@ interface ActivityPanelProps {
 }
 
 const ActivityPanel: FC<ActivityPanelProps> = ({ instanceId }) => {
-  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [selected, setSelected] = useState<ActivityCommon[]>([]);
 
   return (
     <Activities
       instanceId={instanceId}
-      selectedIds={selectedIds}
-      setSelectedIds={(items) => setSelectedIds(items)}
+      selected={selected}
+      setSelected={setSelected}
     />
   );
 };


### PR DESCRIPTION
This prevents an action from being taken when it can't be applied to at least one selected activity. Maybe we can allow a mixed selection by including a message, but for now, this at least prevents any errors.