### PR TITLE
test: add roles page tests

### DIFF
--- a/src/pages/dashboard/settings/roles/AccessGroupBlock/AccessGroupBlock.test.tsx
+++ b/src/pages/dashboard/settings/roles/AccessGroupBlock/AccessGroupBlock.test.tsx
@@ -1,0 +1,97 @@
+import { accessGroups } from "@/tests/mocks/accessGroup";
+import { renderWithProviders } from "@/tests/render";
+import type { ComponentProps } from "react";
+import { getAccessGroupOptions, getSortedOptions } from "../helpers";
+import type { AccessGroupOption } from "../types";
+import AccessGroupBlock from "./AccessGroupBlock";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { INDENTATION } from "./constants";
+
+const accessGroupOptions: AccessGroupOption[] = getSortedOptions(
+  getAccessGroupOptions(accessGroups),
+);
+
+const onAccessGroupChange = vi.fn();
+
+const props: ComponentProps<typeof AccessGroupBlock> = {
+  accessGroupOptions,
+  accessGroups: [],
+  onAccessGroupChange,
+};
+
+const [selectedAccessGroup] = accessGroupOptions;
+
+assert(selectedAccessGroup);
+
+describe("AccessGroupBlock", () => {
+  const user = userEvent.setup();
+
+  it("renders correctly", () => {
+    renderWithProviders(<AccessGroupBlock {...props} />);
+
+    expect(screen.getByText(/access groups/i)).toBeInTheDocument();
+  });
+
+  it("correctly handles indeterminate state when a checkbox has children checked", async () => {
+    renderWithProviders(<AccessGroupBlock {...props} />);
+
+    const [childCheckboxValue] = selectedAccessGroup.children;
+
+    const childCheckboxLabel = accessGroups.find(
+      (group) => group.name === childCheckboxValue,
+    )?.title;
+
+    assert(childCheckboxLabel);
+
+    const childCheckbox = screen.getByLabelText(childCheckboxLabel);
+    await user.click(childCheckbox);
+
+    expect(onAccessGroupChange).toHaveBeenCalledWith(
+      expect.arrayContaining([childCheckboxValue]),
+    );
+  });
+
+  it("selects children when selecting the parent", async () => {
+    renderWithProviders(<AccessGroupBlock {...props} />);
+
+    const parentCheckbox = screen.getByLabelText(selectedAccessGroup.label);
+    await user.click(parentCheckbox);
+
+    expect(onAccessGroupChange).toHaveBeenCalledWith(
+      expect.arrayContaining(selectedAccessGroup.children),
+    );
+  });
+
+  it("styles the checkbox labels in a hierarchy", () => {
+    renderWithProviders(<AccessGroupBlock {...props} />);
+
+    const parentCheckboxInput = screen.getByRole("checkbox", {
+      name: selectedAccessGroup.label,
+    });
+
+    const parentCheckboxContainer = parentCheckboxInput.closest("div");
+    expect(parentCheckboxContainer).toHaveStyle({
+      marginLeft: `${INDENTATION * selectedAccessGroup.depth}rem`,
+    });
+
+    const groupMap = new Map(
+      accessGroupOptions.map((group) => [group.value, group]),
+    );
+
+    for (const childValue of selectedAccessGroup.children) {
+      const childGroup = groupMap.get(childValue);
+
+      assert(childGroup, `Child group with value "${childValue}" not found.`);
+
+      const childCheckboxInput = screen.getByRole("checkbox", {
+        name: childGroup.label,
+      });
+      const childCheckboxContainer = childCheckboxInput.closest("div");
+
+      expect(childCheckboxContainer).toHaveStyle({
+        marginLeft: `${INDENTATION * childGroup.depth}rem`,
+      });
+    }
+  });
+});

