### PR TITLE
fix: wsl profile expandable cells can open individually [LNDENG-3116]

### DIFF
--- a/src/components/layout/Flow/Flow.module.scss
+++ b/src/components/layout/Flow/Flow.module.scss
@@ -27,6 +27,7 @@
   border: 1.5px solid $colors--theme--border-default;
   margin: 0 auto;
   padding: 0 $sph--small;
+  width: min-content;
 }
 
 .children {

--- a/src/features/wsl-profiles/components/WslProfilesList/WslProfilesList.tsx
+++ b/src/features/wsl-profiles/components/WslProfilesList/WslProfilesList.tsx
@@ -24,7 +24,7 @@ import { getCellProps, getRowProps } from "./helpers";
 import classes from "./WslProfilesList.module.scss";
 
 const WslProfilesList: FC = () => {
-  const { expandedRowIndex, getTableRowsRef, handleExpand } =
+  const { expandedRowIndex, expandedColumnId, getTableRowsRef, handleExpand } =
     useExpandableRow();
   const { search } = usePageParams();
   const { setPageParams } = usePageParams();
@@ -73,13 +73,15 @@ const WslProfilesList: FC = () => {
           row: { original: wslProfile, index },
         }: CellProps<WslProfile>) => {
           const onExpand = () => {
-            handleExpand(index);
+            handleExpand(index, "description");
           };
 
           return (
             <TruncatedCell
               content={wslProfile.description}
-              isExpanded={index === expandedRowIndex}
+              isExpanded={
+                index === expandedRowIndex && expandedColumnId === "description"
+              }
               onExpand={onExpand}
             />
           );
@@ -111,7 +113,7 @@ const WslProfilesList: FC = () => {
           }
 
           const onExpand = () => {
-            handleExpand(index);
+            handleExpand(index, "tags");
           };
 
           return (
@@ -121,7 +123,9 @@ const WslProfilesList: FC = () => {
                   {tag}
                 </span>
               ))}
-              isExpanded={index === expandedRowIndex}
+              isExpanded={
+                index === expandedRowIndex && expandedColumnId === "tags"
+              }
               onExpand={onExpand}
               showCount
             />
@@ -184,7 +188,7 @@ const WslProfilesList: FC = () => {
         ),
       },
     ],
-    [accessGroupOptions.length, expandedRowIndex],
+    [accessGroupOptions.length, expandedRowIndex, expandedColumnId],
   );
 
   if (isGettingWslProfiles) {
@@ -197,7 +201,7 @@ const WslProfilesList: FC = () => {
         columns={columns}
         data={wslProfiles}
         emptyMsg={`No WSL profiles found according to your search parameters.`}
-        getCellProps={getCellProps(expandedRowIndex)}
+        getCellProps={getCellProps(expandedRowIndex, expandedColumnId)}
         getRowProps={getRowProps(expandedRowIndex)}
         minWidth={1200}
       />

--- a/src/features/wsl-profiles/components/WslProfilesList/helpers.ts
+++ b/src/features/wsl-profiles/components/WslProfilesList/helpers.ts
@@ -2,7 +2,10 @@ import type { HTMLProps } from "react";
 import type { Cell, Row, TableCellProps, TableRowProps } from "react-table";
 import type { WslProfile } from "../../types";
 
-export const getCellProps = (expandedRowIndex: number | null) => {
+export const getCellProps = (
+  expandedRowIndex: number | null,
+  expandedColumnId: string | null,
+) => {
   return ({
     column,
     row: { index },
@@ -21,12 +24,15 @@ export const getCellProps = (expandedRowIndex: number | null) => {
         break;
       case "tags":
         cellProps["aria-label"] = "Tags";
-        if (expandedRowIndex === index) {
+        if (expandedRowIndex === index && expandedColumnId === "tags") {
           cellProps.className = "expandedCell";
         }
         break;
       case "description":
         cellProps["aria-label"] = "Description";
+        if (expandedRowIndex === index && expandedColumnId === "description") {
+          cellProps.className = "expandedCell";
+        }
         break;
       case "computers['non-compliant']":
         cellProps["aria-label"] = "Not compliant instances";

--- a/src/hooks/useExpandableRow.ts
+++ b/src/hooks/useExpandableRow.ts
@@ -1,8 +1,9 @@
-import { useRef, useState, useCallback } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useOnClickOutside } from "usehooks-ts";
 
 export function useExpandableRow<T extends HTMLElement>() {
   const [expandedRowIndex, setExpandedRowIndex] = useState<number | null>(null);
+  const [expandedColumnId, setExpandedColumnId] = useState<string | null>(null);
   const tableRowsRef = useRef<T[]>([]);
 
   const getTableRowsRef = useCallback((instance: HTMLDivElement | null) => {
@@ -24,12 +25,19 @@ export function useExpandableRow<T extends HTMLElement>() {
     },
   );
 
-  const handleExpand = useCallback((index: number) => {
-    setExpandedRowIndex((prev) => (prev === index ? null : index));
+  const handleExpand = useCallback((index: number, id?: string) => {
+    if (index === expandedRowIndex && id === expandedColumnId) {
+      setExpandedRowIndex(null);
+      setExpandedColumnId(null);
+    } else {
+      setExpandedRowIndex(index);
+      setExpandedColumnId(id ?? null);
+    }
   }, []);
 
   return {
     expandedRowIndex,
+    expandedColumnId,
     getTableRowsRef,
     handleExpand,
   };


### PR DESCRIPTION
- The description and tags cells in the WSL profiles page can open individually
- The styles for the security profile form confirmation step are fixed