### PR TITLE
refactor: fix multiselect z-index issue

### DIFF
--- a/src/components/form/MultiSelectField/MultiSelectField.module.scss
+++ b/src/components/form/MultiSelectField/MultiSelectField.module.scss
@@ -24,3 +24,7 @@
 .errorMessage {
   margin-top: $spv--medium;
 }
+
+:global(.multi-select) {
+  z-index: 3501 !important;
+}

--- a/src/features/reboot-profiles/components/RebootProfileDetails/RebootProfileDetails.tsx
+++ b/src/features/reboot-profiles/components/RebootProfileDetails/RebootProfileDetails.tsx
@@ -155,7 +155,11 @@ const RebootProfileDetails: FC<RebootProfileDetailsProps> = ({
         )}
         {!profile.all_computers && profile.tags.length > 0 && (
           <>
-            <InfoItem label="Tags" value={profile.tags.join(", ")} />
+            <InfoItem
+              label="Tags"
+              type="truncated"
+              value={profile.tags.join(", ")}
+            />
             <InfoItem
               label="associated instances"
               value={

--- a/src/features/script-profiles/components/ScriptProfileInfo/ScriptProfileInfo.tsx
+++ b/src/features/script-profiles/components/ScriptProfileInfo/ScriptProfileInfo.tsx
@@ -134,6 +134,7 @@ const ScriptProfileInfo: FC<ScriptProfileInfoProps> = ({ profile }) => {
       <Row className="u-no-padding">
         <InfoItem
           label="Tags"
+          type="truncated"
           value={
             profile.all_computers
               ? "All instances"

--- a/src/features/security-profiles/components/SecurityProfileDetails/SecurityProfileDetails.tsx
+++ b/src/features/security-profiles/components/SecurityProfileDetails/SecurityProfileDetails.tsx
@@ -218,7 +218,7 @@ const SecurityProfileDetails: FC<SecurityProfileDetailsProps> = ({
       </Row>
 
       <Row className="u-no-padding">
-        <InfoItem label="Tags" value={getTags(profile)} />
+        <InfoItem label="Tags" type="truncated" value={getTags(profile)} />
       </Row>
     </>
   );

--- a/src/features/wsl-profiles/components/WslProfileDetails/WslProfileDetails.tsx
+++ b/src/features/wsl-profiles/components/WslProfileDetails/WslProfileDetails.tsx
@@ -152,9 +152,15 @@ const WslProfileDetails: FC<WslProfileDetailsProps> = ({
       <div className={classes.block}>
         <p className="p-heading--5">Association</p>
 
-        {profile.all_computers ? (
+        {profile.all_computers && (
           <p>This profile has been associated with all instances.</p>
-        ) : (
+        )}
+
+        {!profile.all_computers && !profile.tags.length && (
+          <p>This profile has not yet been associated with any instances.</p>
+        )}
+
+        {!profile.all_computers && profile.tags.length > 0 && (
           <Row className="u-no-padding--left u-no-padding--right">
             <Col size={12}>
               <InfoItem


### PR DESCRIPTION
- Hardcode z-index prop for the multiselect component in order to fix a weird issue happening after the build
- Add "truncated" type for the remaining "Tags" info rows