### PR TITLE
fix: add missing toast notifications, add actions to activities panel

### DIFF
--- a/src/features/access-groups/components/AccessGroupInstanceCountCell/AccessGroupInstanceCountCell.tsx
+++ b/src/features/access-groups/components/AccessGroupInstanceCountCell/AccessGroupInstanceCountCell.tsx
@@ -1,7 +1,7 @@
 import useInstances from "@/hooks/useInstances";
 import { pluralize } from "@/utils/_helpers";
 import { Spinner } from "@canonical/react-components";
-import type { FC } from "react";
+import { type FC } from "react";
 import { Link } from "react-router";
 import type { AccessGroupWithInstancesCount } from "../../types/AccessGroup";
 import classes from "./AccessGroupInstanceCountCell.module.scss";
@@ -22,13 +22,6 @@ const AccessGroupInstanceCountCell: FC<AccessGroupInstanceCountCellProps> = ({
     with_upgrades: true,
     limit: 1,
   });
-
-  if (
-    getInstancesQueryResult?.data &&
-    accessGroup.instancesCount !== getInstancesQueryResult.data.count
-  ) {
-    accessGroup.instancesCount = getInstancesQueryResult.data.count || 0;
-  }
 
   if (isPending) {
     return (

--- a/src/features/access-groups/components/AccessGroupList/AccessGroupList.tsx
+++ b/src/features/access-groups/components/AccessGroupList/AccessGroupList.tsx
@@ -112,7 +112,16 @@ const AccessGroupList: FC<AccessGroupListProps> = ({ accessGroups }) => {
             return null;
           }
 
-          return <AccessGroupListActions accessGroup={row.original} />;
+          const parentTitle =
+            accessGroups.find((group) => group.name === row.original.parent)
+              ?.title || row.original.parent;
+
+          return (
+            <AccessGroupListActions
+              accessGroup={row.original}
+              parentAccessGroupTitle={parentTitle}
+            />
+          );
         },
       },
     ],

--- a/src/features/access-groups/components/AccessGroupListActions/AccessGroupListActions.tsx
+++ b/src/features/access-groups/components/AccessGroupListActions/AccessGroupListActions.tsx
@@ -5,17 +5,23 @@ import { ConfirmationModal } from "@canonical/react-components";
 import { type FC } from "react";
 import { useBoolean } from "usehooks-ts";
 import type { AccessGroupWithInstancesCount } from "../../types";
