### PR TITLE
refactor: add ability for users to override autoinstall file fields

### DIFF
--- a/src/features/autoinstall-files/api/index.ts
+++ b/src/features/autoinstall-files/api/index.ts
@@ -3,3 +3,4 @@ export * from "./useDeleteAutoinstallFile";
 export * from "./useGetAutoinstallFile";
 export * from "./useGetAutoinstallFiles";
 export * from "./useUpdateAutoinstallFile";
+export * from "./useValidateAutoinstallFile";

--- a/src/features/autoinstall-files/api/useAddAutoinstallFile.ts
+++ b/src/features/autoinstall-files/api/useAddAutoinstallFile.ts
@@ -8,6 +8,7 @@ export interface AddAutoinstallFileParams {
   contents: string;
   filename: string;
   is_default: boolean;
+  accept_warning: boolean;
 }
 
 export const useAddAutoinstallFile = (): {

--- a/src/features/autoinstall-files/api/useDeleteAutoinstallFile.ts
+++ b/src/features/autoinstall-files/api/useDeleteAutoinstallFile.ts
@@ -9,7 +9,7 @@ export interface DeleteAutoinstallFileParams {
 
 export const useDeleteAutoinstallFile = (): {
   deleteAutoinstallFile: (params: DeleteAutoinstallFileParams) => Promise<null>;
-  isAutoinstallFileUpdating: boolean;
+  isAutoinstallFileDeleting: boolean;
 } => {
   const authFetch = useFetch();
   const queryClient = useQueryClient();
@@ -26,6 +26,6 @@ export const useDeleteAutoinstallFile = (): {
 
   return {
     deleteAutoinstallFile: mutateAsync,
-    isAutoinstallFileUpdating: isPending,
+    isAutoinstallFileDeleting: isPending,
   };
 };

--- a/src/features/autoinstall-files/api/useUpdateAutoinstallFile.ts
+++ b/src/features/autoinstall-files/api/useUpdateAutoinstallFile.ts
@@ -8,6 +8,7 @@ export interface UpdateAutoinstallFileParams {
   id: number;
   contents?: string;
   is_default?: boolean;
+  accept_warning?: boolean;
 }
 
 export const useUpdateAutoinstallFile = (): {

--- a/src/features/autoinstall-files/api/useValidateAutoinstallFile.ts
+++ b/src/features/autoinstall-files/api/useValidateAutoinstallFile.ts
@@ -1,0 +1,32 @@
+import useFetch from "@/hooks/useFetch";
+import type { ApiError } from "@/types/api/ApiError";
+import { useMutation } from "@tanstack/react-query";
+import type { AxiosError } from "axios";
+import type { AutoinstallFile } from "../types";
+
+export interface ValidateAutoinstallFileParams {
+  contents: string;
+}
+
+export const useValidateAutoinstallFile = (): {
+  validateAutoinstallFile: (
+    params: ValidateAutoinstallFileParams,
+  ) => Promise<AutoinstallFile>;
+  isAutoinstallFileValidating: boolean;
+} => {
+  const authFetch = useFetch();
+
+  const { isPending, mutateAsync } = useMutation<
+    AutoinstallFile,
+    AxiosError<ApiError>,
+    ValidateAutoinstallFileParams
+  >({
+    mutationFn: async (params) =>
+      authFetch.post(`autoinstall:validate`, params),
+  });
+
+  return {
+    isAutoinstallFileValidating: isPending,
+    validateAutoinstallFile: mutateAsync,
+  };
+};

--- a/src/features/autoinstall-files/components/AutoinstallFileDeleteModal/AutoinstallFileDeleteModal.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFileDeleteModal/AutoinstallFileDeleteModal.tsx
@@ -17,7 +17,8 @@ const AutoinstallFileDeleteModal: FC<AutoinstallFileDeleteModalProps> = ({
   const { notify } = useNotify();
   const { closeSidePanel } = useSidePanel();
 
-  const { deleteAutoinstallFile } = useDeleteAutoinstallFile();
+  const { deleteAutoinstallFile, isAutoinstallFileDeleting } =
+    useDeleteAutoinstallFile();
 
   const handleConfirm = async () => {
     await deleteAutoinstallFile({ id: autoinstallFile.id });
@@ -37,6 +38,7 @@ const AutoinstallFileDeleteModal: FC<AutoinstallFileDeleteModalProps> = ({
       confirmButtonAppearance="negative"
       confirmButtonLabel="Remove"
       onConfirm={handleConfirm}
+      confirmButtonLoading={isAutoinstallFileDeleting}
       title={`Remove ${autoinstallFile.filename}, autoinstall file`}
     >
       <p>

--- a/src/features/autoinstall-files/components/AutoinstallFileEditForm/AutoinstallFileEditForm.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFileEditForm/AutoinstallFileEditForm.tsx
@@ -31,27 +31,18 @@ const AutoinstallFileEditForm: FC<AutoinstallFileEditFormProps> = ({
     <>
       {autoinstallFileWithMetadata.metadata.max_versions <=
         autoinstallFileWithMetadata.version && (
-        <Notification
-          inline
-          title="Edit history limit reached:"
-          severity="caution"
-        >
-          <p>
-            You&apos;ve reached the limit of{" "}
-            {autoinstallFileWithMetadata.metadata.max_versions} saved{" "}
-            {pluralize(
-              autoinstallFileWithMetadata.metadata.max_versions,
-              "edit",
-            )}
-            . To save your new change, the oldest version will be automatically
-            removed, keeping the most recent{" "}
-            {autoinstallFileWithMetadata.metadata.max_versions}{" "}
-            {pluralize(
-              autoinstallFileWithMetadata.metadata.max_versions,
-              "version",
-            )}{" "}
-            in history.
-          </p>
+        <Notification title="Edit history limit reached:" severity="caution">
+          You&apos;ve reached the limit of{" "}
+          {autoinstallFileWithMetadata.metadata.max_versions} saved{" "}
+          {pluralize(autoinstallFileWithMetadata.metadata.max_versions, "edit")}
+          . To save your new change, the oldest version will be automatically
+          removed, keeping the most recent{" "}
+          {autoinstallFileWithMetadata.metadata.max_versions}{" "}
+          {pluralize(
+            autoinstallFileWithMetadata.metadata.max_versions,
+            "version",
+          )}{" "}
+          in history.
         </Notification>
       )}
 
@@ -60,11 +51,12 @@ const AutoinstallFileEditForm: FC<AutoinstallFileEditFormProps> = ({
         description={`The duplicated ${autoinstallFileWithMetadata.filename} will be assigned to the same user groups in the identity provider as the original file.`}
         initialFile={autoinstallFileWithMetadata}
         notification={EDIT_AUTOINSTALL_FILE_NOTIFICATION}
-        onSubmit={async ({ contents, is_default }) => {
+        onSubmit={async ({ contents, is_default, accept_warning }) => {
           await updateAutoinstallFile({
             id: autoinstallFileWithMetadata.id,
             contents,
             is_default,
+            accept_warning,
           });
         }}
       />

--- a/src/features/autoinstall-files/components/AutoinstallFileForm/helpers.ts
+++ b/src/features/autoinstall-files/components/AutoinstallFileForm/helpers.ts
@@ -1,6 +1,29 @@
+import type { AxiosError } from "axios";
+import { isAxiosError } from "axios";
+import type { ApiError } from "@/types/api/ApiError";
+import type { AutoinstallOverrideWarning } from "./types";
+
 export const areTextsIdentical = (
   firstText: string,
   secondText: string,
 ): boolean => {
   return firstText === secondText;
+};
+
+export const isAutoinstallOverrideWarning = (
+  value: unknown,
+): value is AxiosError<AutoinstallOverrideWarning> => {
+  if (isAxiosError<ApiError>(value) && value.response) {
+    const { error } = value.response.data;
+    return error === "AutoinstallOverrideWarning";
+  }
+  return false;
+};
+
+export const parseFields = (
+  error: AxiosError<AutoinstallOverrideWarning>,
+): string[] => {
+  const match = error.response?.data.message.match(/overrides fields (.+)$/);
+
+  return match ? match[1].split(",").map((field) => field.trim()) : [];
 };

--- a/src/features/autoinstall-files/components/AutoinstallFileForm/types.d.ts
+++ b/src/features/autoinstall-files/components/AutoinstallFileForm/types.d.ts
@@ -3,3 +3,8 @@ export interface FormikProps {
   readonly filename: string;
   readonly is_default: boolean;
 }
+
+export interface AutoinstallOverrideWarning {
+  error: "AutoinstallOverrideWarning";
+  message: string;
+}

--- a/src/pages/dashboard/settings/employees/tabs/autoinstall-files/AutoinstallFilesPanel.tsx
+++ b/src/pages/dashboard/settings/employees/tabs/autoinstall-files/AutoinstallFilesPanel.tsx
@@ -41,7 +41,6 @@ const AutoinstallFilesPanel: FC = () => {
           notification={ADD_AUTOINSTALL_FILE_NOTIFICATION}
           onSubmit={addAutoinstallFile}
         />
-        ,
       </Suspense>,
     );
   };


### PR DESCRIPTION
## Fixes
- add modal confirmation for user to override autoinstall file fields
- add loading state when clicking on delete autoinstall file confirmation modal button
- remove nested `<p>` tag on notification when editing autoinstall file

## Ticket
[Jira ticket LNDENG-3006 ](https://warthogs.atlassian.net/browse/LNDENG-3006)