### PR TITLE
Revert "fix: wrong ubuntu pro info date showing on non-ubuntu linux instances"

### DIFF
--- a/src/features/instances/components/InstanceList/InstanceList.tsx
+++ b/src/features/instances/components/InstanceList/InstanceList.tsx
@@ -182,18 +182,18 @@ const InstanceList: FC<InstanceListProps> = ({
         canBeHidden: true,
         optionLabel: "Ubuntu pro",
         Header: "Ubuntu pro",
-        Cell: ({ row }: CellProps<Instance>) => {
-          if (
-            row.original.ubuntu_pro_info?.result === "success" &&
-            moment(row.original.ubuntu_pro_info.expires).isValid()
-          ) {
-            return `Exp. ${moment(row.original.ubuntu_pro_info.expires).format(
-              DISPLAY_DATE_TIME_FORMAT,
-            )}`;
-          }
-
-          return <NoData />;
-        },
+        Cell: ({ row }: CellProps<Instance>) => (
+          <>
+            {row.original.ubuntu_pro_info &&
+            moment(row.original.ubuntu_pro_info.expires).isValid() ? (
+              `Exp. ${moment(row.original.ubuntu_pro_info.expires).format(
+                DISPLAY_DATE_TIME_FORMAT,
+              )}`
+            ) : (
+              <NoData />
+            )}
+          </>
+        ),
       },
       {
         accessor: "last_ping",

--- a/src/types/Instance.d.ts
+++ b/src/types/Instance.d.ts
@@ -176,17 +176,6 @@ interface UbuntuProInfo {
   effective?: string;
   contract?: UbuntuProContract;
   account?: UbuntuProAccount;
-  result: "success";
-}
-
-interface FailedUbuntuProInfo {
-  errors: {
-    message: string;
-    message_code: string;
-    service: string | null;
-    type: string;
-  }[];
-  result: "failure";
 }
 
 interface DistributionInfo {
@@ -212,7 +201,7 @@ export interface InstanceWithoutRelation extends Record<string, unknown> {
   last_ping_time: string | null;
   tags: string[];
   title: string;
-  ubuntu_pro_info: UbuntuProInfo | FailedUbuntuProInfo | null;
+  ubuntu_pro_info: UbuntuProInfo | null;
   annotations?: Record<string, string>;
   grouped_hardware?: GroupedHardware;
   alerts?: InstanceAlert[];


### PR DESCRIPTION
Reverts canonical/landscape-dashboard#275