### PR TITLE
fix: script profile forms can show errors

### DIFF
--- a/src/features/script-profiles/components/ScriptProfilesList/ScriptProfilesList.tsx
+++ b/src/features/script-profiles/components/ScriptProfilesList/ScriptProfilesList.tsx
@@ -4,6 +4,7 @@ import ListActions, {
 } from "@/components/layout/ListActions";
 import LoadingState from "@/components/layout/LoadingState";
 import NoData from "@/components/layout/NoData";
+import ResponsiveTable from "@/components/layout/ResponsiveTable";
 import { DISPLAY_DATE_TIME_FORMAT, INPUT_DATE_TIME_FORMAT } from "@/constants";
 import useNotify from "@/hooks/useNotify";
 import useSidePanel from "@/hooks/useSidePanel";
@@ -24,7 +25,6 @@ import type { ScriptProfile } from "../../types";
 import ScriptProfileArchiveModal from "../ScriptProfileArchiveModal";
 import type { ScriptProfileFormSubmitValues } from "../ScriptProfileForm/ScriptProfileForm";
 import classes from "./ScriptProfilesList.module.scss";
-import ResponsiveTable from "@/components/layout/ResponsiveTable";
 
 const ScriptProfileDetails = lazy(
   async () => import("../ScriptProfileDetails"),
@@ -51,7 +51,7 @@ const ScriptProfilesList: FC<ScriptProfilesListProps> = ({ profiles }) => {
 
     edit: () => {
       const handleSubmit = async (values: ScriptProfileFormSubmitValues) => {
-        editScriptProfile({
+        await editScriptProfile({
           id: profile.id,
           all_computers: values.all_computers,
           tags: values.tags,

--- a/src/features/script-profiles/components/ScriptProfilesPanel/ScriptProfilesPanel.tsx
+++ b/src/features/script-profiles/components/ScriptProfilesPanel/ScriptProfilesPanel.tsx
@@ -88,7 +88,7 @@ const ScriptProfilesPanel: FC = () => {
             script: null,
           }}
           onSubmit={async (values) => {
-            addScriptProfile({
+            await addScriptProfile({
               all_computers: values.all_computers,
               script_id: values.script_id,
               tags: values.tags,


### PR DESCRIPTION
Some script profile queries were not `await`ed, so they always succeeded. Now, the errors will display. 