### PR TITLE
refactor: add correct expired attach code error notification

### DIFF
--- a/src/features/attach/components/OTPInputContainer/OTPInputContainer.tsx
+++ b/src/features/attach/components/OTPInputContainer/OTPInputContainer.tsx
@@ -44,7 +44,7 @@ const OTPInputContainer: FC = () => {
         });
 
         if (!data.valid) {
-          debug("Invalid OTP code");
+          debug("The code you entered has expired and is no longer valid.");
           formik.resetForm({
             values: { code: Array(OTP_LENGTH).fill("") },
           });

--- a/src/hooks/useDebug.ts
+++ b/src/hooks/useDebug.ts
@@ -19,6 +19,8 @@ export default function useDebug() {
     } else if (error instanceof Error) {
       const { message } = error;
       errorMessage = message;
+    } else if (typeof error === "string") {
+      errorMessage = error;
     } else {
       errorMessage = "Unknown error";
     }


### PR DESCRIPTION
## How to validate the error appears:

1. Go to network tab, override a network request `ubuntu-installer-attach-sessions/code/<code>` (can be seen after sending a random code in the `/attach` page
2. Put this content in the overwritten endpoint: `{"valid_until": "2000-01-01-T00:00:00", "valid": false}`
3. Resend the request, and see that the error now shows that the code is expired and invalid. Before it would show "Unknown error"

Alternatively you could also use MSW to test

## Fixes
[Jira ticket LNDENG-3004](https://warthogs.atlassian.net/browse/LNDENG-3004)