### PR TITLE
fix: delete wsl children

### DIFF
--- a/src/features/wsl/api/useUninstallWslInstances.ts
+++ b/src/features/wsl/api/useUninstallWslInstances.ts
@@ -19,7 +19,7 @@ export const useUninstallWslInstances = () => {
     UninstallWslInstancesParams
   >({
     mutationFn: async ({ parent_id, ...params }) =>
-      authFetch.post(`computers/${parent_id}/delete-children`, { params }),
+      authFetch.post(`computers/${parent_id}/delete-children`, params),
     onSuccess: async () =>
       Promise.all([
         queryClient.invalidateQueries({ queryKey: ["wsl-hosts"] }),


### PR DESCRIPTION
Right now it passes `{ params: { child_names: [] } }`, it should just be `{ child_names: [] }`.