### PR TITLE
refactor: disable sorting for date-related multiselects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "landscape-webapp-new",
       "version": "1.13.1",
       "dependencies": {
-        "@canonical/react-components": "2.5.0",
+        "@canonical/react-components": "2.6.0",
         "@monaco-editor/react": "4.7.0",
         "@sentry/react": "^9.19.0",
         "@tanstack/react-query": "5.75.7",
@@ -67,7 +67,7 @@
         "vitest": "3.1.2"
       },
       "engines": {
-        "node": ">=20.11.0"
+        "node": ">=22.15.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -439,9 +439,10 @@
       }
     },
     "node_modules/@canonical/react-components": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@canonical/react-components/-/react-components-2.5.0.tgz",
-      "integrity": "sha512-nM/R4bqvB7Pd65scJphvIzlA0QGlclpjiql+Ez5zJgrV32lebFmjZ0x+Qrsaffp+FPPJ7oPG2R3r9cy22kAawg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@canonical/react-components/-/react-components-2.6.0.tgz",
+      "integrity": "sha512-MCJ6ye1IoY/9Kqo3DJP+3z+gt8QQT9xRxvUnfkQ+3+LoBgxgLbZR7tMGG2fPlpSI9vFx117SlOrpUp5SZ0Tk8Q==",
+      "license": "LGPL-3.0",
       "dependencies": {
         "@types/jest": "29.5.14",
         "@types/node": "20.17.19",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:report": "npx playwright show-report"
   },
   "dependencies": {
-    "@canonical/react-components": "2.5.0",
+    "@canonical/react-components": "2.6.0",
     "@monaco-editor/react": "4.7.0",
     "@sentry/react": "^9.19.0",
     "@tanstack/react-query": "5.75.7",

--- a/src/components/form/ScheduleBlock/components/OnSelect/OnSelect.tsx
+++ b/src/components/form/ScheduleBlock/components/OnSelect/OnSelect.tsx
@@ -30,6 +30,8 @@ const OnSelect = <T extends ScheduleBlockFormProps>({
             )
           }
           scrollOverflow={true}
+          isSortedAlphabetically={false}
+          hasSelectedItemsFirst={false}
           required
         />
       );
@@ -63,6 +65,8 @@ const OnSelect = <T extends ScheduleBlockFormProps>({
               items.map(({ value }) => value),
             )
           }
+          isSortedAlphabetically={false}
+          hasSelectedItemsFirst={false}
           scrollOverflow={true}
           required
         />

--- a/src/features/reboot-profiles/components/RebootProfilesForm/RebootProfilesForm.tsx
+++ b/src/features/reboot-profiles/components/RebootProfilesForm/RebootProfilesForm.tsx
@@ -140,6 +140,8 @@ const RebootProfilesForm: FC<RebootProfilesFormProps> = (props) => {
                 items.map(({ value }) => value),
               )
             }
+            isSortedAlphabetically={false}
+            hasSelectedItemsFirst={false}
             error={
               formik.touched.on_days &&
               typeof formik.errors.on_days === "string"

--- a/src/features/upgrade-profiles/components/UpgradeProfileScheduleBlock/UpgradeProfileScheduleBlock.tsx
+++ b/src/features/upgrade-profiles/components/UpgradeProfileScheduleBlock/UpgradeProfileScheduleBlock.tsx
@@ -1,8 +1,8 @@
+import MultiSelectField from "@/components/form/MultiSelectField";
+import { Icon, Input, RadioInput, Tooltip } from "@canonical/react-components";
 import classNames from "classnames";
 import type { FormikContextType } from "formik";
 import type { FC } from "react";
-import { Icon, Input, RadioInput, Tooltip } from "@canonical/react-components";
-import MultiSelectField from "@/components/form/MultiSelectField";
 import { DAY_OPTIONS } from "../../constants";
 import type { FormProps } from "../../types";
 import { EXPIRATION_TOOLTIP_MESSAGE } from "./constants";
@@ -39,6 +39,8 @@ const UpgradeProfileScheduleBlock: FC<UpgradeProfileScheduleBlockProps> = ({
             items.map(({ value }) => value),
           )
         }
+        isSortedAlphabetically={false}
+        hasSelectedItemsFirst={false}
         error={
           formik.touched.on_days && typeof formik.errors.on_days === "string"
             ? formik.errors.on_days


### PR DESCRIPTION
`MultiSelectField`s with date-related options (such as days of the week) will not be sorted.