### PR TITLE
fix: disable invalid apt source delete [LNDENG-2557]

### DIFF
--- a/src/features/apt-sources/components/APTSourcesListActions/APTSourcesListActions.tsx
+++ b/src/features/apt-sources/components/APTSourcesListActions/APTSourcesListActions.tsx
@@ -1,6 +1,7 @@
 import ListActions from "@/components/layout/ListActions";
+import { useRepositoryProfiles } from "@/features/repository-profiles";
 import useDebug from "@/hooks/useDebug";
-import { ConfirmationModal, ICONS } from "@canonical/react-components";
+import { ConfirmationModal, ICONS, Spinner } from "@canonical/react-components";
 import { type FC } from "react";
 import { useBoolean } from "usehooks-ts";
 import { useAPTSources } from "../../hooks";
@@ -13,14 +14,24 @@ interface APTSourcesListActionsProps {
 const APTSourcesListActions: FC<APTSourcesListActionsProps> = ({
   aptSource,
 }) => {
-  const { removeAPTSourceQuery } = useAPTSources();
   const debug = useDebug();
+
+  const { removeAPTSourceQuery } = useAPTSources();
+  const { getRepositoryProfilesQuery } = useRepositoryProfiles();
 
   const {
     value: isModalOpen,
     setTrue: openModal,
     setFalse: closeModal,
   } = useBoolean();
+
+  const {
+    data: getRepositoryProfilesQueryResult,
+    isLoading: isGettingRepositoryProfiles,
+  } = getRepositoryProfilesQuery();
+
+  const repositoryProfiles =
+    getRepositoryProfilesQueryResult?.data.results ?? [];
 
   const { mutateAsync: remove, isPending: isRemoving } = removeAPTSourceQuery;
 
@@ -34,6 +45,10 @@ const APTSourcesListActions: FC<APTSourcesListActionsProps> = ({
     closeModal();
   };
 
+  if (isGettingRepositoryProfiles) {
+    return <Spinner className="u-float-right u-no-padding--top" />;
+  }
+
   return (
     <>
       <ListActions
@@ -44,6 +59,9 @@ const APTSourcesListActions: FC<APTSourcesListActionsProps> = ({
             label: "Delete",
             "aria-label": `Remove ${aptSource.name} APT source`,
             onClick: openModal,
+            disabled: repositoryProfiles.some((profile) =>
+              profile.apt_sources.includes(aptSource.id),
+            ),
           },
         ]}
       />


### PR DESCRIPTION
The delete button for an APT source will be disabled while it's used by a repository profile.