+import useNotify from "@/hooks/useNotify";
+import useInstances from "@/hooks/useInstances";
+import { pluralize } from "@/utils/_helpers";
 
 interface AccessGroupListActionsProps {
   readonly accessGroup: AccessGroupWithInstancesCount;
+  readonly parentAccessGroupTitle: string;
 }
 
 const AccessGroupListActions: FC<AccessGroupListActionsProps> = ({
   accessGroup,
+  parentAccessGroupTitle,
 }) => {
   const debug = useDebug();
-
+  const { notify } = useNotify();
   const { removeAccessGroupQuery } = useRoles();
+  const { getInstancesQuery } = useInstances();
 
   const {
     value: isModalOpen,
@@ -23,12 +29,27 @@ const AccessGroupListActions: FC<AccessGroupListActionsProps> = ({
     setFalse: closeModal,
   } = useBoolean();
 
+  const { data: getInstancesQueryResult } = getInstancesQuery({
+    query: `access-group: ${accessGroup.name}`,
+    root_only: false,
+    with_alerts: true,
+    with_upgrades: true,
+    limit: 1,
+  });
+
+  const count = getInstancesQueryResult?.data.count || 0;
+
   const { mutateAsync: remove, isPending: isRemoving } = removeAccessGroupQuery;
 
   const tryRemove = async () => {
     try {
       await remove({
         name: accessGroup.name,
+      });
+
+      notify.success({
+        title: `You have successfully deleted the "${accessGroup.title}" access group.`,
+        message: `All entities in this access group will now belong to "${parentAccessGroupTitle}".`,
       });
     } catch (error) {
       debug(error);
@@ -61,7 +82,13 @@ const AccessGroupListActions: FC<AccessGroupListActionsProps> = ({
           onConfirm={tryRemove}
           close={closeModal}
         >
-          <p>Are you sure?</p>
+          <p>
+            Removing this access group will affect {count}{" "}
+            {pluralize(count, "instance")}. They will now belong to &quot;
+            {parentAccessGroupTitle}&quot;.
+            <br />
+            This action is <b>irreversible</b>
+          </p>
         </ConfirmationModal>
       )}
     </>

--- a/src/features/activities/components/Activities/Activities.tsx
+++ b/src/features/activities/components/Activities/Activities.tsx
@@ -20,7 +20,14 @@ import type { ActivityCommon } from "../../types";
 import ActivitiesEmptyState from "../ActivitiesEmptyState";
 import ActivitiesHeader from "../ActivitiesHeader";
 import classes from "./Activities.module.scss";
-import { getDateQuery, getStatusQuery, getTypeQuery } from "./helpers";
+import {
+  getDateQuery,
+  getStatusQuery,
+  getTypeQuery,
+  isActivitiesEmptyState,
+  isActivitiesLoadedState,
+  isActivitiesLoadingState,
+} from "./helpers";
 
 const ActivityDetails = lazy(
   async () => import("@/features/activities/components/ActivityDetails"),
@@ -202,27 +209,33 @@ const Activities: FC<ActivitiesProps> = ({
 
   return (
     <>
-      {!searchQuery &&
-        currentPage === 1 &&
-        pageSize === 20 &&
-        getActivitiesQueryLoading && <LoadingState />}
+      {isActivitiesLoadingState({
+        currentPage,
+        getActivitiesQueryLoading,
+        pageSize,
+        searchQuery,
+      }) && <LoadingState />}
 
-      {!searchQuery &&
-        currentPage === 1 &&
-        pageSize === 20 &&
-        !getActivitiesQueryLoading &&
-        (!getActivitiesQueryResult || !getActivitiesQueryResult.data.count) && (
-          <ActivitiesEmptyState />
-        )}
+      {isActivitiesEmptyState({
+        currentPage,
+        getActivitiesQueryLoading,
+        getActivitiesQueryResult,
+        pageSize,
+        searchQuery,
+      }) && <ActivitiesEmptyState />}
 
-      {(!!searchQuery ||
-        currentPage !== 1 ||
-        pageSize !== 20 ||
-        (!getActivitiesQueryLoading &&
-          getActivitiesQueryResult &&
-          getActivitiesQueryResult.data.count > 0)) && (
+      {isActivitiesLoadedState({
+        currentPage,
+        getActivitiesQueryLoading,
+        getActivitiesQueryResult,
+        pageSize,
+        searchQuery,
+      }) && (
         <>
-          <ActivitiesHeader resetSelectedIds={handleClearSelection} />
+          <ActivitiesHeader
+            resetSelectedIds={handleClearSelection}
+            selected={selected}
+          />
           {getActivitiesQueryLoading ? (
             <LoadingState />
           ) : (

--- a/src/features/activities/components/Activities/helpers.ts
+++ b/src/features/activities/components/Activities/helpers.ts
@@ -1,3 +1,7 @@
+import type { ApiPaginatedResponse } from "@/types/api/ApiPaginatedResponse";
+import type { AxiosResponse } from "axios";
+import type { Activity } from "../../types";
+
 export const getDateQuery = (fromDate?: string, toDate?: string): string => {
   if (fromDate && toDate) {
     return ` created-after:${fromDate} created-before:${toDate}`;
@@ -15,4 +19,68 @@ export const getTypeQuery = (type?: string): string => {
 
 export const getStatusQuery = (status?: string): string => {
   return status ? ` status:${status}` : "";
+};
+
+export const isActivitiesEmptyState = ({
+  currentPage,
+  getActivitiesQueryLoading,
+  getActivitiesQueryResult,
+  pageSize,
+  searchQuery,
+}: {
+  currentPage: number;
+  getActivitiesQueryLoading: boolean;
+  getActivitiesQueryResult?: AxiosResponse<ApiPaginatedResponse<Activity>>;
+  pageSize: number;
+  searchQuery: string;
+}) => {
+  return (
+    !searchQuery &&
+    currentPage === 1 &&
+    pageSize === 20 &&
+    !getActivitiesQueryLoading &&
+    (!getActivitiesQueryResult || !getActivitiesQueryResult.data.count)
+  );
+};
+
+export const isActivitiesLoadingState = ({
+  currentPage,
+  getActivitiesQueryLoading,
+  pageSize,
+  searchQuery,
+}: {
+  currentPage: number;
+  getActivitiesQueryLoading: boolean;
+  pageSize: number;
+  searchQuery?: string;
+}) => {
+  return (
+    !searchQuery &&
+    currentPage === 1 &&
+    pageSize === 20 &&
+    getActivitiesQueryLoading
+  );
+};
+
+export const isActivitiesLoadedState = ({
+  currentPage,
+  getActivitiesQueryLoading,
+  getActivitiesQueryResult,
+  pageSize,
+  searchQuery,
+}: {
+  currentPage: number;
+  getActivitiesQueryLoading: boolean;
+  getActivitiesQueryResult?: AxiosResponse<ApiPaginatedResponse<Activity>>;
+  pageSize: number;
+  searchQuery?: string;
+}) => {
+  return (
+    !!searchQuery ||
+    currentPage !== 1 ||
+    pageSize !== 20 ||
+    (!getActivitiesQueryLoading &&
+      getActivitiesQueryResult &&
+      getActivitiesQueryResult.data.count > 0)
+  );
 };

--- a/src/features/activities/components/ActivitiesActions/ActivitiesActions.tsx
+++ b/src/features/activities/components/ActivitiesActions/ActivitiesActions.tsx
@@ -1,0 +1,204 @@
+import type { FC } from "react";
+import { useActivities } from "../../hooks";
+import useDebug from "@/hooks/useDebug";
+import useNotify from "@/hooks/useNotify";
+import type { ActivityCommon } from "../../types";
+import { pluralize } from "@/utils/_helpers";
+import { ConfirmationButton } from "@canonical/react-components";
+
+interface ActivitiesActionsProps {
+  readonly selected: ActivityCommon[];
+}
+
+const ActivitiesActions: FC<ActivitiesActionsProps> = ({ selected }) => {
+  const { notify } = useNotify();
+  const debug = useDebug();
+  const {
+    approveActivitiesQuery,
+    cancelActivitiesQuery,
+    redoActivitiesQuery,
+    undoActivitiesQuery,
+  } = useActivities();
+
+  const {
+    mutateAsync: approveActivities,
+    isPending: approveActivitiesLoading,
+  } = approveActivitiesQuery;
+  const { mutateAsync: cancelActivities, isPending: cancelActivitiesLoading } =
+    cancelActivitiesQuery;
+  const { mutateAsync: redoActivities, isPending: redoActivitiesLoading } =
+    redoActivitiesQuery;
+  const { mutateAsync: undoActivities, isPending: undoActivitiesLoading } =
+    undoActivitiesQuery;
+
+  const selectedIds = selected.map((activity) => activity.id);
+
+  const handleApproveActivities = async () => {
+    try {
+      await approveActivities({ query: `id:${selectedIds.join(" OR id:")}` });
+
+      notify.success({
+        title: `You have successfully approved ${pluralize(selected.length, "an activity", `${selected.length} activities`)}.`,
+        message: `${pluralize(selected.length, "This activity", "These activities")} will be delivered the next time the Landscape server connects with the client.`,
+      });
+    } catch (error) {
+      debug(error);
+    }
+  };
+
+  const handleCancelActivities = async () => {
+    try {
+      await cancelActivities({ query: `id:${selectedIds.join(" OR id:")}` });
+
+      notify.success({
+        title: `You have successfully canceled ${pluralize(selected.length, "an activity", `${selected.length} activities`)}.`,
+        message: `${pluralize(selected.length, "This activity", "These activities")} won't be delivered to the client and will not run.`,
+      });
+    } catch (error) {
+      debug(error);
+    }
+  };
+
+  const handleRedoActivities = async () => {
+    try {
+      await redoActivities({ activity_ids: selectedIds });
+
+      notify.success({
+        title: `You have successfully redone ${pluralize(selected.length, "an activity", `${selected.length} activities`)}.`,
+        message: `${pluralize(
+          selected.length,
+          "An activity has been queued to re-run this activity.",
+          "Activities have been queued to re-run these activities.",
+        )}`,
+      });
+    } catch (error) {
+      debug(error);
+    }
+  };
+
+  const handleUndoActivities = async () => {
+    try {
+      await undoActivities({ activity_ids: selectedIds });
+
+      notify.success({
+        title: `You have successfully undone ${pluralize(selected.length, "an activity", `${selected.length} activities`)}.`,
+        message: `${pluralize(
+          selected.length,
+          "An activity has been queued to revert the changes delivered by this activity.",
+          "Activities have been queued to revert the changes delivered by these activities.",
+        )}`,
+      });
+    } catch (error) {
+      debug(error);
+    }
+  };
+
+  return (
+    <div key="buttons" className="p-segmented-control">
+      <div className="p-segmented-control__list">
+        <ConfirmationButton
+          className="p-segmented-control__button"
+          type="button"
+          disabled={
+            !selected.length ||
+            approveActivitiesLoading ||
+            selected.some((activity) => !activity.actions?.approvable)
+          }
+          confirmationModalProps={{
+            title: `Approve ${selected.length === 1 ? "activity" : "activities"}`,
+            children: (
+              <p>
+                Are you sure you want to approve selected{" "}
+                {selected.length === 1 ? "activity" : "activities"}?
+              </p>
+            ),
+            confirmButtonLabel: "Approve",
+            confirmButtonAppearance: "positive",
+            confirmButtonDisabled: approveActivitiesLoading,
+            confirmButtonLoading: approveActivitiesLoading,
+            onConfirm: handleApproveActivities,
+          }}
+        >
+          Approve
+        </ConfirmationButton>
+        <ConfirmationButton
+          className="p-segmented-control__button"
+          type="button"
+          disabled={
+            !selected.length ||
+            cancelActivitiesLoading ||
+            selected.some((activity) => !activity.actions?.cancelable)
+          }
+          confirmationModalProps={{
+            title: `Cancel ${selected.length === 1 ? "activity" : "activities"}`,
+            children: (
+              <p>
+                Are you sure you want to cancel selected{" "}
+                {selected.length === 1 ? "activity" : "activities"}?
+              </p>
+            ),
+            confirmButtonLabel: "Apply",
+            confirmButtonAppearance: "positive",
+            confirmButtonDisabled: cancelActivitiesLoading,
+            confirmButtonLoading: cancelActivitiesLoading,
+            onConfirm: handleCancelActivities,
+          }}
+        >
+          Cancel
+        </ConfirmationButton>
+        <ConfirmationButton
+          className="p-segmented-control__button"
+          type="button"
+          disabled={
+            !selected.length ||
+            undoActivitiesLoading ||
+            selected.some((activity) => !activity.actions?.revertable)
+          }
+          confirmationModalProps={{
+            title: `Undo ${selected.length === 1 ? "activity" : "activities"}`,
+            children: (
+              <p>
+                Are you sure you want to undo selected{" "}
+                {selected.length === 1 ? "activity" : "activities"}?
+              </p>
+            ),
+            confirmButtonLabel: "Undo",
+            confirmButtonAppearance: "positive",
+            confirmButtonDisabled: undoActivitiesLoading,
+            confirmButtonLoading: undoActivitiesLoading,
+            onConfirm: handleUndoActivities,
+          }}
+        >
+          Undo
+        </ConfirmationButton>
+        <ConfirmationButton
+          className="p-segmented-control__button"
+          type="button"
+          disabled={
+            !selected.length ||
+            redoActivitiesLoading ||
+            selected.some((activity) => !activity.actions?.reappliable)
+          }
+          confirmationModalProps={{
+            title: `Redo ${selected.length === 1 ? "activity" : "activities"}`,
+            children: (
+              <p>
+                Are you sure you want to redo selected{" "}
+                {selected.length === 1 ? "activity" : "activities"}?
+              </p>
+            ),
+            confirmButtonLabel: "Redo",
+            confirmButtonAppearance: "positive",
+            confirmButtonDisabled: redoActivitiesLoading,
+            confirmButtonLoading: redoActivitiesLoading,
+            onConfirm: handleRedoActivities,
+          }}
+        >
+          Redo
+        </ConfirmationButton>
+      </div>
+    </div>
+  );
+};
+
+export default ActivitiesActions;

--- a/src/features/activities/components/ActivitiesActions/index.ts
+++ b/src/features/activities/components/ActivitiesActions/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ActivitiesActions";

--- a/src/features/activities/components/ActivitiesHeader/ActivitiesHeader.module.scss
+++ b/src/features/activities/components/ActivitiesHeader/ActivitiesHeader.module.scss
@@ -19,3 +19,9 @@
   column-gap: $sph--small;
   display: flex;
 }
+
+.actions {
+  display: flex;
+  flex-grow: 1;
+  justify-content: space-between;
+}

--- a/src/features/activities/components/ActivitiesHeader/ActivitiesHeader.tsx
+++ b/src/features/activities/components/ActivitiesHeader/ActivitiesHeader.tsx
@@ -15,18 +15,24 @@ import {
   ACTIVITY_SEARCH_HELP_TERMS,
   ACTIVITY_STATUS_OPTIONS,
 } from "./constants";
+import ActivitiesActions from "../ActivitiesActions";
+import type { ActivityCommon } from "../../types";
 
 interface ActivitiesHeaderProps {
+  readonly selected: ActivityCommon[];
   readonly resetSelectedIds: () => void;
 }
 
-const ActivitiesHeader: FC<ActivitiesHeaderProps> = ({ resetSelectedIds }) => {
+const ActivitiesHeader: FC<ActivitiesHeaderProps> = ({
+  resetSelectedIds,
+  selected,
+}) => {
+  const [searchText, setSearchText] = useState<string>("");
+  const [showSearchHelp, setShowSearchHelp] = useState(false);
+
   const { query, setPageParams } = usePageParams();
   const { instanceId } = useParams<UrlParams>();
   const { getActivityTypesQuery } = useActivities();
-
-  const [searchText, setSearchText] = useState<string>("");
-  const [showSearchHelp, setShowSearchHelp] = useState(false);
 
   const { data: activityTypesQueryData } = getActivityTypesQuery();
 
@@ -42,7 +48,7 @@ const ActivitiesHeader: FC<ActivitiesHeaderProps> = ({ resetSelectedIds }) => {
     ...activityResultOptions,
   ];
 
-  const IS_STICKY = !!instanceId;
+  const IS_PANEL = !!instanceId;
 
   const handleSearch = () => {
     if (!searchText) {
@@ -64,7 +70,7 @@ const ActivitiesHeader: FC<ActivitiesHeaderProps> = ({ resetSelectedIds }) => {
     <>
       <div
         className={classNames(classes.top, {
-          [classes.sticky]: !IS_STICKY,
+          [classes.sticky]: !IS_PANEL,
         })}
       >
         <SearchBoxWithDescriptionButton
@@ -78,11 +84,14 @@ const ActivitiesHeader: FC<ActivitiesHeaderProps> = ({ resetSelectedIds }) => {
           }}
           onClear={handleClear}
         />
+        <div className={classes.actions}>
+          <div className={classes.filters}>
+            <StatusFilter options={ACTIVITY_STATUS_OPTIONS} />
+            <ActivityTypeFilter options={ACTIVITY_TYPE_OPTIONS} />
+            <ActivitiesDateFilter />
+          </div>
 
-        <div className={classes.filters}>
-          <StatusFilter options={ACTIVITY_STATUS_OPTIONS} />
-          <ActivityTypeFilter options={ACTIVITY_TYPE_OPTIONS} />
-          <ActivitiesDateFilter />
+          {IS_PANEL && <ActivitiesActions selected={selected} />}
         </div>
       </div>
       <SearchHelpPopup

--- a/src/features/activities/components/ActivityDetails/ActivityDetails.tsx
+++ b/src/features/activities/components/ActivityDetails/ActivityDetails.tsx
@@ -15,6 +15,8 @@ import type { Activity } from "../../types";
 import useDebug from "@/hooks/useDebug";
 import useInstances from "@/hooks/useInstances";
 import classes from "./ActivityDetails.module.scss";
+import useNotify from "@/hooks/useNotify";
+import useSidePanel from "@/hooks/useSidePanel";
 
 interface ActivityDetailsProps {
   readonly activityId: number;
@@ -22,7 +24,8 @@ interface ActivityDetailsProps {
 
 const ActivityDetails: FC<ActivityDetailsProps> = ({ activityId }) => {
   const debug = useDebug();
-
+  const { notify } = useNotify();
+  const { closeSidePanel } = useSidePanel();
   const {
     approveActivitiesQuery,
     cancelActivitiesQuery,
@@ -68,6 +71,14 @@ const ActivityDetails: FC<ActivityDetailsProps> = ({ activityId }) => {
   const handleApproveActivity = async (a: Activity) => {
     try {
       await approveActivities({ query: `id:${a.id}` });
+
+      closeSidePanel();
+
+      notify.success({
+        title: "You have successfully approved an activity.",
+        message:
+          "This activity will be delivered the next time the Landscape server connects with the client.",
+      });
     } catch (error) {
       debug(error);
     }
@@ -76,6 +87,14 @@ const ActivityDetails: FC<ActivityDetailsProps> = ({ activityId }) => {
   const handleCancelActivity = async (a: Activity) => {
     try {
       await cancelActivities({ query: `id:${a.id}` });
+
+      closeSidePanel();
+
+      notify.success({
+        title: "You have successfully canceled an activity.",
+        message:
+          "This activity won't be delivered to the client and will not run.",
+      });
     } catch (error) {
       debug(error);
     }
@@ -84,6 +103,13 @@ const ActivityDetails: FC<ActivityDetailsProps> = ({ activityId }) => {
   const handleRedoActivity = async (a: Activity) => {
     try {
       await redoActivities({ activity_ids: [a.id] });
+
+      closeSidePanel();
+
+      notify.success({
+        title: "You have successfully redone an activity.",
+        message: "An activity has been queued to re-run this activity.",
+      });
     } catch (error) {
       debug(error);
     }
@@ -92,6 +118,14 @@ const ActivityDetails: FC<ActivityDetailsProps> = ({ activityId }) => {
   const handleUndoActivity = async (a: Activity) => {
     try {
       await undoActivities({ activity_ids: [a.id] });
+
+      closeSidePanel();
+
+      notify.success({
+        title: "You have successfully undone an activity.",
+        message:
+          "An activity has been queued to revert the changes delivered by this activity.",
+      });
     } catch (error) {
       debug(error);
     }

--- a/src/features/activities/constants.ts
+++ b/src/features/activities/constants.ts
@@ -35,7 +35,7 @@ export const ACTIVITY_STATUSES: Record<
   },
   canceled: {
     icon: "error-grey",
-    label: "Cancelled",
+    label: "Canceled",
   },
   failed: {
     icon: `error-grey ${classes.iconError}`,

--- a/src/features/activities/index.tsx
+++ b/src/features/activities/index.tsx
@@ -17,6 +17,7 @@ export const ActivityDetails: FC<
 };
 
 export { default as Activities } from "./components/Activities";
+export { default as ActivitiesActions } from "./components/ActivitiesActions";
 export { ACTIVITY_STATUSES } from "./constants";
 export { useActivities } from "./hooks";
 export type { Activity, ActivityCommon, GetActivitiesParams } from "./types";

--- a/src/features/apt-sources/components/APTSourcesListActions/APTSourcesListActions.tsx
+++ b/src/features/apt-sources/components/APTSourcesListActions/APTSourcesListActions.tsx
@@ -5,6 +5,7 @@ import { type FC } from "react";
 import { useBoolean } from "usehooks-ts";
 import { useAPTSources } from "../../hooks";
 import type { APTSource } from "../../types";
+import useNotify from "@/hooks/useNotify";
 
 interface APTSourcesListActionsProps {
   readonly aptSource: APTSource;
@@ -15,7 +16,7 @@ const APTSourcesListActions: FC<APTSourcesListActionsProps> = ({
 }) => {
   const { removeAPTSourceQuery } = useAPTSources();
   const debug = useDebug();
-
+  const { notify } = useNotify();
   const {
     value: isModalOpen,
     setTrue: openModal,
@@ -27,6 +28,11 @@ const APTSourcesListActions: FC<APTSourcesListActionsProps> = ({
   const tryRemove = async () => {
     try {
       await remove({ name: aptSource.name });
+
+      notify.success({
+        title: "Successfully deleted APT source",
+        message: `You have successfully deleted the ${aptSource.name} APT source`,
+      });
     } catch (error) {
       debug(error);
     } finally {

--- a/src/features/employees/components/ActivateEmployeeModal/ActivateEmployeeModal.tsx
+++ b/src/features/employees/components/ActivateEmployeeModal/ActivateEmployeeModal.tsx
@@ -3,6 +3,7 @@ import { ConfirmationModal } from "@canonical/react-components";
 import type { FC } from "react";
 import type { Employee } from "../../types";
 import { usePatchEmployee } from "../../api";
+import useDebug from "@/hooks/useDebug";
 
 interface ActivateEmployeeModalProps {
   readonly employee: Employee;
@@ -14,19 +15,23 @@ const ActivateEmployeeModal: FC<ActivateEmployeeModalProps> = ({
   handleClose,
 }) => {
   const { notify } = useNotify();
-
+  const debug = useDebug();
   const { patchEmployee, isPending } = usePatchEmployee();
 
   const handleActivateEmployee = async () => {
-    await patchEmployee({
-      id: employee.id,
-      is_active: true,
-    });
-    notify.success({
-      title: `You have successfully activated ${employee.name}`,
-      message: `${employee.name} will be able to log in to Landscape and register new instances with their account.`,
-    });
-    handleClose();
+    try {
+      await patchEmployee({
+        id: employee.id,
+        is_active: true,
+      });
+      notify.success({
+        title: `You have successfully activated ${employee.name}`,
+        message: `${employee.name} will be able to log in to Landscape and register new instances with their account.`,
+      });
+      handleClose();
+    } catch (error) {
+      debug(error);
+    }
   };
 
   return (

--- a/src/features/reboot-profiles/components/RebootProfilesForm/constants.ts
+++ b/src/features/reboot-profiles/components/RebootProfilesForm/constants.ts
@@ -28,4 +28,4 @@ export const DAY_OPTIONS: (SelectOption & {
 
 export const EXPIRATION_TOOLTIP_MESSAGE = `If Landscape cannot reboot the
 associated instances by this point,
-the reboot will be cancelled.`;
+the reboot will be canceled.`;

--- a/src/features/upgrade-profiles/components/UpgradeProfileScheduleBlock/constants.ts
+++ b/src/features/upgrade-profiles/components/UpgradeProfileScheduleBlock/constants.ts
@@ -1,3 +1,3 @@
 export const EXPIRATION_TOOLTIP_MESSAGE = `If Landscape cannot upgrade the
 associated instances by this point,
-the upgrade will be cancelled.`;
+the upgrade will be canceled.`;

--- a/src/features/usns/components/UsnList/UsnList.module.scss
+++ b/src/features/usns/components/UsnList/UsnList.module.scss
@@ -38,3 +38,9 @@
 .cveLink {
   text-wrap: nowrap;
 }
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}

--- a/src/features/usns/components/UsnList/UsnList.tsx
+++ b/src/features/usns/components/UsnList/UsnList.tsx
@@ -214,28 +214,31 @@ const UsnList: FC<UsnListProps> = ({
         {
           accessor: "cves",
           Header: "CVE(s)",
-          Cell: ({ row: { original, index } }: CellProps<Usn>) => (
-            <TruncatedCell
-              content={original.cves.map(({ cve, cve_link }) => (
-                <span key={cve} className={classes.cve}>
-                  <a
-                    href={cve_link}
-                    target="_blank"
-                    rel="nofollow noopener noreferrer"
-                    className={classes.cveLink}
-                  >
-                    {cve}
-                  </a>
-                </span>
-              ))}
-              isExpanded={
-                expandedCell?.column === "cves" && expandedCell.row === index
-              }
-              onExpand={() => {
-                handleExpandCellClick("cves", index);
-              }}
-            />
-          ),
+          Cell: ({ row: { original, index } }: CellProps<Usn>) =>
+            original.cves.length > 0 ? (
+              <TruncatedCell
+                content={original.cves.map(({ cve, cve_link }) => (
+                  <span key={cve} className={classes.cve}>
+                    <a
+                      href={cve_link}
+                      target="_blank"
+                      rel="nofollow noopener noreferrer"
+                      className={classes.cveLink}
+                    >
+                      {cve}
+                    </a>
+                  </span>
+                ))}
+                isExpanded={
+                  expandedCell?.column === "cves" && expandedCell.row === index
+                }
+                onExpand={() => {
+                  handleExpandCellClick("cves", index);
+                }}
+              />
+            ) : (
+              <NoData />
+            ),
         },
         {
           accessor: "date",
@@ -301,7 +304,7 @@ const UsnList: FC<UsnListProps> = ({
   );
 
   return (
-    <div ref={getTableRows(tableRowsRef)}>
+    <div ref={getTableRows(tableRowsRef)} className={classes.wrapper}>
       {otherProps.tableType === "expandable" ? (
         <ExpandableTable
           columns={securityIssueColumns}
@@ -327,15 +330,13 @@ const UsnList: FC<UsnListProps> = ({
             getRowProps={handleRowProps(expandedCell)}
             emptyMsg={`No security issues found with the search "${otherProps.search}"`}
           />
-          {usns.length > 0 && (
-            <TablePagination
-              handleClearSelection={() => {
-                onSelectedUsnsChange([]);
-              }}
-              totalItems={totalUsnCount}
-              currentItemCount={usns.length}
-            />
-          )}
+          <TablePagination
+            handleClearSelection={() => {
+              onSelectedUsnsChange([]);
+            }}
+            totalItems={totalUsnCount}
+            currentItemCount={usns.length}
+          />
         </>
       )}
     </div>

--- a/src/pages/dashboard/activities/ActivitiesPage.tsx
+++ b/src/pages/dashboard/activities/ActivitiesPage.tsx
@@ -1,70 +1,14 @@
-import type { FC } from "react";
-import { useState } from "react";
 import PageContent from "@/components/layout/PageContent";
 import PageHeader from "@/components/layout/PageHeader";
 import PageMain from "@/components/layout/PageMain";
 import type { ActivityCommon } from "@/features/activities";
-import { Activities, useActivities } from "@/features/activities";
-import { ConfirmationButton } from "@canonical/react-components";
-import useDebug from "@/hooks/useDebug";
+import { Activities, ActivitiesActions } from "@/features/activities";
+import type { FC } from "react";
+import { useState } from "react";
 import classes from "./ActivitiesPage.module.scss";
-import { pluralize } from "@/utils/_helpers";
 
 const ActivitiesPage: FC = () => {
   const [selected, setSelected] = useState<ActivityCommon[]>([]);
-
-  const debug = useDebug();
-  const {
-    approveActivitiesQuery,
-    cancelActivitiesQuery,
-    redoActivitiesQuery,
-    undoActivitiesQuery,
-  } = useActivities();
-
-  const {
-    mutateAsync: approveActivities,
-    isPending: approveActivitiesLoading,
-  } = approveActivitiesQuery;
-  const { mutateAsync: cancelActivities, isPending: cancelActivitiesLoading } =
-    cancelActivitiesQuery;
-  const { mutateAsync: redoActivities, isPending: redoActivitiesLoading } =
-    redoActivitiesQuery;
-  const { mutateAsync: undoActivities, isPending: undoActivitiesLoading } =
-    undoActivitiesQuery;
-
-  const selectedIds = selected.map((activity) => activity.id);
-
-  const handleApproveActivities = async () => {
-    try {
-      await approveActivities({ query: `id:${selectedIds.join(" OR id:")}` });
-    } catch (error) {
-      debug(error);
-    }
-  };
-
-  const handleCancelActivities = async () => {
-    try {
-      await cancelActivities({ query: `id:${selectedIds.join(" OR id:")}` });
-    } catch (error) {
-      debug(error);
-    }
-  };
-
-  const handleRedoActivities = async () => {
-    try {
-      await redoActivities({ activity_ids: selectedIds });
-    } catch (error) {
-      debug(error);
-    }
-  };
-
-  const handleUndoActivities = async () => {
-    try {
-      await undoActivities({ activity_ids: selectedIds });
-    } catch (error) {
-      debug(error);
-    }
-  };
 
   return (
     <PageMain>
@@ -72,110 +16,7 @@ const ActivitiesPage: FC = () => {
         title="Activities"
         className={classes.header}
         actions={[
-          <div key="buttons" className="p-segmented-control">
-            <div className="p-segmented-control__list">
-              <ConfirmationButton
-                className="p-segmented-control__button"
-                type="button"
-                disabled={
-                  !selected.length ||
-                  approveActivitiesLoading ||
-                  selected.some((activity) => !activity.actions?.approvable)
-                }
-                confirmationModalProps={{
-                  title: `Approve ${pluralize(selected.length, "activity", "activities")}`,
-                  children: (
-                    <p>
-                      Are you sure you want to approve selected{" "}
-                      {pluralize(selected.length, "activity", "activities")}?
-                    </p>
-                  ),
-                  confirmButtonLabel: "Approve",
-                  confirmButtonAppearance: "positive",
-                  confirmButtonDisabled: approveActivitiesLoading,
-                  confirmButtonLoading: approveActivitiesLoading,
-                  onConfirm: handleApproveActivities,
-                }}
-              >
-                Approve
-              </ConfirmationButton>
-              <ConfirmationButton
-                className="p-segmented-control__button"
-                type="button"
-                disabled={
-                  !selected.length ||
-                  cancelActivitiesLoading ||
-                  selected.some((activity) => !activity.actions?.cancelable)
-                }
-                confirmationModalProps={{
-                  title: `Cancel ${pluralize(selected.length, "activity", "activities")}`,
-                  children: (
-                    <p>
-                      Are you sure you want to cancel selected{" "}
-                      {pluralize(selected.length, "activity", "activities")}?
-                    </p>
-                  ),
-                  confirmButtonLabel: "Apply",
-                  confirmButtonAppearance: "positive",
-                  confirmButtonDisabled: cancelActivitiesLoading,
-                  confirmButtonLoading: cancelActivitiesLoading,
-                  onConfirm: handleCancelActivities,
-                }}
-              >
-                Cancel
-              </ConfirmationButton>
-              <ConfirmationButton
-                className="p-segmented-control__button"
-                type="button"
-                disabled={
-                  !selected.length ||
-                  undoActivitiesLoading ||
-                  selected.some((activity) => !activity.actions?.revertable)
-                }
-                confirmationModalProps={{
-                  title: `Undo ${pluralize(selected.length, "activity", "activities")}`,
-                  children: (
-                    <p>
-                      Are you sure you want to undo selected{" "}
-                      {pluralize(selected.length, "activity", "activities")}?
-                    </p>
-                  ),
-                  confirmButtonLabel: "Undo",
-                  confirmButtonAppearance: "positive",
-                  confirmButtonDisabled: undoActivitiesLoading,
-                  confirmButtonLoading: undoActivitiesLoading,
-                  onConfirm: handleUndoActivities,
-                }}
-              >
-                Undo
-              </ConfirmationButton>
-              <ConfirmationButton
-                className="p-segmented-control__button"
-                type="button"
-                disabled={
-                  !selected.length ||
-                  redoActivitiesLoading ||
-                  selected.some((activity) => !activity.actions?.reappliable)
-                }
-                confirmationModalProps={{
-                  title: `Redo ${pluralize(selected.length, "activity", "activities")}`,
-                  children: (
-                    <p>
-                      Are you sure you want to redo selected{" "}
-                      {pluralize(selected.length, "activity", "activities")}?
-                    </p>
-                  ),
-                  confirmButtonLabel: "Redo",
-                  confirmButtonAppearance: "positive",
-                  confirmButtonDisabled: redoActivitiesLoading,
-                  confirmButtonLoading: redoActivitiesLoading,
-                  onConfirm: handleRedoActivities,
-                }}
-              >
-                Redo
-              </ConfirmationButton>
-            </div>
-          </div>,
+          <ActivitiesActions selected={selected} key="activities-actions" />,
         ]}
       />
       <PageContent>

--- a/src/pages/dashboard/instances/[single]/tabs/processes/ProcessesPanel/ProcessesPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/processes/ProcessesPanel/ProcessesPanel.tsx
@@ -60,7 +60,9 @@ const ProcessesPanel: FC = () => {
           />
           <ProcessesList
             processes={processes}
-            setSelectedPids={(pids) => setSelectedPids(pids)}
+            setSelectedPids={(pids) => {
+              setSelectedPids(pids);
+            }}
             selectedPids={selectedPids}
           />
         </>

--- a/src/pages/dashboard/instances/[single]/tabs/security-issues/SecurityIssueList/SecurityIssueList.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/security-issues/SecurityIssueList/SecurityIssueList.tsx
@@ -29,7 +29,9 @@ const SecurityIssueList: FC<SecurityIssueListProps> = ({
         tableType="paginated"
         instances={[instance]}
         isUsnsLoading={isUsnsLoading}
-        onSelectedUsnsChange={(usns) => setSelectedUsns(usns)}
+        onSelectedUsnsChange={(newUsns) => {
+          setSelectedUsns(newUsns);
+        }}
         search={search}
         selectedUsns={selectedUsns}
         totalUsnCount={totalUsnCount}

--- a/src/pages/dashboard/instances/[single]/tabs/security-issues/SecurityIssuesPanel/SecurityIssuesPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/security-issues/SecurityIssuesPanel/SecurityIssuesPanel.tsx
@@ -5,6 +5,11 @@ import { useUsns } from "@/features/usns";
 import usePageParams from "@/hooks/usePageParams";
 import SecurityIssueList from "@/pages/dashboard/instances/[single]/tabs/security-issues/SecurityIssueList";
 import type { Instance } from "@/types/Instance";
+import {
+  isSecurityEmptyState,
+  isSecurityListLoaded,
+  isSecurityLoadingState,
+} from "./helpers";
 
 interface SecurityIssuesPanelProps {
   readonly instance: Instance;
@@ -25,24 +30,28 @@ const SecurityIssuesPanel: FC<SecurityIssuesPanelProps> = ({ instance }) => {
 
   return (
     <>
-      {!search &&
-        currentPage === 1 &&
-        pageSize === 20 &&
-        getUsnsQueryLoading && <LoadingState />}
-      {!search &&
-        currentPage === 1 &&
-        pageSize === 20 &&
-        !getUsnsQueryLoading &&
-        (!getUsnsQueryResult ||
-          getUsnsQueryResult.data.results.length === 0) && (
-          <EmptyState icon="inspector-debug" title="No security issues found" />
-        )}
-      {(search ||
-        currentPage > 1 ||
-        pageSize !== 20 ||
-        (!getUsnsQueryLoading &&
-          getUsnsQueryResult &&
-          getUsnsQueryResult.data.results.length > 0)) && (
+      {isSecurityLoadingState({
+        search,
+        currentPage,
+        pageSize,
+        getUsnsQueryLoading,
+      }) && <LoadingState />}
+      {isSecurityEmptyState({
+        search,
+        currentPage,
+        pageSize,
+        getUsnsQueryLoading,
+        getUsnsQueryResult,
+      }) && (
+        <EmptyState icon="inspector-debug" title="No security issues found" />
+      )}
+      {isSecurityListLoaded({
+        currentPage,
+        getUsnsQueryLoading,
+        getUsnsQueryResult,
+        pageSize,
+        search,
+      }) && (
         <SecurityIssueList
           instance={instance}
           isUsnsLoading={getUsnsQueryLoading}

--- a/src/pages/dashboard/instances/[single]/tabs/security-issues/SecurityIssuesPanel/helpers.ts
+++ b/src/pages/dashboard/instances/[single]/tabs/security-issues/SecurityIssuesPanel/helpers.ts
@@ -1,0 +1,62 @@
+import type { ApiPaginatedResponse } from "@/types/api/ApiPaginatedResponse";
+import type { Usn } from "@/types/Usn";
+import type { AxiosResponse } from "axios";
+
+export const isSecurityLoadingState = ({
+  currentPage,
+  getUsnsQueryLoading,
+  pageSize,
+  search,
+}: {
+  search: string;
+  currentPage: number;
+  pageSize: number;
+  getUsnsQueryLoading: boolean;
+}) => {
+  return !search && currentPage === 1 && pageSize === 20 && getUsnsQueryLoading;
+};
+
+export const isSecurityEmptyState = ({
+  search,
+  currentPage,
+  pageSize,
+  getUsnsQueryLoading,
+  getUsnsQueryResult,
+}: {
+  search: string;
+  currentPage: number;
+  pageSize: number;
+  getUsnsQueryLoading: boolean;
+  getUsnsQueryResult?: AxiosResponse<ApiPaginatedResponse<Usn>>;
+}) => {
+  return (
+    !search &&
+    currentPage === 1 &&
+    pageSize === 20 &&
+    !getUsnsQueryLoading &&
+    (!getUsnsQueryResult || getUsnsQueryResult.data.results.length === 0)
+  );
+};
+
+export const isSecurityListLoaded = ({
+  currentPage,
+  getUsnsQueryLoading,
+  getUsnsQueryResult,
+  pageSize,
+  search,
+}: {
+  currentPage: number;
+  getUsnsQueryLoading: boolean;
+  getUsnsQueryResult?: AxiosResponse<ApiPaginatedResponse<Usn>>;
+  pageSize: number;
+  search: string;
+}) => {
+  return (
+    search ||
+    currentPage > 1 ||
+    pageSize !== 20 ||
+    (!getUsnsQueryLoading &&
+      getUsnsQueryResult &&
+      getUsnsQueryResult.data.results.length > 0)
+  );
+};

--- a/src/pages/dashboard/settings/administrators/tabs/administrators/AdministratorListActions/AdministratorListActions.tsx
+++ b/src/pages/dashboard/settings/administrators/tabs/administrators/AdministratorListActions/AdministratorListActions.tsx
@@ -1,6 +1,7 @@
 import ListActions from "@/components/layout/ListActions";
 import useAdministrators from "@/hooks/useAdministrators";
 import useDebug from "@/hooks/useDebug";
+import useNotify from "@/hooks/useNotify";
 import type { Administrator } from "@/types/Administrator";
 import { ConfirmationModal } from "@canonical/react-components";
 import { type FC } from "react";
@@ -14,7 +15,7 @@ const AdministratorListActions: FC<AdministratorListActionsProps> = ({
   administrator,
 }) => {
   const debug = useDebug();
-
+  const { notify } = useNotify();
   const { disableAdministratorQuery } = useAdministrators();
 
   const {
@@ -29,6 +30,12 @@ const AdministratorListActions: FC<AdministratorListActionsProps> = ({
   const tryDisable = async () => {
     try {
       await disable({ email: administrator.email });
+
+      notify.success({
+        title: `You have successfully removed ${administrator.name} as an administrator.`,
+        message:
+          "They will no longer be able to access this Landscape organization and all permissions have been revoked.",
+      });
     } catch (error) {
       debug(error);
     } finally {

--- a/src/pages/dashboard/settings/administrators/tabs/administrators/EditAdministratorForm/EditAdministratorForm.tsx
+++ b/src/pages/dashboard/settings/administrators/tabs/administrators/EditAdministratorForm/EditAdministratorForm.tsx
@@ -6,6 +6,7 @@ import useAdministrators from "@/hooks/useAdministrators";
 import useDebug from "@/hooks/useDebug";
 import useNotify from "@/hooks/useNotify";
 import useRoles from "@/hooks/useRoles";
+import useSidePanel from "@/hooks/useSidePanel";
 import type { Administrator } from "@/types/Administrator";
 import type { SelectOption } from "@/types/SelectOption";
 import {
@@ -37,6 +38,7 @@ const EditAdministratorForm: FC<EditAdministratorFormProps> = ({
 
   const { notify } = useNotify();
   const debug = useDebug();
+  const { closeSidePanel } = useSidePanel();
   const { disableAdministratorQuery, editAdministratorQuery } =
     useAdministrators();
   const { getRolesQuery } = useRoles();
@@ -57,6 +59,13 @@ const EditAdministratorForm: FC<EditAdministratorFormProps> = ({
   const handleDisableAdministrator = async () => {
     try {
       await disableAdministrator({ email: currentAdministrator.email });
+
+      notify.success({
+        title: "Administrator removed",
+        message: `Administrator "${administrator.name}" has been removed successfully.`,
+      });
+
+      closeSidePanel();
     } catch (error) {
       debug(error);
     }


### PR DESCRIPTION
### Items done:
- Activities bulk actions: https://warthogs.atlassian.net/browse/LNDENG-2516
- Activities toast notifications: https://warthogs.atlassian.net/browse/LNDENG-2519
- Access group, apt sources, administrators notifications: https://warthogs.atlassian.net/browse/LNDENG-2531

### Extra fixes:
- Changed "cancelled" to "canceled"
- Fixed security list panel layout issue where table pagination was not shown at the bottom of the page
- Added `try catch` block when activating and deactivating employee
- Added empty state `---` if no CVE is in the security issues list