### PR TITLE
refactor: passing groupnames to EditUserForm appropriately [LNDENG - 2646]

### DIFF
--- a/src/pages/dashboard/instances/[single]/tabs/users/EditUserForm/EditUserForm.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/EditUserForm/EditUserForm.tsx
@@ -119,9 +119,7 @@ const EditUserForm: FC<EditUserFormProps> = ({ user }) => {
           promises.push(
             removeUserFromGroupMutation({
               computer_id: instanceId,
-              groupnames: groupsData
-                .filter((g) => groupsToBeRemoved.includes(String(g.gid)))
-                .map((g) => g.name),
+              groupnames: groupNames,
 
               usernames: [values.username],
               action: "remove",


### PR DESCRIPTION
- Filtering `groupnames` appropriately when adding or removing groups in `EditUserForm.tsx`, so that the group name gets passed to the endpoint instead of the group uid. 

https://warthogs.atlassian.net/browse/LNDENG-2646


<img width="821" alt="Screenshot 2025-06-06 at 3 32 30 PM" src="https://github.com/user-attachments/assets/33a4ac61-420c-4412-8c13-7f76dc768e74" />

<img width="776" alt="Screenshot 2025-06-06 at 3 33 21 PM" src="https://github.com/user-attachments/assets/752c8ce1-660f-4ac9-939e-0e53deaea425" />

