### PR TITLE
fix: allow copy-and-paste in text confirmation modals

### DIFF
--- a/src/components/form/TextConfirmationModal/TextConfirmationModal.module.scss
+++ b/src/components/form/TextConfirmationModal/TextConfirmationModal.module.scss
@@ -1,3 +1,0 @@
-.confirmationKeyword {
-  user-select: none;
-}

--- a/src/components/form/TextConfirmationModal/TextConfirmationModal.tsx
+++ b/src/components/form/TextConfirmationModal/TextConfirmationModal.tsx
@@ -1,6 +1,5 @@
 import { ConfirmationModal, Form, Input } from "@canonical/react-components";
 import { useState, type ComponentProps, type FC } from "react";
-import classes from "./TextConfirmationModal.module.scss";
 
 interface TextConfirmationModalProps
   extends ComponentProps<typeof ConfirmationModal> {
@@ -68,13 +67,7 @@ const TextConfirmationModal: FC<TextConfirmationModalProps> = ({
 
         <Input
           type="text"
-          label={
-            <span>
-              Type{" "}
-              <b className={classes.confirmationKeyword}>{confirmationText}</b>{" "}
-              to confirm
-            </span>
-          }
+          label={<span>Type {confirmationText} to confirm.</span>}
           placeholder={confirmationText}
           autoComplete="off"
           value={inputText}


### PR DESCRIPTION
This change is in response to [feedback](https://discourse.ubuntu.com/t/feedback-on-the-new-web-portal/50528/71).