--- a/src/pages/dashboard/settings/roles/AddRoleForm/AddRoleForm.test.tsx
+++ b/src/pages/dashboard/settings/roles/AddRoleForm/AddRoleForm.test.tsx
@@ -1,0 +1,51 @@
+import { renderWithProviders } from "@/tests/render";
+import AddRoleForm from "./AddRoleForm";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe("AddRoleForm", () => {
+  const user = userEvent.setup();
+
+  it("renders correctly", () => {
+    renderWithProviders(<AddRoleForm />);
+
+    expect(
+      screen.getByRole("textbox", { name: /role name/i }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("textbox", { name: /description/i }),
+    ).toBeInTheDocument();
+
+    expect(screen.getAllByRole("table")).toHaveLength(2);
+
+    expect(screen.getByText("Access Groups")).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", { name: /add role/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error messages when form is submitted with invalid data", async () => {
+    renderWithProviders(<AddRoleForm />);
+
+    await user.click(screen.getByRole("button", { name: /add role/i }));
+
+    expect(
+      await screen.findByText(/this field is required/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error message when an invalid name is entered", async () => {
+    renderWithProviders(<AddRoleForm />);
+
+    await user.type(screen.getByRole("textbox", { name: /role name/i }), "123");
+    await user.click(screen.getByRole("button", { name: /add role/i }));
+
+    expect(
+      await screen.findByText(
+        /name must start with a letter and can contain alphanumeric/i,
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/settings/roles/EditRoleForm/EditRoleForm.test.tsx
+++ b/src/pages/dashboard/settings/roles/EditRoleForm/EditRoleForm.test.tsx
@@ -1,0 +1,20 @@
+import { roles } from "@/tests/mocks/roles";
+import { renderWithProviders } from "@/tests/render";
+import { screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import EditRoleForm from "./EditRoleForm";
+
+const props: ComponentProps<typeof EditRoleForm> = {
+  role: roles[0],
+};
+
+describe("EditRoleForm", () => {
+  it("renders EditRoleForm", () => {
+    renderWithProviders(<EditRoleForm {...props} />);
+
+    expect(screen.getByText("Global permissions")).toBeInTheDocument();
+    expect(screen.getByText("Permissions")).toBeInTheDocument();
+    expect(screen.getByText("Access Groups")).toBeInTheDocument();
+    expect(screen.getByText(/save changes/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/settings/roles/EditRoleForm/helpers.test.ts
+++ b/src/pages/dashboard/settings/roles/EditRoleForm/helpers.test.ts
@@ -1,0 +1,147 @@
+import { accessGroups } from "@/tests/mocks/accessGroup";
+import { permissions } from "@/tests/mocks/roles";
+import type { Role } from "@/types/Role";
+import type { PermissionOption } from "../types";
+import { getAccessGroupOptions, getPermissionOptions } from "../helpers";
+import { addImpliedViewPermissions, getValuesToEditRole } from "./helpers";
+
+const manageComputerPermission = permissions.find(
+  (p) => p.name === "ManageComputer",
+);
+const viewComputerPermission = permissions.find(
+  (p) => p.name === "ViewComputer",
+);
+assert(manageComputerPermission, "Mock 'ManageComputer' permission not found");
+assert(viewComputerPermission, "Mock 'ViewComputer' permission not found");
+
+describe("Role Helpers", () => {
+  describe("addImpliedViewPermissions", () => {
+    const permissionOptions = getPermissionOptions(permissions);
+
+    it("should add the implied 'view' permission when a 'manage' permission is present", () => {
+      const result = addImpliedViewPermissions(
+        [manageComputerPermission.name],
+        permissionOptions,
+      );
+      expect(result.sort()).toEqual(
+        [manageComputerPermission.name, viewComputerPermission.name].sort(),
+      );
+    });
+
+    it("should not add duplicates if both 'manage' and 'view' are already present", () => {
+      const result = addImpliedViewPermissions(
+        [manageComputerPermission.name, viewComputerPermission.name],
+        permissionOptions,
+      );
+      expect(result.sort()).toEqual(
+        [manageComputerPermission.name, viewComputerPermission.name].sort(),
+      );
+    });
+
+    it("should not add a 'manage' permission if only 'view' is present", () => {
+      const result = addImpliedViewPermissions(
+        [viewComputerPermission.name],
+        permissionOptions,
+      );
+      expect(result).toEqual([viewComputerPermission.name]);
+    });
+
+    it("should ignore permission options with an empty string 'manage' key", () => {
+      const options: PermissionOption[] = [
+        ...permissionOptions,
+        {
+          label: "WithEmptyManageString",
+          global: false,
+          values: { manage: "", view: "ViewEventLog" },
+        },
+      ];
+      const initialPermissions = ["ViewRole", ""];
+      const result = addImpliedViewPermissions(initialPermissions, options);
+      expect(result.sort()).toEqual(initialPermissions.sort());
+    });
+  });
+
+  describe("getValuesToEditRole", () => {
+    const permissionOptions = getPermissionOptions(permissions);
+    const accessGroupOptions = getAccessGroupOptions(accessGroups);
+    const mockRole: Role = {
+      name: "TestRole",
+      permissions: [],
+      global_permissions: [],
+      access_groups: [],
+      description: "Test role description",
+      persons: [],
+    };
+
+    it("should find no changes if 'view' was implied from 'manage' (BUG FIX)", () => {
+      const role: Role = {
+        ...mockRole,
+        permissions: [manageComputerPermission.name],
+      };
+      const formValues = {
+        permissions: [
+          manageComputerPermission.name,
+          viewComputerPermission.name,
+        ],
+        accessGroups: [],
+      };
+
+      const { permissionsToAdd, permissionsToRemove } = getValuesToEditRole(
+        formValues,
+        role,
+        accessGroupOptions,
+        permissionOptions,
+      );
+
+      expect(permissionsToAdd).toEqual([]);
+      expect(permissionsToRemove).toEqual([]);
+    });
+
+    it("should find no changes for a pre-existing global permission (BUG FIX)", () => {
+      const role: Role = {
+        ...mockRole,
+        global_permissions: ["ViewRole"],
+      };
+      const formValues = {
+        permissions: ["ViewRole"],
+        accessGroups: [],
+      };
+
+      const { permissionsToAdd, permissionsToRemove } = getValuesToEditRole(
+        formValues,
+        role,
+        accessGroupOptions,
+        permissionOptions,
+      );
+
+      expect(permissionsToAdd).toEqual([]);
+      expect(permissionsToRemove).toEqual([]);
+    });
+
+    it("should find no changes in a combined scenario of global and implied permissions", () => {
+      const role: Role = {
+        ...mockRole,
+        permissions: [manageComputerPermission.name],
+        global_permissions: ["ViewRole"],
+      };
+      const formValues = {
+        permissions: [
+          manageComputerPermission.name,
+          viewComputerPermission.name,
+          "ViewRole",
+        ],
+        accessGroups: [],
+      };
+
+      const { permissionsToAdd, permissionsToRemove } = getValuesToEditRole(
+        formValues,
+        role,
+        accessGroupOptions,
+        permissionOptions,
+      );
+
+      expect(permissionsToAdd).toEqual([]);
+      expect(permissionsToRemove).toEqual([]);
+    });
+  });
+});

--- a/src/pages/dashboard/settings/roles/PermissionBlock/PermissionBlock.test.tsx
+++ b/src/pages/dashboard/settings/roles/PermissionBlock/PermissionBlock.test.tsx
@@ -1,0 +1,73 @@
+import { renderWithProviders } from "@/tests/render";
+import PermissionBlock from "./PermissionBlock";
+import { screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { getPermissionOptions } from "../helpers";
+import { permissions } from "@/tests/mocks/roles";
+import userEvent from "@testing-library/user-event";
+import { isOptionDisabled } from "./helpers";
+
+const permissionOptions = getPermissionOptions(permissions);
+const onPermissionChange = vi.fn();
+const props: ComponentProps<typeof PermissionBlock> = {
+  title: "Global permissions",
+  description: "Manage user permissions",
+  onPermissionChange,
+  options: permissionOptions.filter(({ global }) => !global),
+  permissions: [],
+};
+
+describe("PermissionBlock", () => {
+  const user = userEvent.setup();
+
+  it("renders PermissionBlock", () => {
+    renderWithProviders(<PermissionBlock {...props} />);
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: /property/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: /view/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: /manage/i }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText(props.description)).toBeInTheDocument();
+    expect(screen.getByText(props.title)).toBeInTheDocument();
+  });
+
+  it("calls onPermissionChange when a permission is toggled", async () => {
+    renderWithProviders(<PermissionBlock {...props} />);
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes).toHaveLength(props.options.length * 2);
+
+    const availableCheckbox = checkboxes.find(
+      (checkbox) => !checkbox.hasAttribute("disabled"),
+    );
+
+    assert(availableCheckbox);
+
+    await user.click(availableCheckbox);
+    expect(onPermissionChange).toHaveBeenCalled();
+  });
+
+  it("renders disabled checkboxes", () => {
+    renderWithProviders(<PermissionBlock {...props} />);
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes).toHaveLength(props.options.length * 2);
+
+    const disabledCheckboxes = checkboxes.filter((checkbox) =>
+      checkbox.hasAttribute("disabled"),
+    );
+
+    const actualDisabledCheckboxes = props.options.filter((option) =>
+      isOptionDisabled({ option, permissions: props.permissions }),
+    );
+
+    expect(disabledCheckboxes).toHaveLength(actualDisabledCheckboxes.length);
+  });
+});

--- a/src/pages/dashboard/settings/roles/PermissionBlock/PermissionBlock.tsx
+++ b/src/pages/dashboard/settings/roles/PermissionBlock/PermissionBlock.tsx
@@ -4,6 +4,7 @@ import type { FC } from "react";
 import { useMemo } from "react";
 import type { CellProps, Column } from "react-table";
 import classes from "./PermissionBlock.module.scss";
+import { isOptionDisabled } from "./helpers";
 
 interface PermissionBlockProps {
   readonly description: string;
@@ -35,12 +36,6 @@ const PermissionBlock: FC<PermissionBlockProps> = ({
       }),
     [options],
   );
-
-  const isOptionDisabled = (option: PermissionOption) => {
-    return (
-      option.values.view === "" || permissions.includes(option.values.manage)
-    );
-  };
 
   const handlePermissionChange = (
     permissionOption: PermissionOption,
@@ -93,7 +88,7 @@ const PermissionBlock: FC<PermissionBlockProps> = ({
             }
             name="permissions"
             value={row.original.values.view}
-            disabled={isOptionDisabled(row.original)}
+            disabled={isOptionDisabled({ option: row.original, permissions })}
             checked={
               row.original.values.view === "" ||
               permissions.includes(row.original.values.view)

--- a/src/pages/dashboard/settings/roles/PermissionBlock/helpers.ts
+++ b/src/pages/dashboard/settings/roles/PermissionBlock/helpers.ts
@@ -1,0 +1,13 @@
+import type { PermissionOption } from "../types";
+
+export const isOptionDisabled = ({
+  option,
+  permissions,
+}: {
+  option: PermissionOption;
+  permissions: string[];
+}) => {
+  return (
+    option.values.view === "" || permissions.includes(option.values.manage)
+  );
+};

--- a/src/pages/dashboard/settings/roles/RoleList/RoleList.test.tsx
+++ b/src/pages/dashboard/settings/roles/RoleList/RoleList.test.tsx
@@ -1,0 +1,41 @@
+import { renderWithProviders } from "@/tests/render";
+import RoleList from "./RoleList";
+import type { ComponentProps } from "react";
+import { roles } from "@/tests/mocks/roles";
+import { screen } from "@testing-library/react";
+
+const props: ComponentProps<typeof RoleList> = {
+  roleList: roles,
+};
+
+describe("RoleList", () => {
+  it("renders RoleList correctly", () => {
+    renderWithProviders(<RoleList {...props} />);
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+
+    const columnHeaders = [
+      /name/i,
+      /administrators/i,
+      /view/i,
+      /manage/i,
+      /actions/i,
+    ];
+
+    columnHeaders.forEach((header) => {
+      expect(
+        screen.getByRole("columnheader", { name: header }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders the roles in the table", () => {
+    renderWithProviders(<RoleList {...props} />);
+
+    roles.forEach((role) => {
+      expect(
+        screen.getByRole("rowheader", { name: role.name }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/dashboard/settings/roles/RoleListActions/RoleListActions.test.tsx
+++ b/src/pages/dashboard/settings/roles/RoleListActions/RoleListActions.test.tsx
@@ -1,0 +1,69 @@
+import { renderWithProviders } from "@/tests/render";
+import RoleListActions from "./RoleListActions";
+import type { ComponentProps } from "react";
+import { roles } from "@/tests/mocks/roles";
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const props: ComponentProps<typeof RoleListActions> = {
+  role: roles[0],
+};
+
+describe("RoleListActions", () => {
+  const user = userEvent.setup();
+
+  beforeEach(async () => {
+    renderWithProviders(<RoleListActions {...props} />);
+
+    const contextualMenuButton = screen.getByRole("button", {
+      name: `${props.role.name} role actions`,
+    });
+    expect(contextualMenuButton).toBeInTheDocument();
+
+    await user.click(contextualMenuButton);
+  });
+
+  it("opens the actions of the role", async () => {
+    const editButton = await screen.findByRole("button", {
+      name: `Edit "${props.role.name}" role`,
+    });
+    expect(editButton).toBeInTheDocument();
+
+    const removeButton = await screen.findByRole("button", {
+      name: `Remove "${props.role.name}" role`,
+    });
+    expect(removeButton).toBeInTheDocument();
+  });
+
+  it("opens modal on remove button click", async () => {
+    const removeButton = await screen.findByRole("button", {
+      name: `Remove "${props.role.name}" role`,
+    });
+    expect(removeButton).toBeInTheDocument();
+
+    await user.click(removeButton);
+
+    const confirmationModal = await screen.findByRole("dialog");
+    expect(confirmationModal).toBeInTheDocument();
+
+    expect(screen.getByText(/this will remove/i)).toBeInTheDocument();
+  });
+
+  it("opens edit sidepanel on edit button click", async () => {
+    const editButton = await screen.findByRole("button", {
+      name: `Edit "${props.role.name}" role`,
+    });
+    expect(editButton).toBeInTheDocument();
+
+    await user.click(editButton);
+
+    const sidePanel = await screen.findByRole("complementary");
+    expect(sidePanel).toBeInTheDocument();
+
+    expect(
+      within(sidePanel).getByRole("heading", {
+        name: `Edit "${props.role.name}" role`,
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/settings/roles/RoleListActions/RoleListActions.tsx
+++ b/src/pages/dashboard/settings/roles/RoleListActions/RoleListActions.tsx
@@ -55,7 +55,7 @@ const RoleListActions: FC<RoleListActionsProps> = ({ role }) => {
           {
             icon: "edit",
             label: "Edit",
-            "aria-label": `Edit "${role.group}" role`,
+            "aria-label": `Edit "${role.name}" role`,
             onClick: edit,
           },
         ]}
@@ -63,7 +63,7 @@ const RoleListActions: FC<RoleListActionsProps> = ({ role }) => {
           {
             icon: "delete",
             label: "Remove",
-            "aria-label": `Remove "${role.group}" role`,
+            "aria-label": `Remove "${role.name}" role`,
             onClick: openModal,
           },
         ]}

--- a/src/pages/dashboard/settings/roles/RolesContainer/RolesContainer.test.tsx
+++ b/src/pages/dashboard/settings/roles/RolesContainer/RolesContainer.test.tsx
@@ -1,0 +1,45 @@
+import { renderWithProviders } from "@/tests/render";
+import RolesContainer from "./RolesContainer";
+import { screen } from "@testing-library/react";
+import { expectLoadingState } from "@/tests/helpers";
+import { setEndpointStatus } from "@/tests/controllers/controller";
+
+describe("RolesContainer", () => {
+  it("renders correctly", async () => {
+    renderWithProviders(<RolesContainer />);
+
+    await expectLoadingState();
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+
+    const columnHeaders = [
+      /name/i,
+      /administrators/i,
+      /view/i,
+      /manage/i,
+      /actions/i,
+    ];
+
+    columnHeaders.forEach((header) => {
+      expect(
+        screen.getByRole("columnheader", { name: header }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders empty state for roles", async () => {
+    setEndpointStatus("empty");
+
+    renderWithProviders(<RolesContainer />);
+
+    await expectLoadingState();
+
+    expect(screen.getByText(/no roles found/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/how to manage administrators in landscape/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /add role/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/settings/roles/RolesPage/RolesPage.test.tsx
+++ b/src/pages/dashboard/settings/roles/RolesPage/RolesPage.test.tsx
@@ -1,0 +1,41 @@
+import { renderWithProviders } from "@/tests/render";
+import RolesPage from "./RolesPage";
+import { expectLoadingState } from "@/tests/helpers";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe("RolesPage", () => {
+  const user = userEvent.setup();
+
+  it("renders the Roles Page correctly", async () => {
+    renderWithProviders(<RolesPage />);
+
+    await expectLoadingState();
+
+    expect(screen.getByRole("heading", { name: /roles/i })).toBeInTheDocument();
+
+    const addRoleButton = screen.getByRole("button", { name: /add role/i });
+    expect(addRoleButton).toBeInTheDocument();
+
+    await user.click(addRoleButton);
+
+    expect(screen.getByRole("complementary")).toBeInTheDocument();
+  });
+
+  it("checks that the roles page table is present", async () => {
+    const { container } = renderWithProviders(<RolesPage />);
+
+    await expectLoadingState();
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+
+    const tableHeaders = [
+      "Name",
+      "Administrators",
+      "View",
+      "Manage",
+      "Actions",
+    ];
+    expect(container).toHaveTexts(tableHeaders);
+  });
+});

--- a/src/pages/dashboard/settings/roles/helpers.test.ts
+++ b/src/pages/dashboard/settings/roles/helpers.test.ts
@@ -1,0 +1,222 @@
+import {
+  getPermissionOptions,
+  getAccessGroupOptions,
+  getSortedOptions,
+  getAccessGroupsToSubmit,
+} from "./helpers";
+import { permissions } from "@/tests/mocks/roles";
+import { accessGroups } from "@/tests/mocks/accessGroup";
+import assert from "assert";
+
+const [
+  globalGroupMock,
+  serverGroupMock,
+  desktopGroupMock,
+  testGroupMock,
+  ,
+  subTestGroupMock,
+  subSubTestGroupMock,
+] = accessGroups;
+
+const [
+  viewComputerPermission,
+  manageComputerPermission,
+  addComputerPermission,
+] = permissions;
+
+const manageAccountPermission = permissions.find(
+  (p) => p.name === "ManageAccount",
+);
+
+assert(manageAccountPermission);
+
+describe("Role and Permission Helpers", () => {
+  describe("getPermissionOptions", () => {
+    it("should correctly group view and manage permissions", () => {
+      const options = getPermissionOptions(permissions);
+      const instancesOption = options.find((opt) => opt.label === "instances");
+      assert(instancesOption);
+
+      expect(instancesOption.values.view).toBe(viewComputerPermission.name);
+      expect(instancesOption.values.manage).toBe(manageComputerPermission.name);
+    });
+
+    it('should filter out "RemoveComputerFromAccessGroup"', () => {
+      const options = getPermissionOptions(permissions);
+      const removePermissionName = "RemoveComputerFromAccessGroup";
+      const hasRemovePermission = options.some(
+        (opt) =>
+          opt.values.manage === removePermissionName ||
+          opt.values.view === removePermissionName,
+      );
+      expect(hasRemovePermission).toBe(false);
+    });
+
+    it('should correctly label "AddComputerToAccessGroup" as "access group"', () => {
+      const options = getPermissionOptions(permissions);
+      const accessGroupOption = options.find(
+        (opt) => opt.label === "access group",
+      );
+      assert(accessGroupOption);
+      expect(accessGroupOption.values.manage).toBe(addComputerPermission.name);
+    });
+
+    it("should handle an empty array of permissions", () => {
+      const options = getPermissionOptions([]);
+      expect(options).toEqual([]);
+    });
+
+    it("should set the global flag correctly based on the permission", () => {
+      const options = getPermissionOptions(permissions);
+      const instancesOption = options.find((opt) => opt.label === "instances");
+      const accountOption = options.find((opt) => opt.label === "account");
+
+      assert(instancesOption);
+      assert(accountOption);
+
+      expect(instancesOption.global).toBe(viewComputerPermission.global);
+      expect(accountOption.global).toBe(manageAccountPermission.global);
+    });
+  });
+
+  describe("getAccessGroupOptions", () => {
+    it("should build a hierarchical structure from a flat list", () => {
+      const options = getAccessGroupOptions(accessGroups);
+
+      const globalGroup = options.find(
+        (opt) => opt.value === globalGroupMock.name,
+      );
+      assert(globalGroup);
+      expect(globalGroup.depth).toBe(0);
+
+      const allOtherGroupNames = accessGroups
+        .map((g) => g.name)
+        .filter((name) => name !== globalGroupMock.name);
+      expect(globalGroup.children).toEqual(
+        expect.arrayContaining(allOtherGroupNames),
+      );
+
+      const testGroup = options.find((opt) => opt.value === testGroupMock.name);
+      assert(testGroup);
+
+      expect(testGroup.depth).toBe(1);
+      expect(testGroup.parents).toEqual([globalGroupMock.name]);
+      expect(testGroup.children).toEqual(
+        expect.arrayContaining([
+          subTestGroupMock.name,
+          subSubTestGroupMock.name,
+        ]),
+      );
+
+      const subSubTestGroup = options.find(
+        (opt) => opt.value === subSubTestGroupMock.name,
+      );
+      assert(subSubTestGroup);
+
+      expect(subSubTestGroup.depth).toBe(3);
+      expect(subSubTestGroup.parents).toEqual([
+        subTestGroupMock.name,
+        testGroupMock.name,
+        globalGroupMock.name,
+      ]);
+    });
+
+    it("should handle an empty array of access groups", () => {
+      const options = getAccessGroupOptions([]);
+      expect(options).toEqual([]);
+    });
+
+    it("should correctly identify root elements (depth 0)", () => {
+      const options = getAccessGroupOptions(accessGroups);
+      const rootOptions = options.filter((opt) => opt.depth === 0);
+
+      assert(rootOptions[0]);
+
+      expect(rootOptions.length).toBe(1);
+      expect(rootOptions[0].value).toBe(globalGroupMock.name);
+    });
+  });
+
+  describe("getSortedOptions", () => {
+    it("should sort parents before children", () => {
+      const options = getAccessGroupOptions(accessGroups);
+      const sorted = getSortedOptions(options);
+      const globalIndex = sorted.findIndex(
+        (opt) => opt.value === globalGroupMock.name,
+      );
+      const testIndex = sorted.findIndex(
+        (opt) => opt.value === testGroupMock.name,
+      );
+      const subTestIndex = sorted.findIndex(
+        (opt) => opt.value === subTestGroupMock.name,
+      );
+
+      expect(globalIndex).toBeLessThan(testIndex);
+      expect(testIndex).toBeLessThan(subTestIndex);
+    });
+
+    it("should sort siblings alphabetically", () => {
+      const options = getAccessGroupOptions(accessGroups);
+      const sorted = getSortedOptions(options);
+      const desktopIndex = sorted.findIndex(
+        (opt) => opt.value === desktopGroupMock.name,
+      );
+      const serverIndex = sorted.findIndex(
+        (opt) => opt.value === serverGroupMock.name,
+      );
+      const testIndex = sorted.findIndex(
+        (opt) => opt.value === testGroupMock.name,
+      );
+
+      expect(desktopIndex).toBeLessThan(serverIndex);
+      expect(serverIndex).toBeLessThan(testIndex);
+    });
+  });
+
+  describe("getAccessGroupsToSubmit", () => {
+    it("should remove children if the parent and all its children are selected", () => {
+      const options = getAccessGroupOptions(accessGroups);
+      const selectedGroups = [
+        testGroupMock.name,
+        subTestGroupMock.name,
+        subSubTestGroupMock.name,
+      ];
+
+      const result = getAccessGroupsToSubmit([...selectedGroups], options);
+      expect(result).toEqual([testGroupMock.name]);
+    });
+
+    it("should NOT remove children if parent is selected but NOT ALL children are", () => {
+      const options = getAccessGroupOptions(accessGroups);
+      const selectedGroups = [globalGroupMock.name, serverGroupMock.name];
+      const result = getAccessGroupsToSubmit([...selectedGroups], options);
+      expect(result).toEqual(expect.arrayContaining(selectedGroups));
+      expect(result.length).toBe(selectedGroups.length);
+    });
+
+    it("should handle nested cases correctly by simplifying to the highest-level parent", () => {
+      const options = getAccessGroupOptions(accessGroups);
+      const selectedGroups = [
+        testGroupMock.name,
+        subTestGroupMock.name,
+        subSubTestGroupMock.name,
+      ];
+      const result = getAccessGroupsToSubmit([...selectedGroups], options);
+      expect(result).toEqual([testGroupMock.name]);
+    });
+
+    it("should return an empty array if the input is empty", () => {
+      const options = getAccessGroupOptions(accessGroups);
+      const result = getAccessGroupsToSubmit([], options);
+      expect(result).toEqual([]);
+    });
+
+    it("should not modify the list if no parent-child full selections exist", () => {
+      const options = getAccessGroupOptions(accessGroups);
+      const selectedGroups = [serverGroupMock.name, subTestGroupMock.name];
+      const result = getAccessGroupsToSubmit([...selectedGroups], options);
+      expect(result).toEqual(expect.arrayContaining(selectedGroups));
+      expect(result.length).toBe(selectedGroups.length);
+    });
+  });
+});

--- a/src/tests/mocks/roles.ts
+++ b/src/tests/mocks/roles.ts
@@ -1,10 +1,118 @@
+import type { Permission } from "@/types/Permission";
 import type { Role } from "@/types/Role";
 
-export const roles: Role[] = [
+export const permissions = [
+  { name: "ViewComputer", title: "View computers", global: false },
+  { name: "ManageComputer", title: "Manage computers", global: false },
+  {
+    name: "AddComputerToAccessGroup",
+    title: "Add computers to an access group",
+    global: false,
+  },
+  {
+    name: "RemoveComputerFromAccessGroup",
+    title: "Remove computers from an access group",
+    global: false,
+  },
+  {
+    name: "ManagePendingComputer",
+    title: "Manage pending computers",
+    global: false,
+  },
+  { name: "ViewScript", title: "View scripts", global: false },
+  { name: "ManageScript", title: "Manage scripts", global: false },
+  { name: "RedactScript", title: "Redact scripts", global: false },
+  { name: "ManageMAAS", title: "Manage MAAS Servers", global: false },
+  {
+    name: "ViewRepositoryProfile",
+    title: "View repository profiles",
+    global: false,
+  },
+  {
+    name: "ManageRepositoryProfile",
+    title: "Manage repository profiles",
+    global: false,
+  },
+  { name: "ViewRepository", title: "View package repositories", global: false },
+  {
+    name: "ManageRepository",
+    title: "Manage package repositories",
+    global: false,
+  },
+  { name: "ViewUpgradeProfile", title: "View upgrade profiles", global: false },
+  {
+    name: "ManageUpgradeProfile",
+    title: "Manage upgrade profiles",
+    global: false,
+  },
+  {
+    name: "ViewScheduledProfile",
+    title: "View scheduled profiles",
+    global: false,
+  },
+  {
+    name: "ManageScheduledProfile",
+    title: "Manage scheduled profiles",
+    global: false,
+  },
+  { name: "ViewPackageProfile", title: "View package profiles", global: false },
+  {
+    name: "ManagePackageProfile",
+    title: "Manage package profiles",
+    global: false,
+  },
+  {
+    name: "ViewAutoinstallFile",
+    title: "View Autoinstall Files",
+    global: false,
+  },
+  {
+    name: "ManageAutoinstallFile",
+    title: "Manage Autoinstall Files",
+    global: false,
+  },
+  { name: "ViewEmployee", title: "View Employees", global: false },
+  { name: "ManageEmployee", title: "Manage Employees", global: false },
+  { name: "ViewRemovalProfile", title: "View removal profiles", global: false },
+  {
+    name: "ManageRemovalProfile",
+    title: "Manage removal profiles",
+    global: false,
+  },
+  {
+    name: "ViewChildInstanceProfile",
+    title: "View child instance profiles",
+    global: false,
+  },
+  {
+    name: "ManageChildInstanceProfile",
+    title: "Manage child instance profiles",
+    global: false,
+  },
+  { name: "ViewScriptProfile", title: "View script profiles", global: false },
+  {
+    name: "ManageScriptProfile",
+    title: "Manage script profiles",
+    global: false,
+  },
+  { name: "ManageAccount", title: "Manage account", global: true },
+  { name: "ViewRole", title: "View Roles", global: true },
+  { name: "ManageRole", title: "Manage Roles", global: true },
+  { name: "ViewEventLog", title: "View event log", global: true },
+  { name: "ManageGPGKey", title: "Manage GPG keys", global: true },
+  { name: "ViewBilling", title: "View Billing", global: true },
+  { name: "ManageBilling", title: "Manage Billing", global: true },
+  { name: "ManageSecrets", title: "Manage secrets", global: true },
+] as const satisfies Permission[];
+
+const getRolePermissions = (slicedPermissions: Permission[]) =>
+  slicedPermissions.map((p) => p.name);
+
+export const roles = [
   {
     name: "GlobalAdmin",
     description: "Global role with full privileges in the account",
-    permissions: ["ViewComputer", "ManageComputer", "AddComputerToAccessGroup"],
+    permissions: getRolePermissions(permissions.slice(0, 3)),
     persons: [
       "bob@example.com",
       "john@example.com",
@@ -16,12 +124,7 @@ export const roles: Role[] = [
   {
     name: "Auditor",
     description: "Predefined Auditor role",
-    permissions: [
-      "ViewPackageProfile",
-      "ViewUpgradeProfile",
-      "ViewComputer",
-      "ViewScript",
-    ],
+    permissions: getRolePermissions(permissions.slice(1, 4)),
     global_permissions: [],
     persons: [
       "bob@example.com",
@@ -35,19 +138,14 @@ export const roles: Role[] = [
     name: "Billing-Office1",
     description: "",
     permissions: [],
-    global_permissions: [
-      "ManageRole",
-      "ManageBilling",
-      "ViewRole",
-      "ViewBilling",
-    ],
+    global_permissions: getRolePermissions(permissions.slice(0, 3)),
     persons: ["bob@example.com", "robert@example.com"],
     access_groups: [],
   },
   {
     name: "DesktopAdmin",
     description: "Desktops administrators",
-    permissions: ["ManageComputer", "ViewScript", "ManagePackageProfile"],
+    permissions: getRolePermissions(permissions.slice(3, 6)),
     global_permissions: [],
     persons: ["bob@example.com", "robert@example.com"],
     access_groups: ["desktop"],
@@ -56,7 +154,7 @@ export const roles: Role[] = [
     name: "NewRole",
     description: "Custom role for testing",
     permissions: [],
-    global_permissions: ["ManageRole", "ManageGPGKey", "ViewRole"],
+    global_permissions: getRolePermissions(permissions.slice(0, 3)),
     persons: ["bob@example.com"],
     access_groups: ["sub-test", "test"],
   },
@@ -64,23 +162,14 @@ export const roles: Role[] = [
     name: "Officer",
     description: "",
     permissions: [],
-    global_permissions: ["ManageRole", "ViewRole"],
+    global_permissions: getRolePermissions(permissions.slice(0, 3)),
     persons: ["bob@example.com"],
     access_groups: ["global"],
   },
   {
     name: "ServerAdmin",
     description: "Servers administrators",
-    permissions: [
-      "ViewScript",
-      "ViewPackageProfile",
-      "RedactScript",
-      "ViewComputer",
-      "ManagePackageProfile",
-      "ManageComputer",
-      "ViewUpgradeProfile",
-      "ManageUpgradeProfile",
-    ],
+    permissions: getRolePermissions(permissions),
     global_permissions: [],
     persons: ["bob@example.com", "robert@example.com"],
     access_groups: [],
@@ -88,14 +177,7 @@ export const roles: Role[] = [
   {
     name: "ServerAuditor",
     description: "Servers auditors",
-    permissions: [
-      "RemoveComputerFromAccessGroup",
-      "ViewPackageProfile",
-      "ViewScript",
-      "ViewUpgradeProfile",
-      "ViewComputer",
-      "AddComputerToAccessGroup",
-    ],
+    permissions: getRolePermissions(permissions.slice(0, 5)),
     global_permissions: [],
     persons: ["bob@example.com", "robert@example.com"],
     access_groups: [],
@@ -103,12 +185,7 @@ export const roles: Role[] = [
   {
     name: "SupportAnalyst",
     description: "Predefined SupportAnalyst role",
-    permissions: [
-      "ViewPackageProfile",
-      "ViewUpgradeProfile",
-      "ViewScript",
-      "ViewComputer",
-    ],
+    permissions: getRolePermissions(permissions.slice(1, 6)),
     global_permissions: [],
     persons: ["bob@example.com"],
     access_groups: ["desktop", "windows-xp"],
@@ -116,11 +193,11 @@ export const roles: Role[] = [
   {
     name: "TestRole",
     description: "Test role description",
-    permissions: ["ViewPackageProfile", "ManagePendingComputer"],
-    global_permissions: ["ViewRole"],
+    permissions: getRolePermissions(permissions.slice(0, 3)),
+    global_permissions: getRolePermissions(permissions.slice(0, 1)),
     persons: ["bob@example.com", "jane@example.com"],
     access_groups: ["global"],
   },
-];
+] as const satisfies Role[];
 
 export const administratorRoles = roles.map((role) => role.name);

--- a/src/tests/server/handlers/roles.ts
+++ b/src/tests/server/handlers/roles.ts
@@ -1,16 +1,32 @@
 import { API_URL_OLD } from "@/constants";
 import type { GetRolesParams } from "@/hooks/useRoles";
-import { roles } from "@/tests/mocks/roles";
+import { getEndpointStatus } from "@/tests/controllers/controller";
+import { permissions, roles } from "@/tests/mocks/roles";
 import { isAction } from "@/tests/server/handlers/_helpers";
+import type { Permission } from "@/types/Permission";
 import type { Role } from "@/types/Role";
 import { http, HttpResponse } from "msw";
 
 export default [
   http.get<never, GetRolesParams, Role[]>(API_URL_OLD, ({ request }) => {
+    const { status } = getEndpointStatus();
+
     if (!isAction(request, "GetRoles")) {
       return;
     }
 
+    if (status === "empty") {
+      return HttpResponse.json([]);
+    }
+
     return HttpResponse.json(roles);
+  }),
+
+  http.get<never, never, Permission[]>(API_URL_OLD, ({ request }) => {
+    if (!isAction(request, "GetPermissions")) {
+      return;
+    }
+
+    return HttpResponse.json(permissions);
   }),
 ];


### PR DESCRIPTION
This PR introduces tests for roles page.
It also fixes a bug when updating role permissions, caused by updating both global and non-global permissions