### PR TITLE
fix: responsive issues with button groups, sidebar and overview page

### DIFF
--- a/src/components/layout/PageHeader/PageHeader.module.scss
+++ b/src/components/layout/PageHeader/PageHeader.module.scss
@@ -14,5 +14,5 @@
   background-color: $color-x-light;
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 350;
 }

--- a/src/components/layout/PageHeader/PageHeader.tsx
+++ b/src/components/layout/PageHeader/PageHeader.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, type FC, type ReactNode } from "react";
+import { type FC, type ReactNode, useLayoutEffect, useRef } from "react";
 import classes from "./PageHeader.module.scss";
 import classNames from "classnames";
 import { Link } from "react-router";
@@ -34,7 +34,7 @@ const PageHeader: FC<PageHeaderProps> = ({
       return;
     }
 
-    const height = headerRef.current.getBoundingClientRect().height;
+    const { height } = headerRef.current.getBoundingClientRect();
     document.documentElement.style.setProperty(
       "--pageheader-height",
       `${height}px`,

--- a/src/components/ui/ResponsiveButtons/ResponsiveButtons.module.scss
+++ b/src/components/ui/ResponsiveButtons/ResponsiveButtons.module.scss
@@ -1,0 +1,5 @@
+.grouped {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+}

--- a/src/components/ui/ResponsiveButtons/ResponsiveButtons.test.tsx
+++ b/src/components/ui/ResponsiveButtons/ResponsiveButtons.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ComponentProps } from "react";
+import ResponsiveButtons from "./ResponsiveButtons";
+import { resetScreenSize, setScreenSize } from "@/tests/helpers";
+import { Button, Icon } from "@canonical/react-components";
+
+const simpleButtonClick = vi.fn();
+const buttonWithIconClick = vi.fn();
+const disabledButtonClick = vi.fn();
+
+const buttons: ComponentProps<typeof ResponsiveButtons>["buttons"] = [
+  <button key="primary" onClick={simpleButtonClick}>
+    Simple button
+  </button>,
+  <Button
+    key="button-with-icon"
+    type="button"
+    hasIcon
+    onClick={buttonWithIconClick}
+  >
+    <Icon name="code" />
+    <span>Button with icon</span>
+  </Button>,
+  <Button
+    key="disabled-button"
+    type="button"
+    hasIcon
+    onClick={disabledButtonClick}
+    disabled
+  >
+    Disabled button
+  </Button>,
+];
+
+describe("ResponsiveButtons", () => {
+  beforeEach(() => {
+    resetScreenSize();
+  });
+
+  it("renders every button on large screens", () => {
+    setScreenSize("lg");
+
+    render(<ResponsiveButtons buttons={buttons} collapseFrom="md" />);
+
+    expect(
+      screen.getByRole("button", { name: "Simple button" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Button with icon" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Disabled button" }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the first button visible and collapses the rest on small screens", async () => {
+    setScreenSize("xs");
+
+    render(
+      <ResponsiveButtons
+        buttons={buttons}
+        alwaysVisible={1}
+        menuLabel="Actions"
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Simple button" }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("button", { name: "Button with icon" }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("button", { name: "Disabled button" }),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /actions/i }));
+
+    expect(
+      screen.queryByRole("button", { name: "Button with icon" }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("button", { name: "Disabled button" }),
+    ).toBeInTheDocument();
+  });
+
+  it("fires onClick for a collapsed menu item", async () => {
+    setScreenSize("xs");
+
+    render(<ResponsiveButtons buttons={buttons} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /actions/i }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Simple button" }),
+    );
+
+    expect(simpleButtonClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("disabled button for a collapsed menu item", async () => {
+    setScreenSize("xs");
+
+    render(<ResponsiveButtons buttons={buttons} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /actions/i }));
+
+    expect(
+      screen.getByRole("button", { name: "Disabled button" }),
+    ).toHaveAttribute("aria-disabled");
+  });
+});

--- a/src/components/ui/ResponsiveButtons/ResponsiveButtons.tsx
+++ b/src/components/ui/ResponsiveButtons/ResponsiveButtons.tsx
@@ -1,0 +1,117 @@
+import type { FC, ReactElement, ReactNode } from "react";
+import { isValidElement, useMemo } from "react";
+import { useMediaQuery } from "usehooks-ts";
+import classNames from "classnames";
+import type { MenuLink } from "@canonical/react-components";
+import { ContextualMenu } from "@canonical/react-components";
+import { BREAKPOINT_PX } from "@/constants";
+import classes from "./ResponsiveButtons.module.scss";
+import type { ButtonLikeProps } from "./types";
+import {
+  decorateNode,
+  textFromNode,
+} from "@/components/ui/ResponsiveButtons/helpers";
+
+export interface ResponsiveButtonGroupProps {
+  readonly buttons: ReactNode[];
+  readonly collapseFrom?: keyof typeof BREAKPOINT_PX;
+  readonly alwaysVisible?: number;
+  readonly menuLabel?: string;
+  readonly className?: string;
+  readonly menuPosition?: "left" | "right";
+  readonly grouped?: boolean;
+}
+
+const ResponsiveButtons: FC<ResponsiveButtonGroupProps> = ({
+  buttons,
+  collapseFrom = "md",
+  alwaysVisible = 0,
+  menuLabel = "Actions",
+  className,
+  menuPosition = "right",
+  grouped = true,
+}) => {
+  const isLargeScreen = useMediaQuery(
+    `(min-width: ${BREAKPOINT_PX[collapseFrom]}px)`,
+  );
+
+  const { visibleButtons, collapsedLinks } = useMemo(() => {
+    const visible = isLargeScreen ? buttons : buttons.slice(0, alwaysVisible);
+
+    const collapsed: (MenuLink & { key: string })[] = [];
+
+    buttons.slice(isLargeScreen ? 0 : alwaysVisible).forEach((node, i) => {
+      const index = isLargeScreen ? i : i + alwaysVisible;
+
+      if (
+        isValidElement(node) &&
+        (node.props as ButtonLikeProps).onClick &&
+        !visible.includes(node)
+      ) {
+        const el = node as ReactElement<ButtonLikeProps>;
+
+        collapsed.push({
+          key: `action-${index}`,
+          children: textFromNode(el) || `Action ${index + 1}`,
+          onClick: el.props.onClick,
+          disabled: el.props.disabled,
+        });
+
+        return;
+      }
+
+      if (!visible.includes(node)) {
+        visible.push(node);
+      }
+    });
+
+    return { visibleButtons: visible, collapsedLinks: collapsed };
+  }, [buttons, alwaysVisible, isLargeScreen]);
+
+  const groupedMarkup =
+    grouped && visibleButtons.length > 1 ? (
+      <div className="p-segmented-control">
+        <div className="p-segmented-control__list">
+          {visibleButtons.map(
+            (node, i): ReactNode =>
+              decorateNode(
+                node,
+                i,
+                "p-segmented-control__button u-no-margin--bottom",
+              ),
+          )}
+        </div>
+      </div>
+    ) : (
+      <>
+        {visibleButtons.map(
+          (node, i): ReactNode => decorateNode(node, i, "u-no-margin--bottom"),
+        )}
+      </>
+    );
+
+  return (
+    <div
+      className={classNames(className, {
+        [classes.grouped]: grouped,
+      })}
+    >
+      {visibleButtons.length > 0 && groupedMarkup}
+
+      {collapsedLinks.length > 0 && (
+        <ContextualMenu
+          position={menuPosition}
+          hasToggleIcon
+          toggleLabel={menuLabel}
+          toggleClassName="u-no-margin--bottom"
+          toggleDisabled={collapsedLinks.every(
+            (link) => "disabled" in link && link.disabled,
+          )}
+          links={collapsedLinks}
+        />
+      )}
+    </div>
+  );
+};
+
+export default ResponsiveButtons;

--- a/src/components/ui/ResponsiveButtons/helpers.ts
+++ b/src/components/ui/ResponsiveButtons/helpers.ts
@@ -1,0 +1,40 @@
+import type { ReactElement, ReactNode } from "react";
+import { cloneElement, isValidElement } from "react";
+import type { ButtonLikeProps } from "./types";
+import classNames from "classnames";
+
+export const textFromNode = (node: ReactNode): string => {
+  const collect = (n: ReactNode): string[] => {
+    if (typeof n === "string") {
+      return [n];
+    }
+
+    if (Array.isArray(n)) {
+      return n.flatMap(collect);
+    }
+
+    if (isValidElement(n)) {
+      return collect((n as ReactElement<ButtonLikeProps>).props.children);
+    }
+
+    return [];
+  };
+
+  return collect(node).join(" ").trim();
+};
+
+export const decorateNode = (
+  node: ReactNode,
+  i: number,
+  extraClasses?: string,
+): ReactNode => {
+  if (isValidElement(node)) {
+    const el = node as ReactElement<ButtonLikeProps>;
+    return cloneElement(el, {
+      key: el.key ?? i,
+      className: classNames(extraClasses, el.props.className),
+    });
+  }
+
+  return node;
+};

--- a/src/components/ui/ResponsiveButtons/index.ts
+++ b/src/components/ui/ResponsiveButtons/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ResponsiveButtons";

--- a/src/components/ui/ResponsiveButtons/types.d.ts
+++ b/src/components/ui/ResponsiveButtons/types.d.ts
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react";
+
+export interface ButtonLikeProps {
+  children?: ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+  className?: string;
+  "aria-label"?: string;
+  title?: string;
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,1 @@
+export { default as ResponsiveButtons } from "./ResponsiveButtons";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,3 +31,11 @@ export const COMMON_NUMBERS = {
 };
 export const HOMEPAGE_PATH = "/overview";
 export const DEFAULT_ACCESS_GROUP_NAME = "global";
+export const BREAKPOINT_PX = {
+  xs: 460,
+  sm: 620,
+  md: 768,
+  lg: 1036,
+  xl: 1280,
+  xxl: 1400,
+};

--- a/src/features/access-groups/components/AccessGroupList/AccessGroupList.test.tsx
+++ b/src/features/access-groups/components/AccessGroupList/AccessGroupList.test.tsx
@@ -35,9 +35,7 @@ describe("AccessGroupList", () => {
       );
       expect(confirmationTitle).toBeInTheDocument();
 
-      const confirmationMessage = screen.getByText(
-        /removing this access group will affect/i,
-      );
+      const confirmationMessage = screen.getByText(/irreversible/i);
       expect(confirmationMessage).toBeInTheDocument();
 
       const confirmButton = screen.getByRole("button", { name: /delete/i });

--- a/src/features/access-groups/components/AccessGroupListActions/AccessGroupListActions.tsx
+++ b/src/features/access-groups/components/AccessGroupListActions/AccessGroupListActions.tsx
@@ -82,11 +82,14 @@ const AccessGroupListActions: FC<AccessGroupListActionsProps> = ({
           onConfirm={tryRemove}
           close={closeModal}
         >
+          {count > 0 && (
+            <p>
+              Removing this access group will affect {count}{" "}
+              {pluralize(count, "instance")}. They will now belong to &quot;
+              {parentAccessGroupTitle}&quot;.
+            </p>
+          )}
           <p>
-            Removing this access group will affect {count}{" "}
-            {pluralize(count, "instance")}. They will now belong to &quot;
-            {parentAccessGroupTitle}&quot;.
-            <br />
             This action is <b>irreversible</b>
           </p>
         </ConfirmationModal>

--- a/src/features/alerts/components/AlertsList/AlertsList.test.tsx
+++ b/src/features/alerts/components/AlertsList/AlertsList.test.tsx
@@ -48,7 +48,7 @@ describe("AlertsList", () => {
   });
 
   it("renders AlertsTable component", () => {
-    setScreenSize("large");
+    setScreenSize("lg");
 
     renderWithProviders(
       <AlertsList
@@ -65,7 +65,7 @@ describe("AlertsList", () => {
       ...authProps,
       user: { ...authUser, current_account: "non-existent" },
     });
-    setScreenSize("large");
+    setScreenSize("lg");
 
     renderWithProviders(
       <AlertsList
@@ -78,7 +78,7 @@ describe("AlertsList", () => {
   });
 
   it("renders correctly when there are no alerts", () => {
-    setScreenSize("large");
+    setScreenSize("lg");
 
     renderWithProviders(
       <AlertsList alerts={[]} availableTagOptions={mockAvailableTagOptions} />,
@@ -88,7 +88,7 @@ describe("AlertsList", () => {
   });
 
   it("renders mobile view when screen is small", () => {
-    setScreenSize("small");
+    setScreenSize("xs");
 
     renderWithProviders(
       <AlertsList

--- a/src/features/alerts/components/AlertsTable/AlertsTable.test.tsx
+++ b/src/features/alerts/components/AlertsTable/AlertsTable.test.tsx
@@ -18,7 +18,7 @@ describe("AlertsTable", () => {
   });
 
   it("renders the table in desktop view", () => {
-    setScreenSize("large");
+    setScreenSize("lg");
 
     renderWithProviders(
       <AlertsTable
@@ -38,7 +38,7 @@ describe("AlertsTable", () => {
   });
 
   it("renders the mobile view when screen is small", () => {
-    setScreenSize("small");
+    setScreenSize("xs");
 
     renderWithProviders(
       <AlertsTable
@@ -57,7 +57,7 @@ describe("AlertsTable", () => {
   });
 
   it("handles alert subscription action", async () => {
-    setScreenSize("large");
+    setScreenSize("lg");
 
     renderWithProviders(
       <AlertsTable
@@ -70,7 +70,7 @@ describe("AlertsTable", () => {
       name: /no/i,
     });
 
-    const disabledSwitch = disabledSwitches[0];
+    const [disabledSwitch] = disabledSwitches;
 
     expect(disabledSwitch).not.toBeChecked();
 
@@ -79,7 +79,7 @@ describe("AlertsTable", () => {
   });
 
   it("handles alert unsubscribe action", async () => {
-    setScreenSize("large");
+    setScreenSize("lg");
 
     renderWithProviders(
       <AlertsTable
@@ -101,7 +101,7 @@ describe("AlertsTable", () => {
   });
 
   it('displays "No data available" when there are no alerts', () => {
-    setScreenSize("large");
+    setScreenSize("lg");
 
     renderWithProviders(
       <AlertsTable alerts={[]} availableTagOptions={mockAvailableTagOptions} />,

--- a/src/features/api-credentials/components/ApiCredentialsTables/ApiCredentialsTables.test.tsx
+++ b/src/features/api-credentials/components/ApiCredentialsTables/ApiCredentialsTables.test.tsx
@@ -56,7 +56,7 @@ describe("ApiCredentialsTables", () => {
   });
 
   it("renders the table in desktop view", () => {
-    setScreenSize("large");
+    setScreenSize("lg");
 
     renderWithProviders(
       <ApiCredentialsTables user={mockUser} credentials={mockCredentials} />,
@@ -70,7 +70,7 @@ describe("ApiCredentialsTables", () => {
   });
 
   it("renders the mobile view when screen is small", () => {
-    setScreenSize("small");
+    setScreenSize("xs");
 
     renderWithProviders(
       <ApiCredentialsTables user={mockUser} credentials={mockCredentials} />,
@@ -86,7 +86,7 @@ describe("ApiCredentialsTables", () => {
   });
 
   it("displays 'Generate API credentials' button when no credentials exist", () => {
-    setScreenSize("large");
+    setScreenSize("lg");
 
     renderWithProviders(
       <ApiCredentialsTables user={mockUser} credentials={mockCredentials} />,
@@ -97,7 +97,7 @@ describe("ApiCredentialsTables", () => {
   });
 
   it("displays 'Regenerate API credentials' button when credentials exist", () => {
-    setScreenSize("large");
+    setScreenSize("lg");
 
     renderWithProviders(
       <ApiCredentialsTables user={mockUser} credentials={mockCredentials} />,
@@ -108,7 +108,7 @@ describe("ApiCredentialsTables", () => {
   });
 
   it("handles generate/regenerate button click", async () => {
-    setScreenSize("large");
+    setScreenSize("lg");
 
     renderWithProviders(
       <ApiCredentialsTables user={mockUser} credentials={mockCredentials} />,

--- a/src/features/instances/components/InstancesPageActions/InstancesPageActions.test.tsx
+++ b/src/features/instances/components/InstancesPageActions/InstancesPageActions.test.tsx
@@ -5,6 +5,7 @@ import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach } from "vitest";
 import InstancesPageActions from "./InstancesPageActions";
+import { resetScreenSize, setScreenSize } from "@/tests/helpers";
 
 const selected = instances.slice(0, 2);
 
@@ -20,6 +21,11 @@ const BUTTON_LABELS = [
 describe("InstancesPageActions", () => {
   beforeEach(() => {
     vi.spyOn(Constants, "REPORT_VIEW_ENABLED", "get").mockReturnValue(true);
+    setScreenSize("xxl");
+  });
+
+  afterEach(() => {
+    resetScreenSize();
   });
 
   it("should render correctly", () => {

--- a/src/features/kernel/components/KernelHeader/KernelHeader.test.tsx
+++ b/src/features/kernel/components/KernelHeader/KernelHeader.test.tsx
@@ -1,6 +1,7 @@
 import { renderWithProviders } from "@/tests/render";
 import type { ComponentProps } from "react";
 import KernelHeader from "./KernelHeader";
+import { resetScreenSize, setScreenSize } from "@/tests/helpers";
 
 const props: ComponentProps<typeof KernelHeader> = {
   hasTableData: false,
@@ -20,6 +21,14 @@ const props: ComponentProps<typeof KernelHeader> = {
 };
 
 describe("KernelHeader", () => {
+  beforeEach(() => {
+    setScreenSize("lg");
+  });
+
+  afterEach(() => {
+    resetScreenSize();
+  });
+
   it("renders KernelHeader", () => {
     const { container } = renderWithProviders(<KernelHeader {...props} />);
     expect(container).toHaveTexts([

--- a/src/features/kernel/components/KernelHeader/KernelHeader.tsx
+++ b/src/features/kernel/components/KernelHeader/KernelHeader.tsx
@@ -5,10 +5,11 @@ import type { FC } from "react";
 import { lazy, Suspense } from "react";
 import type { KernelManagementInfo } from "../../types";
 import classes from "./KernelHeader.module.scss";
+import { ResponsiveButtons } from "@/components/ui";
 
-const DowngradeKernelForm = lazy(() => import("../DowngradeKernelForm"));
-const UpgradeKernelForm = lazy(() => import("../UpgradeKernelForm"));
-const RestartInstanceForm = lazy(() => import("../RestartInstanceForm"));
+const DowngradeKernelForm = lazy(async () => import("../DowngradeKernelForm"));
+const UpgradeKernelForm = lazy(async () => import("../UpgradeKernelForm"));
+const RestartInstanceForm = lazy(async () => import("../RestartInstanceForm"));
 
 interface KernelHeaderProps {
   readonly instanceName: string;
@@ -71,18 +72,21 @@ const KernelHeader: FC<KernelHeaderProps> = ({
       <h2 className="p-heading--4 u-no-padding--top u-no-margin--bottom">
         Kernel overview
       </h2>
-      <div key="buttons" className="p-segmented-control">
-        <div className="p-segmented-control__list">
+      <ResponsiveButtons
+        collapseFrom="lg"
+        buttons={[
           <Button
+            key="restart-instance"
             hasIcon
             className="p-segmented-control__button"
             onClick={handleRestartInstance}
           >
             <Icon name="restart" />
             <span>Restart instance</span>
-          </Button>
+          </Button>,
 
           <Button
+            key="downgrade-kernel"
             hasIcon
             className="p-segmented-control__button"
             type="button"
@@ -91,9 +95,10 @@ const KernelHeader: FC<KernelHeaderProps> = ({
           >
             <Icon name="begin-downloading" />
             <span>Downgrade kernel</span>
-          </Button>
+          </Button>,
 
           <Button
+            key="upgrade-kernel"
             hasIcon
             className="p-segmented-control__button"
             type="button"
@@ -102,9 +107,9 @@ const KernelHeader: FC<KernelHeaderProps> = ({
           >
             <Icon name="change-version" />
             <span>Upgrade kernel</span>
-          </Button>
-        </div>
-      </div>
+          </Button>,
+        ]}
+      />
     </div>
   );
 };

--- a/src/features/mirrors/components/DistributionCard/DistributionCard.test.tsx
+++ b/src/features/mirrors/components/DistributionCard/DistributionCard.test.tsx
@@ -75,7 +75,7 @@ describe("DistributionCard", () => {
   });
 
   it("renders menu buttons", async () => {
-    setScreenSize("large");
+    setScreenSize("lg");
 
     renderWithProviders(<DistributionCard {...commonProps} />);
 
@@ -86,7 +86,7 @@ describe("DistributionCard", () => {
   });
 
   it("renders contextual menu buttons", async () => {
-    setScreenSize("small");
+    setScreenSize("xs");
 
     renderWithProviders(<DistributionCard {...commonProps} />);
 

--- a/src/features/mirrors/components/SeriesCard/SeriesCard.test.tsx
+++ b/src/features/mirrors/components/SeriesCard/SeriesCard.test.tsx
@@ -143,7 +143,7 @@ describe("SeriesCard", () => {
   });
 
   it("renders series card buttons", async () => {
-    setScreenSize("large");
+    setScreenSize("lg");
 
     renderWithProviders(<SeriesCard {...propsWithoutSnapshotDate} />);
     expect(
@@ -158,7 +158,7 @@ describe("SeriesCard", () => {
   });
 
   it("renders series card contextual buttons", async () => {
-    setScreenSize("small");
+    setScreenSize("xs");
 
     renderWithProviders(<SeriesCard {...propsWithoutSnapshotDate} />);
 
@@ -174,7 +174,7 @@ describe("SeriesCard", () => {
   });
 
   it("renders series card with snapshot date and only remove button", () => {
-    setScreenSize("small");
+    setScreenSize("xs");
 
     renderWithProviders(<SeriesCard {...propsWithSnapshotDate} />);
 
@@ -194,7 +194,7 @@ describe("SeriesCard", () => {
   });
 
   it("renders only remove button on smaller screen", async () => {
-    setScreenSize("small");
+    setScreenSize("xs");
 
     renderWithProviders(<SeriesCard {...propsWithSnapshotDate} />);
 

--- a/src/features/mirrors/components/SeriesPocketList/SeriesPocketList.test.tsx
+++ b/src/features/mirrors/components/SeriesPocketList/SeriesPocketList.test.tsx
@@ -19,8 +19,9 @@ describe("SeriesPocketList", () => {
   afterEach(() => {
     resetScreenSize();
   });
+
   it("renders table series pocket list for big screens", () => {
-    setScreenSize("large");
+    setScreenSize("lg");
 
     const { container } = renderWithProviders(<SeriesPocketList {...props} />);
 
@@ -31,7 +32,7 @@ describe("SeriesPocketList", () => {
   });
 
   it("renders table series pocket list for small screens", () => {
-    setScreenSize("small");
+    setScreenSize("xs");
 
     renderWithProviders(<SeriesPocketList {...props} />);
 

--- a/src/features/overview/components/ChartContainer/ChartContainer.tsx
+++ b/src/features/overview/components/ChartContainer/ChartContainer.tsx
@@ -13,11 +13,13 @@ const ChartContainer: FC = () => {
     limit: 1,
     root_only: false,
   });
+
   const { data: packageUpgrades } = getInstancesQuery({
     query: "alert:package-upgrades",
     limit: 1,
     root_only: false,
   });
+
   const { data: upToDateInstances } = getInstancesQuery({
     query: "NOT alert:package-upgrades",
     limit: 1,
@@ -55,9 +57,9 @@ const ChartContainer: FC = () => {
   };
 
   const data = getChartData({
-    chartData: chartData.map((data, index) => ({
+    chartData: chartData.map((info, index) => ({
       backgroundColors: [chartColors[index], Colors.WHITE],
-      ...data,
+      ...info,
     })),
     totalInstances: totalInstances,
   });

--- a/src/features/overview/components/Legend/Legend.module.scss
+++ b/src/features/overview/components/Legend/Legend.module.scss
@@ -8,6 +8,11 @@
   height: 100%;
   justify-content: space-between;
   width: 100%;
+
+  @media (width >= 1300px) and (width < 1550px) {
+    align-items: flex-start;
+    flex-direction: column;
+  }
 }
 
 .legendItem__icon {
@@ -37,5 +42,12 @@
   @media (min-width: $breakpoint-large) {
     border-right: 1px solid $color-mid-light;
     padding-right: $sp-x-large;
+  }
+
+  @media (width >= 1300px) and (width < 1550px) {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: $sp-large;
+    padding-right: 0;
   }
 }

--- a/src/features/overview/components/PieChart/PieChart.module.scss
+++ b/src/features/overview/components/PieChart/PieChart.module.scss
@@ -13,7 +13,7 @@
     padding-right: 0;
   }
 
-  @media (min-width: $breakpoint-small) {
+  @media (width >= 1300px) {
     flex-direction: column;
     width: 45%;
   }
@@ -30,11 +30,11 @@
   flex-direction: column;
   height: 100%;
 
-  @media (min-width: $breakpoint-large) {
+  @media (width >= 1300px) {
     flex-direction: row;
   }
 
-  @media (width <= calc(#{$breakpoint-small} - 1px)) {
+  @media (width < 1300px) {
     flex-direction: row;
     width: 100%;
   }

--- a/src/features/packages/components/PackageActions/PackageActions.tsx
+++ b/src/features/packages/components/PackageActions/PackageActions.tsx
@@ -8,6 +8,7 @@ import { INSTALLED_PACKAGE_ACTIONS } from "../../constants";
 import type { InstalledPackageAction, InstancePackage } from "../../types";
 import classes from "./PackageActions.module.scss";
 import { pluralize } from "@/utils/_helpers";
+import { ResponsiveButtons } from "@/components/ui";
 
 const InstalledPackagesActionForm = lazy(
   async () => import("../InstalledPackagesActionForm"),
@@ -79,11 +80,9 @@ const PackageActions: FC<PackageActionsProps> = ({ selectedPackages }) => {
         <i className="p-icon--plus" />
         <span>Install</span>
       </Button>
-      <div
-        key="buttons"
-        className={classNames("p-segmented-control is-small", classes.noWrap)}
-      >
-        {Object.keys(INSTALLED_PACKAGE_ACTIONS)
+      <ResponsiveButtons
+        collapseFrom="lg"
+        buttons={Object.keys(INSTALLED_PACKAGE_ACTIONS)
           .filter((packageAction) => packageAction !== "downgrade")
           .map((key) => key as Exclude<InstalledPackageAction, "downgrade">)
           .sort(
@@ -105,7 +104,7 @@ const PackageActions: FC<PackageActionsProps> = ({ selectedPackages }) => {
               <span>{INSTALLED_PACKAGE_ACTIONS[packageAction].label}</span>
             </Button>
           ))}
-      </div>
+      />
     </div>
   );
 };

--- a/src/features/snaps/components/SnapsActions/SnapActions.module.scss
+++ b/src/features/snaps/components/SnapsActions/SnapActions.module.scss
@@ -1,7 +1,3 @@
 .container {
   display: flex;
 }
-
-.noWrap {
-  white-space: nowrap;
-}

--- a/src/features/snaps/components/SnapsActions/SnapsActions.test.tsx
+++ b/src/features/snaps/components/SnapsActions/SnapsActions.test.tsx
@@ -5,6 +5,7 @@ import SnapsActions from "./SnapsActions";
 import { renderWithProviders } from "@/tests/render";
 import { installedSnaps } from "@/tests/mocks/snap";
 import { getSelectedSnaps } from "../../helpers";
+import { resetScreenSize, setScreenSize } from "@/tests/helpers";
 
 const snapData = {
   empty: [],
@@ -44,6 +45,14 @@ const formUnheldSnapButtons = [
 ];
 
 describe("SnapsActions", () => {
+  beforeEach(() => {
+    setScreenSize("lg");
+  });
+
+  afterEach(() => {
+    resetScreenSize();
+  });
+
   describe("Snap buttons in table", () => {
     it("renders table buttons", () => {
       const { container } = renderWithProviders(

--- a/src/features/snaps/components/SnapsActions/SnapsActions.tsx
+++ b/src/features/snaps/components/SnapsActions/SnapsActions.tsx
@@ -14,6 +14,7 @@ import EditSnap from "../EditSnap";
 import InstallSnaps from "../InstallSnaps";
 import classes from "./SnapActions.module.scss";
 import { pluralize } from "@/utils/_helpers";
+import { ResponsiveButtons } from "@/components/ui";
 
 interface SnapsActionProps {
   readonly selectedSnapIds: string[];
@@ -69,75 +70,77 @@ const SnapsActions: FC<SnapsActionProps> = ({
           <span>Install</span>
         </Button>
       )}
-      <div
-        key="buttons"
-        className={classNames(
-          "p-segmented-control is-small u-no-margin--bottom",
-          classes.noWrap,
-        )}
-      >
-        {singleSnap && sidePanel && (
+      <ResponsiveButtons
+        collapseFrom="lg"
+        buttons={[
+          singleSnap && sidePanel && (
+            <Button
+              key="switch-channel"
+              type="button"
+              className="p-segmented-control__button has-icon u-no-margin--bottom"
+              disabled={0 === selectedSnapIds.length}
+              onClick={() => {
+                handleEditSnap(EditSnapType.Switch);
+              }}
+            >
+              <Icon name="fork" />
+              <span>Switch channel</span>
+            </Button>
+          ),
           <Button
+            type="button"
+            key="uninstall"
+            className="p-segmented-control__button has-icon u-no-margin--bottom"
+            disabled={0 === selectedSnapIds.length}
+            onClick={() => {
+              handleEditSnap(EditSnapType.Uninstall);
+            }}
+          >
+            <Icon name={ICONS.delete} />
+            <span>Uninstall</span>
+          </Button>,
+          (singleSnap?.held_until === null || !sidePanel) && (
+            <Button
+              key="hold"
+              type="button"
+              className="p-segmented-control__button has-icon u-no-margin--bottom"
+              disabled={0 === unheld}
+              onClick={() => {
+                handleEditSnap(EditSnapType.Hold);
+              }}
+            >
+              <Icon name="pause" />
+              <span>Hold</span>
+            </Button>
+          ),
+          (singleSnap?.held_until !== null || !sidePanel) && (
+            <Button
+              key="unhold"
+              type="button"
+              className="p-segmented-control__button has-icon u-no-margin--bottom"
+              disabled={0 === held}
+              onClick={() => {
+                handleEditSnap(EditSnapType.Unhold);
+              }}
+            >
+              <Icon name="play" />
+              <span>Unhold</span>
+            </Button>
+          ),
+          <Button
+            key="refresh"
             type="button"
             className="p-segmented-control__button has-icon u-no-margin--bottom"
             disabled={0 === selectedSnapIds.length}
             onClick={() => {
-              handleEditSnap(EditSnapType.Switch);
+              handleEditSnap(EditSnapType.Refresh);
             }}
           >
-            <Icon name="fork" />
-            <span>Switch channel</span>
-          </Button>
-        )}
-        <Button
-          type="button"
-          className="p-segmented-control__button has-icon u-no-margin--bottom"
-          disabled={0 === selectedSnapIds.length}
-          onClick={() => {
-            handleEditSnap(EditSnapType.Uninstall);
-          }}
-        >
-          <Icon name={ICONS.delete} />
-          <span>Uninstall</span>
-        </Button>
-        {(singleSnap?.held_until === null || !sidePanel) && (
-          <Button
-            type="button"
-            className="p-segmented-control__button has-icon u-no-margin--bottom"
-            disabled={0 === unheld}
-            onClick={() => {
-              handleEditSnap(EditSnapType.Hold);
-            }}
-          >
-            <Icon name="pause" />
-            <span>Hold</span>
-          </Button>
-        )}
-        {(singleSnap?.held_until !== null || !sidePanel) && (
-          <Button
-            type="button"
-            className="p-segmented-control__button has-icon u-no-margin--bottom"
-            disabled={0 === held}
-            onClick={() => {
-              handleEditSnap(EditSnapType.Unhold);
-            }}
-          >
-            <Icon name="play" />
-            <span>Unhold</span>
-          </Button>
-        )}
-        <Button
-          type="button"
-          className="p-segmented-control__button has-icon u-no-margin--bottom"
-          disabled={0 === selectedSnapIds.length}
-          onClick={() => {
-            handleEditSnap(EditSnapType.Refresh);
-          }}
-        >
-          <Icon name="change-version" />
-          <span>Refresh</span>
-        </Button>
-      </div>
+            <Icon name="change-version" />
+            <span>Refresh</span>
+          </Button>,
+        ]}
+      />
     </div>
   );
 };

--- a/src/features/snaps/components/SnapsList/SnapsList.test.tsx
+++ b/src/features/snaps/components/SnapsList/SnapsList.test.tsx
@@ -7,6 +7,7 @@ import SnapsList from "./SnapsList";
 import moment from "moment";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import NoData from "@/components/layout/NoData";
+import { setScreenSize } from "@/tests/helpers";
 
 async function findSnapByName(name: string) {
   return await screen.findByRole("button", {
@@ -125,6 +126,8 @@ describe("SnapsList", () => {
       renderWithProviders(<SnapsList {...props} />);
 
       await clickSnapOnTable(selectedSnap.snap.name);
+
+      setScreenSize("lg");
     });
 
     it("should open side panel when snap in table is clicked", async () => {

--- a/src/pages/dashboard/instances/InstancesPage/InstancesPage.module.scss
+++ b/src/pages/dashboard/instances/InstancesPage/InstancesPage.module.scss
@@ -1,8 +1,0 @@
-@import "vanilla-framework/scss/settings_colors";
-
-.header {
-  background-color: $color-x-light;
-  position: sticky;
-  top: 0;
-  z-index: 10;
-}

--- a/src/pages/dashboard/instances/InstancesPage/InstancesPage.tsx
+++ b/src/pages/dashboard/instances/InstancesPage/InstancesPage.tsx
@@ -4,7 +4,6 @@ import PageMain from "@/components/layout/PageMain";
 import PageHeader from "@/components/layout/PageHeader";
 import PageContent from "@/components/layout/PageContent";
 import InstancesContainer from "@/pages/dashboard/instances/InstancesContainer/InstancesContainer";
-import classes from "./InstancesPage.module.scss";
 import type { Instance } from "@/types/Instance";
 import { InstancesPageActions } from "@/features/instances";
 
@@ -15,8 +14,8 @@ const InstancesPage: FC = () => {
     <PageMain>
       <PageHeader
         title="Instances"
-        className={classes.header}
         actions={[<InstancesPageActions key="actions" selected={selected} />]}
+        sticky
       />
       <PageContent>
         <InstancesContainer

--- a/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.test.tsx
@@ -9,6 +9,7 @@ import useAuth from "@/hooks/useAuth";
 import type { AuthContextProps } from "@/context/auth";
 import { authUser } from "@/tests/mocks/auth";
 import type { FeatureKey } from "@/types/FeatureKey";
+import { setScreenSize } from "@/tests/helpers";
 
 const PROPS_TO_CHECK: (keyof Instance)[] = [
   "title",
@@ -37,6 +38,7 @@ describe("InfoPanel", () => {
     beforeEach(() => {
       vi.mocked(useAuth).mockReturnValue(authProps);
       renderWithProviders(<InfoPanel instance={instances[0]} />);
+      setScreenSize("xxl");
     });
 
     it("should render instance info", () => {

--- a/src/pages/dashboard/instances/[single]/tabs/users/UserList/UserList.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/UserList/UserList.test.tsx
@@ -7,7 +7,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, vi } from "vitest";
 import UserList from "./UserList";
 import NoData from "@/components/layout/NoData";
-import { expectLoadingState } from "@/tests/helpers";
+import { expectLoadingState, setScreenSize } from "@/tests/helpers";
 
 const userIds = users.map((user) => user.uid);
 const unlockedUser = users.find((user) => user.enabled);
@@ -84,6 +84,7 @@ describe("UserList", () => {
   describe("User details sidepanel", () => {
     beforeEach(() => {
       renderWithProviders(<UserList {...props} />);
+      setScreenSize("lg");
     });
     it("should open side panel when user in table is clicked", async () => {
       const user = await screen.findByRole("button", {

--- a/src/pages/dashboard/instances/[single]/tabs/users/UserPanelActionButtons/UserPanelActionButtons.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/UserPanelActionButtons/UserPanelActionButtons.test.tsx
@@ -5,6 +5,7 @@ import { renderWithProviders } from "@/tests/render";
 import UserPanelActionButtons from "./UserPanelActionButtons";
 import { users } from "@/tests/mocks/user";
 import { getSelectedUsers } from "../UserPanelHeader/helpers";
+import { resetScreenSize, setScreenSize } from "@/tests/helpers";
 
 const userData = {
   empty: [],
@@ -28,6 +29,14 @@ const formLockedUserButtons = ["Unlock", "Edit", "Delete"];
 const formUnlockedUserButtons = ["Lock", "Edit", "Delete"];
 
 describe("UserPanelActionButtons", () => {
+  beforeEach(() => {
+    setScreenSize("lg");
+  });
+
+  afterEach(() => {
+    resetScreenSize();
+  });
+
   describe("User buttons in table", () => {
     it("renders table buttons", () => {
       const { container } = renderWithProviders(
@@ -51,9 +60,9 @@ describe("UserPanelActionButtons", () => {
         for (const button of tableUserButtons) {
           const actionButton = screen.getByRole("button", { name: button });
           if (button !== "Add user") {
-            expect(actionButton).toBeDisabled();
+            expect(actionButton).toHaveAttribute("aria-disabled");
           } else {
-            expect(actionButton).not.toBeDisabled();
+            expect(actionButton).not.toHaveAttribute("aria-disabled");
           }
         }
       });
@@ -69,7 +78,7 @@ describe("UserPanelActionButtons", () => {
           />,
         );
         const unlockButton = screen.getByRole("button", { name: "Unlock" });
-        expect(unlockButton).toBeDisabled();
+        expect(unlockButton).toHaveAttribute("aria-disabled");
       });
 
       it("Lock button disabled when only locked users are selected", () => {
@@ -83,7 +92,7 @@ describe("UserPanelActionButtons", () => {
           />,
         );
         const lockButton = screen.getByRole("button", { name: "Lock" });
-        expect(lockButton).toBeDisabled();
+        expect(lockButton).toHaveAttribute("aria-disabled");
       });
 
       it("Lock and Unlock enabled when only locked and unlocked users are selected", () => {

--- a/src/pages/dashboard/instances/[single]/tabs/users/UserPanelActionButtons/UserPanelActionButtons.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/UserPanelActionButtons/UserPanelActionButtons.tsx
@@ -1,6 +1,6 @@
 import {
   Button,
-  ConfirmationButton,
+  ConfirmationModal,
   Icon,
   ICONS,
   Input,
@@ -23,6 +23,7 @@ import {
 import LoadingState from "@/components/layout/LoadingState";
 import { useParams } from "react-router";
 import type { UrlParams } from "@/types/UrlParams";
+import { ResponsiveButtons } from "@/components/ui";
 
 const EditUserForm = lazy(
   async () =>
@@ -48,6 +49,9 @@ const UserPanelActionButtons: FC<UserPanelActionButtonsProps> = ({
   const { notify } = useNotify();
   const { setSidePanelContent, closeSidePanel } = useSidePanel();
   const { removeUserQuery, lockUserQuery, unlockUserQuery } = useUsers();
+  const [lockOpen, setLockOpen] = useState(false);
+  const [unlockOpen, setUnlockOpen] = useState(false);
+  const [removeOpen, setRemoveOpen] = useState(false);
 
   const { mutateAsync: removeUserMutation, isPending: isRemoving } =
     removeUserQuery;
@@ -115,138 +119,156 @@ const UserPanelActionButtons: FC<UserPanelActionButtonsProps> = ({
   };
 
   return (
-    <div
-      className={classNames("p-panel__controls u-no-padding--top", {
-        "u-no-margin--left": sidePanel,
-      })}
-    >
-      {!sidePanel && (
-        <Button
-          className={classNames("u-no-margin--right", {
-            "u-no-margin--bottom": !sidePanel,
-          })}
-          type="button"
-          hasIcon
-          onClick={handleAddUser}
-        >
-          <Icon name={ICONS.plus} />
-          <span>Add user</span>
-        </Button>
-      )}
-      <div className="p-segmented-control">
-        <div className="p-segmented-control__list">
-          {(user?.enabled || !sidePanel) && (
-            <ConfirmationButton
-              className={classNames("p-segmented-control__button has-icon", {
-                "u-no-margin--bottom": !sidePanel,
-              })}
-              type="button"
-              disabled={unlockedUsersCount === 0}
-              aria-disabled={unlockedUsersCount === 0}
-              confirmationModalProps={{
-                title: `Lock ${
-                  user
-                    ? `user ${user.username}`
-                    : `${selectedUsers.length} users`
-                }`,
-                children: renderModalBody({
-                  user: user,
-                  selectedUsers: selectedUsers,
-                  userAction: UserAction.Lock,
-                }),
-                confirmButtonLabel: "Lock",
-                confirmButtonAppearance: "positive",
-                confirmButtonLoading: isLocking,
-                confirmButtonDisabled: isLocking,
-                onConfirm: lockUser,
-              }}
-            >
-              <Icon name="lock-locked" />
-              <span>Lock</span>
-            </ConfirmationButton>
-          )}
-          {(!user?.enabled || !sidePanel) && (
-            <ConfirmationButton
-              className={classNames("p-segmented-control__button has-icon", {
-                "u-no-margin--bottom": !sidePanel,
-              })}
-              type="button"
-              disabled={lockedUsersCount === 0}
-              aria-disabled={lockedUsersCount === 0}
-              confirmationModalProps={{
-                title: `Unlock ${
-                  user
-                    ? `user ${user.username}`
-                    : `${selectedUsers.length} users`
-                }`,
-                children: renderModalBody({
-                  user: user,
-                  selectedUsers: selectedUsers,
-                  userAction: UserAction.Unlock,
-                }),
-                confirmButtonLabel: "Unlock",
-                confirmButtonAppearance: "positive",
-                confirmButtonLoading: isUnlocking,
-                confirmButtonDisabled: isUnlocking,
-                onConfirm: unlockUser,
-              }}
-            >
-              <Icon name="lock-unlock" />
-              <span>Unlock</span>
-            </ConfirmationButton>
-          )}
-          {sidePanel && user && (
-            <Button
-              className={classNames("p-segmented-control__button has-icon", {
-                "u-no-margin--bottom": !sidePanel,
-              })}
-              type="button"
-              onClick={() => {
-                handleEditUser(user);
-              }}
-            >
-              <Icon name="edit" />
-              <span>Edit</span>
-            </Button>
-          )}
-
-          <ConfirmationButton
-            className={classNames("p-segmented-control__button has-icon", {
+    <>
+      <div
+        className={classNames("p-panel__controls u-no-padding--top", {
+          "u-no-margin--left": sidePanel,
+        })}
+      >
+        {!sidePanel && (
+          <Button
+            className={classNames("u-no-margin--right", {
               "u-no-margin--bottom": !sidePanel,
             })}
             type="button"
-            disabled={0 === selectedUsers.length}
-            aria-disabled={0 === selectedUsers.length}
-            confirmationModalProps={{
-              title: `Delete ${user ? user.username : "users"}`,
-              children: (
-                <div>
-                  <p className="u-no-margin--bottom">
-                    {user
-                      ? `This will delete user ${user.username}. You can delete this user's home folders at the same time.`
-                      : "This will delete selected users. You can delete their home folders as well."}
-                  </p>
-                  <Input
-                    label="Delete the home folders as well"
-                    type="checkbox"
-                    checked={confirmDeleteHomeFolders}
-                    onChange={handleToggleDeleteUserHomeFolders}
-                  />
-                </div>
-              ),
-              confirmButtonLabel: "Delete",
-              confirmButtonAppearance: "negative",
-              confirmButtonLoading: isRemoving,
-              confirmButtonDisabled: isRemoving,
-              onConfirm: removeUser,
-            }}
+            hasIcon
+            onClick={handleAddUser}
           >
-            <Icon name={ICONS.delete} />
-            <span>Delete</span>
-          </ConfirmationButton>
-        </div>
+            <Icon name={ICONS.plus} />
+            <span>Add user</span>
+          </Button>
+        )}
+        <ResponsiveButtons
+          collapseFrom="lg"
+          buttons={[
+            (user?.enabled || !sidePanel) && (
+              <Button
+                key="lock"
+                hasIcon
+                type="button"
+                disabled={unlockedUsersCount === 0}
+                onClick={() => {
+                  setLockOpen(true);
+                }}
+              >
+                <Icon name="lock-locked" />
+                <span>Lock</span>
+              </Button>
+            ),
+            (!user?.enabled || !sidePanel) && (
+              <Button
+                key="unlock"
+                hasIcon
+                type="button"
+                disabled={lockedUsersCount === 0}
+                onClick={() => {
+                  setUnlockOpen(true);
+                }}
+              >
+                <Icon name="lock-unlock" />
+                <span>Unlock</span>
+              </Button>
+            ),
+            sidePanel && user && (
+              <Button
+                key="edit"
+                className={classNames("p-segmented-control__button has-icon", {
+                  "u-no-margin--bottom": !sidePanel,
+                })}
+                type="button"
+                onClick={() => {
+                  handleEditUser(user);
+                }}
+              >
+                <Icon name="edit" />
+                <span>Edit</span>
+              </Button>
+            ),
+            <Button
+              key="delete"
+              hasIcon
+              type="button"
+              disabled={0 === selectedUsers.length}
+              onClick={() => {
+                setRemoveOpen(true);
+              }}
+            >
+              <Icon name={ICONS.delete} />
+              <span>Delete</span>
+            </Button>,
+          ]}
+        />
       </div>
-    </div>
+      {lockOpen && (
+        <ConfirmationModal
+          title={`Lock ${
+            user ? `user ${user.username}` : `${selectedUsers.length} users`
+          }`}
+          close={() => {
+            setLockOpen(false);
+          }}
+          confirmButtonLabel="Lock"
+          confirmButtonAppearance="positive"
+          confirmButtonLoading={isLocking}
+          confirmButtonDisabled={isLocking}
+          onConfirm={lockUser}
+        >
+          {renderModalBody({
+            user: user,
+            selectedUsers: selectedUsers,
+            userAction: UserAction.Lock,
+          })}
+        </ConfirmationModal>
+      )}
+      {unlockOpen && (
+        <ConfirmationModal
+          title={`Unlock ${
+            user ? `user ${user.username}` : `${selectedUsers.length} users`
+          }`}
+          close={() => {
+            setUnlockOpen(false);
+          }}
+          confirmButtonLabel="Unlock"
+          confirmButtonAppearance="positive"
+          confirmButtonLoading={isUnlocking}
+          confirmButtonDisabled={isUnlocking}
+          onConfirm={unlockUser}
+        >
+          {renderModalBody({
+            user: user,
+            selectedUsers: selectedUsers,
+            userAction: UserAction.Unlock,
+          })}
+        </ConfirmationModal>
+      )}
+      {removeOpen && (
+        <ConfirmationModal
+          title={`Delete ${user ? user.username : "users"}`}
+          close={() => {
+            setRemoveOpen(false);
+          }}
+          confirmButtonLabel="Delete"
+          confirmButtonAppearance="negative"
+          confirmButtonLoading={isRemoving}
+          confirmButtonDisabled={isRemoving}
+          onConfirm={removeUser}
+        >
+          <div>
+            <p className="u-no-margin--bottom">
+              {user
+                ? `This will delete user ${user.username}. You can delete this user's home folders at the same time.`
+                : "This will delete selected users. You can delete their home folders as well."}
+            </p>
+            <Input
+              label="Delete the home folders as well"
+              type="checkbox"
+              checked={confirmDeleteHomeFolders}
+              onChange={handleToggleDeleteUserHomeFolders}
+            />
+          </div>
+        </ConfirmationModal>
+      )}
+    </>
   );
 };
 

--- a/src/pages/dashboard/overview/OverviewPage.module.scss
+++ b/src/pages/dashboard/overview/OverviewPage.module.scss
@@ -6,7 +6,7 @@
   flex-direction: column;
   gap: $sp-large;
 
-  @media (min-width: $breakpoint-small) {
+  @media (width >= 1300px) {
     flex-direction: row;
   }
 }

--- a/src/styles/partials/modal.scss
+++ b/src/styles/partials/modal.scss
@@ -1,4 +1,6 @@
 .p-modal {
+  z-index: 350;
+
   &__footer {
     & > button {
       margin-bottom: 0 !important;

--- a/src/templates/dashboard/DesktopHeader.module.scss
+++ b/src/templates/dashboard/DesktopHeader.module.scss
@@ -15,7 +15,7 @@
 .logoImg,
 .logoIcon {
   display: block;
-  margin-left: calc($sph--x-small + 1px);
+  margin-left: 2px;
 }
 
 .logoIcon {

--- a/src/templates/dashboard/OrganisationSwitch/OrganisationSwitch.tsx
+++ b/src/templates/dashboard/OrganisationSwitch/OrganisationSwitch.tsx
@@ -17,11 +17,13 @@ const OrganisationSwitch = () => {
 
   if (isOnSubdomain || options.length === 1) {
     return (
-      <InfoItem
-        label="Organization"
-        value={currentAccount.title}
-        className={classes.organisation}
-      />
+      <div className={classes.container}>
+        <InfoItem
+          label="Organization"
+          value={currentAccount.title}
+          className={classes.organisation}
+        />
+      </div>
     );
   }
 

--- a/src/templates/dashboard/Sidebar.module.scss
+++ b/src/templates/dashboard/Sidebar.module.scss
@@ -1,4 +1,5 @@
 @import "vanilla-framework/scss/settings_spacing";
+@import "vanilla-framework/scss/settings_breakpoints";
 
 .container {
   display: flex;
@@ -15,4 +16,14 @@
 
 .footer {
   margin-top: auto;
+}
+
+:global(.l-navigation) {
+  z-index: 450;
+}
+
+@media (width >= $breakpoint-small) and (width < $breakpoint-large) {
+  :global(.l-navigation.is-collapsed:not(:hover, :focus-within, .is-pinned)) {
+    width: 3rem;
+  }
 }

--- a/src/templates/dashboard/Sidebar.tsx
+++ b/src/templates/dashboard/Sidebar.tsx
@@ -17,7 +17,9 @@ const Sidebar: FC = () => {
       <div className="l-navigation-bar">
         <div className="p-panel is-dark">
           <MobileHeader
-            toggleMenu={() => setMenuClosed((prevValue) => !prevValue)}
+            toggleMenu={() => {
+              setMenuClosed((prevValue) => !prevValue);
+            }}
           />
         </div>
       </div>
@@ -27,7 +29,12 @@ const Sidebar: FC = () => {
         <div className="l-navigation__drawer">
           <div className="p-panel is-dark">
             <div className={classes.container}>
-              <DesktopHeader closeMenu={() => setMenuClosed(true)} />
+              <DesktopHeader
+                closeMenu={() => {
+                  setMenuClosed(true);
+                }}
+              />
+
               <div className={classes.navigation}>
                 <OrganisationSwitch />
                 <Navigation />

--- a/src/tests/helpers.ts
+++ b/src/tests/helpers.ts
@@ -1,6 +1,6 @@
 import { expect } from "vitest";
 import { screen, waitForElementToBeRemoved } from "@testing-library/react";
-import { COMMON_NUMBERS } from "@/constants";
+import { BREAKPOINT_PX, COMMON_NUMBERS } from "@/constants";
 
 export const expectLoadingState = async (): Promise<void> => {
   const loadingSpinner = await screen.findByRole("status");
@@ -66,12 +66,19 @@ export const restoreRangeBoundingClientRect = (): void => {
   }
 };
 
-export const setScreenSize = (size: "small" | "large"): void => {
-  if (size === "small") {
-    mockMatchMedia([{ query: "(min-width: 620px)", matches: false }]);
-  } else {
-    mockMatchMedia([{ query: "(min-width: 620px)", matches: true }]);
+export const setScreenSize = (bp: keyof typeof BREAKPOINT_PX): void => {
+  const currentWidth = BREAKPOINT_PX[bp];
+
+  if (currentWidth === undefined) {
+    throw new Error(`Unknown breakpoint "${bp}"`);
   }
+
+  const mediaConfig = Object.entries(BREAKPOINT_PX).map(([_, px]) => ({
+    query: `(min-width: ${px}px)`,
+    matches: currentWidth >= px,
+  }));
+
+  mockMatchMedia(mediaConfig);
 };
 
 export function resetScreenSize(): void {


### PR DESCRIPTION
1. Button groups on /instances and inside a single instance (info, kernel, packages, snaps, users
2. The "Upgrades" widget on /overview
3. Org. name in the collapsed sidebar