### PR TITLE
fix: disable root_only for instances

### DIFF
--- a/src/features/instances/api/useGetInstances.ts
+++ b/src/features/instances/api/useGetInstances.ts
@@ -60,7 +60,8 @@ export const useGetInstances = (
     AxiosError<ApiError>
   >({
     queryKey: ["instances", params],
-    queryFn: async () => authFetch.get("computers", { params }),
+    queryFn: async () =>
+      authFetch.get("computers", { params: { ...params, root_only: false } }),
     ...options,
   });
 


### PR DESCRIPTION
This allows us to see WSL children in the main instances table. It's not `false` by default.