### PR TITLE
style: change multiselect to be scrollable by default

### DIFF
--- a/src/components/form/MultiSelectField/MultiSelectField.tsx
+++ b/src/components/form/MultiSelectField/MultiSelectField.tsx
@@ -141,6 +141,7 @@ const MultiSelectField: FC<MultiSelectFieldProps> = ({
         error={error}
         items={items}
         label={label}
+        scrollOverflow
         {...otherProps}
       />
       {error && (

--- a/src/components/form/ScheduleBlock/components/OnSelect/OnSelect.tsx
+++ b/src/components/form/ScheduleBlock/components/OnSelect/OnSelect.tsx
@@ -29,7 +29,6 @@ const OnSelect = <T extends ScheduleBlockFormProps>({
               items.map(({ value }) => value),
             )
           }
-          scrollOverflow={true}
           isSortedAlphabetically={false}
           hasSelectedItemsFirst={false}
           required
@@ -67,7 +66,6 @@ const OnSelect = <T extends ScheduleBlockFormProps>({
           }
           isSortedAlphabetically={false}
           hasSelectedItemsFirst={false}
-          scrollOverflow={true}
           required
         />
       );

--- a/src/features/scripts/components/RunScriptForm/RunScriptForm.tsx
+++ b/src/features/scripts/components/RunScriptForm/RunScriptForm.tsx
@@ -210,7 +210,6 @@ const RunScriptForm: FC<RunScriptFormProps> = ({ script }) => {
                     formik.setFieldTouched("tags", true, false);
                   }}
                   error={getFormikError(formik, "tags")}
-                  scrollOverflow
                 />
               )}
 
@@ -235,7 +234,6 @@ const RunScriptForm: FC<RunScriptFormProps> = ({ script }) => {
                     formik.setFieldTouched("instanceIds", true, false);
                   }}
                   error={getFormikError(formik, "instanceIds")}
-                  scrollOverflow
                 />
               )}
             </div>


### PR DESCRIPTION
This fixes an issue of not being able to scroll in most multiselects. This was visible in multiselects containing "tags" or "instances".