### PR TITLE
refactor: add optional chaining and default fallbacks

### DIFF
--- a/src/features/employee-groups/components/AssignAutoInstallFileForm/AssignAutoInstallFileForm.tsx
+++ b/src/features/employee-groups/components/AssignAutoInstallFileForm/AssignAutoInstallFileForm.tsx
@@ -61,12 +61,12 @@ const AssignAutoInstallFileForm: FC<AssignAutoInstallFileFormProps> = ({
     notify.success({
       title: `Successfully reassigned ${filename} to ${pluralize(
         employeeGroups.length,
-        `${employeeGroups[0].name} group`,
+        `${employeeGroups[0]?.name ?? "1"} group`,
         `${employeeGroups.length} groups`,
       )}.`,
       message: `Autoinstall file assigned to ${affectedEmployeesAmount} employees${pluralize(
         employeeGroups.length,
-        ` in ${employeeGroups[0].name} group`,
+        ` in ${employeeGroups[0]?.name ?? "1"} group`,
         ` across ${employeeGroups.length} groups`,
       )}.`,
     });

--- a/src/features/employee-groups/components/EmployeeGroupsHeader/EmployeeGroupsHeader.tsx
+++ b/src/features/employee-groups/components/EmployeeGroupsHeader/EmployeeGroupsHeader.tsx
@@ -76,7 +76,7 @@ const EmployeeGroupsHeader: FC<EmployeeGroupsHeaderProps> = ({
   const handleAssignAutoinstallFile = () => {
     const formTitle = pluralize(
       selectedGroups.length,
-      `Reassign autoinstall file to ${selectedGroups[0].name}`,
+      `Reassign autoinstall file to ${selectedGroups[0]?.name ?? "employee group"}`,
       `Reassign autoinstall files to ${selectedGroups.length} employee groups`,
     );
 

--- a/src/features/employee-groups/components/EmployeeGroupsOrganiserForm/EmployeeGroupsOrganiserForm.tsx
+++ b/src/features/employee-groups/components/EmployeeGroupsOrganiserForm/EmployeeGroupsOrganiserForm.tsx
@@ -51,7 +51,7 @@ const EmployeeGroupsOrganiserForm: FC<EmployeeGroupsOrganiserFormProps> = ({
 
       const message = pluralize(
         updatedGroups.length,
-        `You've successfully updated priority for the ${updatedGroups[0].name} group.`,
+        `You've successfully updated priority for the ${updatedGroups[0]?.name ?? ""} group.`,
         `You've successfully updated priorities for ${updatedGroups.length} ${pluralize(updatedGroups.length, "group")}.`,
       );
 

--- a/src/features/instances/components/AccessGroupChange/AccessGroupChange.test.tsx
+++ b/src/features/instances/components/AccessGroupChange/AccessGroupChange.test.tsx
@@ -3,13 +3,15 @@ import { renderWithProviders } from "@/tests/render";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import AccessGroupChange from "./AccessGroupChange";
+import { pluralize } from "@/utils/_helpers";
 
-const selected = instances.slice(0, 2);
+const selectedMultiple = instances.slice(0, 2);
+const selectedSingle = instances.slice(0, 1);
 const newAccessGroup = "test";
 
 describe("AccessGroupChange", () => {
-  test("should Assign access group for selected instances", async () => {
-    renderWithProviders(<AccessGroupChange selected={selected} />);
+  it("should Assign access group for single selected instance", async () => {
+    renderWithProviders(<AccessGroupChange selected={selectedSingle} />);
 
     expect(
       screen.queryByText("This field is required"),
@@ -30,7 +32,34 @@ describe("AccessGroupChange", () => {
     expect(screen.getByText("Access group changed")).toBeInTheDocument();
     expect(
       screen.getByText(
-        `Access group for ${selected.length} instances successfully changed to ${newAccessGroup}`,
+        `Access group for ${pluralize(selectedSingle.length, `"${selectedSingle[0]?.title ?? ""}" instance`, `${selectedSingle.length} instances`)} successfully changed to ${newAccessGroup}`,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("should Assign access group for selected instances", async () => {
+    renderWithProviders(<AccessGroupChange selected={selectedMultiple} />);
+
+    expect(
+      screen.queryByText("This field is required"),
+    ).not.toBeInTheDocument();
+
+    const select = await screen.findByRole("combobox", {
+      name: /access group/i,
+    });
+
+    await userEvent.selectOptions(select, newAccessGroup);
+
+    expect(
+      screen.queryByText("This field is required"),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /assign/i }));
+
+    expect(screen.getByText("Access group changed")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `Access group for ${pluralize(selectedMultiple.length, `"${selectedMultiple[0]?.title ?? ""}" instance`, `${selectedMultiple.length} instances`)} successfully changed to ${newAccessGroup}`,
       ),
     ).toBeInTheDocument();
   });

--- a/src/features/instances/components/AccessGroupChange/AccessGroupChange.tsx
+++ b/src/features/instances/components/AccessGroupChange/AccessGroupChange.tsx
@@ -11,6 +11,7 @@ import type { FC } from "react";
 import { INITIAL_VALUES, VALIDATION_SCHEMA } from "./constants";
 import { getAccessGroupOptions } from "./helpers";
 import type { AccessGroupChangeFormValues } from "./types";
+import { pluralize } from "@/utils/_helpers";
 
 interface AccessGroupChangeProps {
   readonly selected: Instance[];
@@ -44,7 +45,7 @@ const AccessGroupChange: FC<AccessGroupChangeProps> = ({ selected }) => {
 
       notify.success({
         title: "Access group changed",
-        message: `Access group for ${selected.length > 1 ? `${selected.length} instances` : `"${selected[0].title}" instance`} successfully changed to ${accessGroupOptions.find(({ value }) => value === access_group)?.label ?? ""}`,
+        message: `Access group for ${pluralize(selected.length, `"${selected[0]?.title ?? ""}" instance`, `${selected.length} instances`)} successfully changed to ${accessGroupOptions.find(({ value }) => value === access_group)?.label ?? ""}`,
       });
     } catch (error) {
       debug(error);

--- a/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
+++ b/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
@@ -161,7 +161,7 @@ const InstancesPageActions = memo(function InstancesPageActions({
 
   const handleReportView = () => {
     setSidePanelContent(
-      `Report for ${pluralize(selectedInstances.length, selectedInstances[0].title, `${selectedInstances.length} instances`)}`,
+      `Report for ${pluralize(selectedInstances.length, selectedInstances[0]?.title ?? "1 instance", `${selectedInstances.length} instances`)}`,
       <Suspense fallback={<LoadingState />}>
         <ReportView instanceIds={selectedInstances.map(({ id }) => id)} />
       </Suspense>,

--- a/src/features/instances/components/InstancesPageActions/helpers.ts
+++ b/src/features/instances/components/InstancesPageActions/helpers.ts
@@ -1,5 +1,6 @@
 import type { NotificationMethodArgs } from "@/types/Notification";
 import type { Instance } from "@/types/Instance";
+import { pluralize } from "@/utils/_helpers";
 
 type GetNotificationArgsFn = (params: {
   action: "reboot" | "shutdown";
@@ -13,8 +14,8 @@ export const getNotificationArgs: GetNotificationArgsFn = ({
   selected,
 }) => {
   return {
-    title: `Selected ${selected.length > 1 ? "instances have" : "instance has"} been queued for ${action}.`,
-    message: `${selected.length > 1 ? `${selected.length} instances have` : `"${selected[0].title}" instance has`} been queued in Activities for ${action}.`,
+    title: `Selected ${pluralize(selected.length, "instance has", "instances have")} been queued for ${action}.`,
+    message: `${pluralize(selected.length, `"${selected[0]?.title ?? ""}" instance has`, `${selected.length} instances have`)} been queued in Activities for ${action}.`,
     actions: [
       {
         label: "View details",

--- a/src/features/instances/components/TagsAddConfirmationModal/TagsAddConfirmationModal.tsx
+++ b/src/features/instances/components/TagsAddConfirmationModal/TagsAddConfirmationModal.tsx
@@ -77,19 +77,24 @@ const TagsAddConfirmationModal: FC<TagsAddConfirmationModalProps> = ({
 
   return (
     <ConfirmationModal
-      title={`Add ${tags.length > 1 ? `${tags.length} tags` : `${tags[0]} tag`} to ${instances.length > 1 ? `${instances.length} instances` : `${instances[0].title} instance`}`}
+      title={`Add ${pluralize(tags.length, `${tags[0]} tag`, `${tags.length} tags`)} to ${pluralize(instances.length, `${instances[0]?.title ?? "this"} instance`, `${instances.length} instances`)}`}
       confirmButtonLabel="Add tags"
       {...props}
     >
       <p>Adding tags could trigger irreversible changes to your instances.</p>
-
       <p>
         Adding{" "}
-        {tags.length > 1 ? `these ${tags.length} tags` : `the ${tags[0]} tag`}{" "}
+        {pluralize(
+          tags.length,
+          `the ${tags[0]} tag`,
+          `these ${tags.length} tags`,
+        )}{" "}
         to{" "}
-        {instances.length > 1
-          ? `${instances.length} instances`
-          : `the ${instances[0].title} instance`}{" "}
+        {pluralize(
+          instances.length,
+          `the ${instances[0]?.title ?? "this"} instance`,
+          `${instances.length} instances`,
+        )}{" "}
         will associate the {pluralize(instances.length, "instance")} with the
         following profiles.
         {securityProfiles.some((profile) =>

--- a/src/features/instances/components/TagsAddForm/TagsAddForm.tsx
+++ b/src/features/instances/components/TagsAddForm/TagsAddForm.tsx
@@ -15,6 +15,7 @@ import { useMemo, useState } from "react";
 import type { CellProps, Column } from "react-table";
 import { useTaggedSecurityProfiles } from "../../hooks";
 import TagsAddConfirmationModal from "../TagsAddConfirmationModal";
+import { pluralize } from "@/utils/_helpers";
 
 interface TagsAddFormProps {
   readonly selected: Instance[];
@@ -53,11 +54,11 @@ const TagsAddForm: FC<TagsAddFormProps> = ({ selected }) => {
 
       notify.success({
         title: "Tags assigned",
-        message: `Tags successfully assigned to ${
-          selected.length > 1
-            ? `${selected.length} instances`
-            : `"${selected[0].title}" instance`
-        }`,
+        message: `Tags successfully assigned to ${pluralize(
+          selected.length,
+          `"${selected[0]?.title ?? ""}" instance`,
+          `${selected.length} instances`,
+        )}`,
       });
     } catch (error) {
       debug(error);

--- a/src/features/mirrors/components/PocketSyncActivity/PocketSyncActivity.tsx
+++ b/src/features/mirrors/components/PocketSyncActivity/PocketSyncActivity.tsx
@@ -55,7 +55,7 @@ const PocketSyncActivity: FC<PocketSyncActivityProps> = ({
   if (pocket.last_sync_status === "synced") {
     return (
       <span className="font-monospace">
-        {moment(pocket.last_sync_time).format(DISPLAY_DATE_TIME_FORMAT)};
+        {moment(pocket.last_sync_time).format(DISPLAY_DATE_TIME_FORMAT)}
       </span>
     );
   }

--- a/src/features/packages/components/InstalledPackagesActionForm/helpers.ts
+++ b/src/features/packages/components/InstalledPackagesActionForm/helpers.ts
@@ -1,6 +1,7 @@
 import moment from "moment/moment";
 import * as Yup from "yup";
 import type { InstalledPackageAction, InstancePackage } from "../../types";
+import { pluralize } from "@/utils/_helpers";
 
 export const getValidationSchema = (action: InstalledPackageAction) =>
   Yup.object({
@@ -32,8 +33,11 @@ export const getActionInfo = (
   packages: InstancePackage[],
   action: "hold" | "unhold",
 ) => {
-  const title =
-    packages.length > 1 ? "selected packages" : `${packages[0].name} Package`;
+  const title = pluralize(
+    packages.length,
+    `${packages[0]?.name ?? ""} Package`,
+    "selected packages",
+  );
 
   return `This will ${action === "hold" ? "disable" : "enable"} upgrades for the ${title}. It will ${action === "hold" ? "not " : ""}be eligible to upgrade to the latest available version.`;
 };
@@ -43,10 +47,11 @@ export const getActionSuccessNotificationProps = (
   packages: InstancePackage[],
   version: string,
 ) => {
-  const itemTitle =
-    packages.length > 1
-      ? `${packages.length} packages`
-      : `${packages[0].name} Package`;
+  const itemTitle = pluralize(
+    packages.length,
+    `${packages[0]?.name ?? ""} Package`,
+    "selected packages",
+  );
 
   const titleEnding: Record<InstalledPackageAction, string> = {
     downgrade: "downgrade",

--- a/src/features/packages/components/PackageActions/PackageActions.tsx
+++ b/src/features/packages/components/PackageActions/PackageActions.tsx
@@ -27,7 +27,7 @@ const PackageActions: FC<PackageActionsProps> = ({ selectedPackages }) => {
   ) => {
     const titleEnding = pluralize(
       selectedPackages.length,
-      selectedPackages[0].name,
+      selectedPackages[0]?.name ?? "",
       `${selectedPackages.length} selected packages`,
     );
 

--- a/src/features/packages/components/PackagesInstallForm/PackagesInstallForm.tsx
+++ b/src/features/packages/components/PackagesInstallForm/PackagesInstallForm.tsx
@@ -40,8 +40,8 @@ const PackagesInstallForm: FC = () => {
       closeSidePanel();
 
       notify.success({
-        title: `You queued ${pluralize(selected.length, `package ${selected[0].name}`, `${selected.length} packages`)} to be installed.`,
-        message: `${pluralize(selected.length, `${selected[0].name} package`, `${selected.length} selected packages`)} will be installed and ${pluralize(selected.length, "is", "are")} queued in Activities.`,
+        title: `You queued ${pluralize(selected.length, `package ${selected[0]?.name ?? ""}`, `${selected.length} packages`)} to be installed.`,
+        message: `${pluralize(selected.length, `${selected[0]?.name ?? ""} package`, `${selected.length} selected packages`)} will be installed and ${pluralize(selected.length, "is", "are")} queued in Activities.`,
         actions: [
           {
             label: "Details",

--- a/src/features/scripts/components/RunScriptFormInstanceList/RunScriptFormInstanceList.module.scss
+++ b/src/features/scripts/components/RunScriptFormInstanceList/RunScriptFormInstanceList.module.scss
@@ -2,7 +2,3 @@
   margin-bottom: 0;
   position: static;
 }
-
-.table {
-  width: 40rem;
-}

--- a/src/features/scripts/components/RunScriptFormInstanceList/RunScriptFormInstanceList.tsx
+++ b/src/features/scripts/components/RunScriptFormInstanceList/RunScriptFormInstanceList.tsx
@@ -36,11 +36,7 @@ const RunScriptFormInstanceList: FC<RunScriptFormInstanceListProps> = ({
 
   return (
     <>
-      <ModularTable
-        columns={columns}
-        data={currentInstances}
-        className={classes.table}
-      />
+      <ModularTable columns={columns} data={currentInstances} />
 
       <TablePaginationBase
         className={classes.pagination}

--- a/src/features/wsl/components/WslInstancesHeader/WslInstancesHeader.tsx
+++ b/src/features/wsl/components/WslInstancesHeader/WslInstancesHeader.tsx
@@ -98,7 +98,11 @@ const WslInstancesHeader: FC<WslInstancesHeaderProps> = ({
       <HeaderWithSearch
         actions={
           <div className={classes.cta}>
-            <Button type="button" onClick={handleWslInstanceInstall}>
+            <Button
+              type="button"
+              onClick={handleWslInstanceInstall}
+              className="u-no-margin--bottom"
+            >
               <span>Create new instance</span>
             </Button>
 
@@ -106,7 +110,7 @@ const WslInstancesHeader: FC<WslInstancesHeaderProps> = ({
               <div className="p-segmented-control__list">
                 <Button
                   type="button"
-                  className="p-segmented-control__button"
+                  className="p-segmented-control__button u-no-margin--bottom"
                   disabled={selectedInstances.length === 0}
                   onClick={() => {
                     handleOpenModal("delete");
@@ -117,7 +121,7 @@ const WslInstancesHeader: FC<WslInstancesHeaderProps> = ({
 
                 <Button
                   type="button"
-                  className="p-segmented-control__button"
+                  className="p-segmented-control__button u-no-margin--bottom"
                   disabled={selectedInstances.length === 0}
                   onClick={() => {
                     handleOpenModal("remove");
@@ -143,7 +147,7 @@ const WslInstancesHeader: FC<WslInstancesHeaderProps> = ({
         confirmButtonLoading={isRemoving}
         confirmationText={pluralize(
           selectedInstances.length,
-          `remove ${selectedInstances[0].title}`,
+          `remove ${selectedInstances[0]?.title ?? "instance"}`,
           "remove instances",
         )}
       >
@@ -155,7 +159,7 @@ const WslInstancesHeader: FC<WslInstancesHeaderProps> = ({
           </p>
         ) : (
           <p>
-            This will remove the instance <b>{selectedInstances[0].title}</b>{" "}
+            This will remove the instance <b>{selectedInstances[0]?.title}</b>{" "}
             from Landscape. It will remain on the parent machine. You can
             re-register it to Landscape at any time.
           </p>
@@ -173,7 +177,7 @@ const WslInstancesHeader: FC<WslInstancesHeaderProps> = ({
         confirmButtonLoading={isDeleting}
         confirmationText={pluralize(
           selectedInstances.length,
-          `delete ${selectedInstances[0].title}`,
+          `delete ${selectedInstances[0]?.title ?? ""}`,
           "delete instances",
         )}
       >
@@ -185,8 +189,8 @@ const WslInstancesHeader: FC<WslInstancesHeaderProps> = ({
         ) : (
           <p>
             This will permanently delete the instance{" "}
-            <b>{selectedInstances[0].title}</b> from both the Windows host
-            machine and Landscape.
+            <b>{selectedInstances[0]?.title ?? ""}</b> from both the Windows
+            host machine and Landscape.
           </p>
         )}
       </TextConfirmationModal>

--- a/src/pages/dashboard/instances/[single]/SingleInstanceContainer/helpers.ts
+++ b/src/pages/dashboard/instances/[single]/SingleInstanceContainer/helpers.ts
@@ -37,7 +37,7 @@ export const getKernelCount = (kernelStatus?: KernelStatus[]) => {
   if (
     !kernelStatus ||
     kernelStatus.length === 0 ||
-    !kernelStatus[0].Livepatch.Fixes
+    !kernelStatus[0]?.Livepatch?.Fixes
   ) {
     return undefined;
   }

--- a/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.tsx
@@ -110,6 +110,11 @@ const InfoPanel: FC<InfoPanelProps> = ({ instance }) => {
   const { mutateAsync: sanitizeInstance, isPending: isSanitizing } =
     sanitizeInstanceQuery;
 
+  const tagsChanged =
+    instanceTags.length !== instance.tags.length ||
+    instanceTags.some((tag) => !instance.tags.includes(tag)) ||
+    instance.tags.some((tag) => !instanceTags.includes(tag));
+
   const handleSubmit = async (values: ModalConfirmationFormProps) => {
     if (!values.action) {
       return;
@@ -430,7 +435,7 @@ const InfoPanel: FC<InfoPanelProps> = ({ instance }) => {
               type="button"
               className="u-no-margin--bottom"
               onClick={handleTagsUpdate}
-              disabled={isSecurityProfilesLoading}
+              disabled={isSecurityProfilesLoading || !tagsChanged}
             >
               Update
             </Button>

--- a/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/helpers.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/helpers.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from "react";
 import moment from "moment/moment";
 import type { InfoItemProps } from "@/components/layout/InfoItem";
 import NoData from "@/components/layout/NoData";
@@ -69,10 +70,10 @@ export const getInstanceInfoItems = (
       value: instance.annotations ? (
         Object.entries(instance.annotations).map(
           ([key, value], index, array) => (
-            <>
+            <Fragment key={key}>
               <span>{`${key}: ${value}`}</span>
               {index < array.length - 1 && <br />}
-            </>
+            </Fragment>
           ),
         )
       ) : (

--- a/src/pages/dashboard/settings/roles/PermissionBlock/PermissionBlock.tsx
+++ b/src/pages/dashboard/settings/roles/PermissionBlock/PermissionBlock.tsx
@@ -40,7 +40,7 @@ const PermissionBlock: FC<PermissionBlockProps> = ({
     return (
       option.values.view === "" ||
       permissions.includes(
-        options.filter(({ label }) => label === option.label)[0].values.manage,
+        options.filter(({ label }) => label === option.label)[0]?.values.manage,
       )
     );
   };
@@ -101,7 +101,9 @@ const PermissionBlock: FC<PermissionBlockProps> = ({
               row.original.values.view === "" ||
               permissions.includes(row.original.values.view)
             }
-            onChange={() => handlePermissionChange(row.original, "view")}
+            onChange={() => {
+              handlePermissionChange(row.original, "view");
+            }}
           />
         ),
       },
@@ -119,7 +121,9 @@ const PermissionBlock: FC<PermissionBlockProps> = ({
             value={row.original.values.manage}
             disabled={row.original.values.manage === ""}
             checked={permissions.includes(row.original.values.manage)}
-            onChange={() => handlePermissionChange(row.original, "manage")}
+            onChange={() => {
+              handlePermissionChange(row.original, "manage");
+            }}
           />
         ),
       },

--- a/src/styles/partials/modal.scss
+++ b/src/styles/partials/modal.scss
@@ -6,6 +6,10 @@
       margin-bottom: 0 !important;
     }
   }
+
+  table {
+    width: 40rem;
+  }
 }
 
 .p-modal__dialog {

--- a/src/templates/dashboard/Navigation/Navigation.test.tsx
+++ b/src/templates/dashboard/Navigation/Navigation.test.tsx
@@ -70,6 +70,7 @@ const testMenuItem = (item: MenuItem, parentItem?: MenuItem) => {
     it(`should render ${item.label} page with ${item.requiresFeature} enabled${parentItem ? " under " + parentItem?.label : ""}`, () => {
       vi.mocked(useAuth, { partial: true }).mockReturnValue({
         ...authProps,
+        isOidcAvailable: false,
         isFeatureEnabled: (feature: FeatureKey) =>
           feature === item.requiresFeature,
       });

--- a/src/tests/mocks/pockets.ts
+++ b/src/tests/mocks/pockets.ts
@@ -237,7 +237,7 @@ export const pockets: Pocket[] = [
       summary: "",
       type: "sync",
     },
-    last_sync_time: "",
+    last_sync_time: "2024-12-01T14:30:00Z",
     last_sync_status: "synced",
     last_sync_status_message: "",
     mirror_suite: "",


### PR DESCRIPTION
## Fixes:
- Fixed `WslInstancesHeader` component from causing a page crash
- Vertically aligned `WslInstancesHeader` buttons with the searchbox
- Used `pluralize` function in `InstalledPackagesActionForm helpers`, `InstancesPageActions helpers`, `AccessGroupChange`, `TagsAddForm`
- Added default fallbacks and optional chaining in places where array indexing was happening
- Added `Fragment` and `key` to `annotations` in `InfoPanel`
- Removed `;` in `PocketSyncActivity` date
- Made tables inside `Modal` a fixed size `40rem`
- Disabled `update tags` button in `InfoPanel` (when not disabled, and when `securityProfiles.length > 0` it would the ConfirmationModal would be opened with no new tags which would render `undefined` strings in the ConfirmationModal)

## Tests:
- Fixed `Navigation` test not passing