### PR TITLE
feat: account creation

### DIFF
--- a/src/components/form/PasswordConstraints/PasswordConstraints.module.scss
+++ b/src/components/form/PasswordConstraints/PasswordConstraints.module.scss
@@ -1,10 +1,14 @@
 @import "vanilla-framework/scss/settings_colors";
 @import "vanilla-framework/scss/settings_spacing";
 
-.passwordConstraint {
+.constraint {
   align-items: center;
   column-gap: $sph--small;
   display: flex;
+
+  &:not(:last-child) {
+    margin-bottom: $spv--small;
+  }
 
   &.passed {
     color: $color-positive;

--- a/src/components/form/PasswordConstraints/PasswordConstraints.tsx
+++ b/src/components/form/PasswordConstraints/PasswordConstraints.tsx
@@ -1,0 +1,67 @@
+import { Icon } from "@canonical/react-components";
+import classNames from "classnames";
+import type { FC } from "react";
+import { MAX_PASSWORD_LENGTH } from "@/constants";
+import classes from "./PasswordConstraints.module.scss";
+import { getIconName } from "./helpers";
+
+interface PasswordConstraint {
+  label: string;
+  passed: boolean;
+}
+
+interface PasswordConstraintsProps {
+  readonly password: string;
+  readonly touched: boolean;
+  readonly hasError: boolean;
+  readonly className?: string;
+}
+
+const PasswordConstraints: FC<PasswordConstraintsProps> = ({
+  password,
+  touched,
+  hasError,
+  className,
+}) => {
+  const constraints: PasswordConstraint[] = [
+    {
+      label: "8-50 characters",
+      passed: password.length >= 8 && password.length <= MAX_PASSWORD_LENGTH,
+    },
+    {
+      label: "Lower case letters (a-z)",
+      passed: /[a-z]/.test(password),
+    },
+    {
+      label: "Upper case letters (A-Z)",
+      passed: /[A-Z]/.test(password),
+    },
+    {
+      label: "Numbers (0-9)",
+      passed: /[0-9]/.test(password),
+    },
+  ];
+
+  return (
+    <div className={className}>
+      <p className="u-text--muted p-text--small">Password must contain</p>
+      <div>
+        {constraints.map((constraint) => (
+          <span
+            key={constraint.label}
+            className={classNames("p-text--small", classes.constraint, {
+              [classes.passed]: constraint.passed,
+              [classes.default]: !constraint.passed && !touched,
+              [classes.failed]: !constraint.passed && hasError && touched,
+            })}
+          >
+            <Icon name={getIconName(constraint.passed, hasError, touched)} />
+            {constraint.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PasswordConstraints;

--- a/src/components/form/PasswordConstraints/constants.ts
+++ b/src/components/form/PasswordConstraints/constants.ts
@@ -1,0 +1,15 @@
+import { MAX_PASSWORD_LENGTH } from "@/constants";
+import * as Yup from "yup";
+
+export const passwordValidationSchema = {
+  password: Yup.string()
+    .required("This field is required")
+    .min(8, "Password must be at least 8 characters long")
+    .max(
+      MAX_PASSWORD_LENGTH,
+      `Password must be at most ${MAX_PASSWORD_LENGTH} characters long`,
+    )
+    .matches(/[a-z]/, "Password must contain at least one lowercase letter")
+    .matches(/[A-Z]/, "Password must contain at least one uppercase letter")
+    .matches(/[0-9]/, "Password must contain at least one number"),
+};

--- a/src/components/form/PasswordConstraints/helpers.ts
+++ b/src/components/form/PasswordConstraints/helpers.ts
@@ -1,0 +1,14 @@
+export const getIconName = (
+  passed: boolean,
+  hasError: boolean,
+  touched: boolean,
+): "success" | "error" | "information--muted" => {
+  if (passed) {
+    return "success";
+  }
+  if (hasError && touched) {
+    return "error";
+  }
+
+  return "information--muted";
+};

--- a/src/components/form/PasswordConstraints/index.ts
+++ b/src/components/form/PasswordConstraints/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./PasswordConstraints";
+export { passwordValidationSchema } from "./constants";

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -22,6 +22,7 @@ const NOT_AUTHORIZED_CODE = 401;
 export interface AuthContextProps {
   authLoading: boolean;
   authorized: boolean;
+  hasAccounts: boolean;
   logout: () => void;
   redirectToExternalUrl: (url: string, options?: { replace: boolean }) => void;
   setAuthLoading: (loading: boolean) => void;
@@ -33,6 +34,7 @@ export interface AuthContextProps {
 const initialState: AuthContextProps = {
   authLoading: false,
   authorized: false,
+  hasAccounts: false,
   logout: () => undefined,
   redirectToExternalUrl: () => undefined,
   setAuthLoading: () => undefined,
@@ -76,7 +78,7 @@ const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
     }
 
     setLoading(false);
-  }, [pathname]);
+  }, [loading, pathname]);
 
   const { data: getAuthStateQueryResult } = getAuthStateQuery(
     {},
@@ -105,13 +107,13 @@ const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
     [notify.notification],
   );
 
-  const handleLogout = () => {
+  const handleLogout = useCallback(() => {
     setUser(null);
     navigate(ROUTES.auth.login(), { replace: true });
     queryClient.removeQueries({
       predicate: (query) => query.queryKey[0] !== "authUser",
     });
-  };
+  }, [navigate, queryClient]);
 
   useEffect(() => {
     if (!isAuthError) {
@@ -119,7 +121,7 @@ const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
     }
 
     handleLogout();
-  }, [isAuthError]);
+  }, [handleLogout, isAuthError]);
 
   const handleSetUser = (newUser: AuthUser) => {
     setUser(newUser);
@@ -148,6 +150,7 @@ const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
         user,
         authLoading: loading || isFeaturesLoading,
         authorized: null !== user,
+        hasAccounts: !!user?.accounts.length,
         logout: handleLogout,
         redirectToExternalUrl: handleExternalRedirect,
         setAuthLoading: handleAuthLoading,

--- a/src/context/env.tsx
+++ b/src/context/env.tsx
@@ -2,6 +2,7 @@ import axios from "axios";
 import type { FC, ReactNode } from "react";
 import { createContext, useEffect, useState } from "react";
 import { API_URL, IS_SELF_HOSTED_ENV } from "@/constants";
+import useDebug from "@/hooks/useDebug";
 
 interface AboutResponse {
   self_hosted: boolean;
@@ -36,26 +37,31 @@ interface EnvProviderProps {
 
 const EnvProvider: FC<EnvProviderProps> = ({ children }) => {
   const [state, setState] = useState<EnvContextState>(initialState);
+  const debug = useDebug();
 
   useEffect(() => {
     (async () => {
-      const { data } = await axios.get<AboutResponse>(`${API_URL}about`);
-      setState({
-        envLoading: false,
-        isSaas:
-          undefined !== IS_SELF_HOSTED_ENV
-            ? ["false", "0"].includes(IS_SELF_HOSTED_ENV)
-            : !data.self_hosted,
-        isSelfHosted:
-          undefined !== IS_SELF_HOSTED_ENV
-            ? ["true", "1"].includes(IS_SELF_HOSTED_ENV)
-            : data.self_hosted,
-        packageVersion: data.package_version,
-        revision: data.revision,
-        displayDisaStigBanner: data.display_disa_stig_banner,
-      });
+      try {
+        const { data } = await axios.get<AboutResponse>(`${API_URL}about`);
+        setState({
+          envLoading: false,
+          isSaas:
+            undefined !== IS_SELF_HOSTED_ENV
+              ? ["false", "0"].includes(IS_SELF_HOSTED_ENV)
+              : !data.self_hosted,
+          isSelfHosted:
+            undefined !== IS_SELF_HOSTED_ENV
+              ? ["true", "1"].includes(IS_SELF_HOSTED_ENV)
+              : data.self_hosted,
+          packageVersion: data.package_version,
+          revision: data.revision,
+          displayDisaStigBanner: data.display_disa_stig_banner,
+        });
+      } catch (error) {
+        debug(error);
+      }
     })();
-  }, []);
+  }, [debug]);
 
   return <EnvContext.Provider value={state}>{children}</EnvContext.Provider>;
 };

--- a/src/features/account-creation/api/index.ts
+++ b/src/features/account-creation/api/index.ts
@@ -1,0 +1,6 @@
+export { useCreateSaaSAccount } from "./useCreateSaaSAccount";
+export { useGetStandaloneAccount } from "./useGetStandaloneAccount";
+export {
+  useCreateStandaloneAccount,
+  type CreateStandaloneAccountParams,
+} from "./useCreateStandaloneAccount";

--- a/src/features/account-creation/api/useCreateSaaSAccount.ts
+++ b/src/features/account-creation/api/useCreateSaaSAccount.ts
@@ -1,0 +1,31 @@
+import useFetch from "@/hooks/useFetch";
+import type { ApiError } from "@/types/api/ApiError";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { AxiosError, AxiosResponse } from "axios";
+
+export interface CreateSaaSAccountParams {
+  title: string;
+  email?: string;
+  password?: string;
+}
+
+export const useCreateSaaSAccount = () => {
+  const authFetch = useFetch();
+  const queryClient = useQueryClient();
+
+  const { isPending, mutateAsync } = useMutation<
+    AxiosResponse<void>,
+    AxiosError<ApiError>,
+    CreateSaaSAccountParams
+  >({
+    mutationFn: async (params) => authFetch.post("accounts", params),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["authUser"] });
+    },
+  });
+
+  return {
+    createSaaSAccount: mutateAsync,
+    isCreatingSaaSAccount: isPending,
+  };
+};

--- a/src/features/account-creation/api/useCreateStandaloneAccount.ts
+++ b/src/features/account-creation/api/useCreateStandaloneAccount.ts
@@ -1,0 +1,35 @@
+import type { ApiError } from "@/types/api/ApiError";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { AxiosError, AxiosResponse } from "axios";
+import axios from "axios";
+import { API_URL } from "@/constants";
+
+export interface CreateStandaloneAccountParams {
+  email: string;
+  name: string;
+  password: string;
+}
+
+export const useCreateStandaloneAccount = () => {
+  const queryClient = useQueryClient();
+  const axiosInstance = axios.create({ baseURL: API_URL });
+
+  const { isPending, mutateAsync } = useMutation<
+    AxiosResponse<unknown>,
+    AxiosError<ApiError>,
+    CreateStandaloneAccountParams
+  >({
+    mutationFn: async (params) =>
+      axiosInstance.post("standalone-account", params),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["standaloneAccount"],
+      });
+    },
+  });
+
+  return {
+    createStandaloneAccount: mutateAsync,
+    isCreatingStandaloneAccount: isPending,
+  };
+};

--- a/src/features/account-creation/api/useGetStandaloneAccount.ts
+++ b/src/features/account-creation/api/useGetStandaloneAccount.ts
@@ -1,0 +1,32 @@
+import useEnv from "@/hooks/useEnv";
+import type { ApiError } from "@/types/api/ApiError";
+import { useQuery } from "@tanstack/react-query";
+import type { AxiosError, AxiosResponse } from "axios";
+import axios from "axios";
+import { API_URL } from "@/constants";
+import { useState } from "react";
+
+export const useGetStandaloneAccount = () => {
+  const { isSelfHosted } = useEnv();
+  const [axiosInstance] = useState(() => axios.create({ baseURL: API_URL }));
+
+  const { data, isLoading, error } = useQuery<
+    AxiosResponse<{ exists: boolean }>,
+    AxiosError<ApiError>
+  >({
+    queryKey: ["standaloneAccount"],
+    queryFn: async () => await axiosInstance.get("standalone-account"),
+    retry: false,
+    enabled: isSelfHosted,
+    staleTime: 0,
+    gcTime: 0,
+  });
+
+  const accountExists = data?.data.exists ?? false;
+
+  return {
+    accountExists,
+    isLoading,
+    error,
+  };
+};

--- a/src/features/account-creation/components/AccountCreationSaaSForm/AccountCreationSaaSForm.module.scss
+++ b/src/features/account-creation/components/AccountCreationSaaSForm/AccountCreationSaaSForm.module.scss
@@ -1,0 +1,5 @@
+@import "vanilla-framework/scss/settings_spacing";
+
+.button {
+  margin-top: $spv--large;
+}

--- a/src/features/account-creation/components/AccountCreationSaaSForm/AccountCreationSaaSForm.test.tsx
+++ b/src/features/account-creation/components/AccountCreationSaaSForm/AccountCreationSaaSForm.test.tsx
@@ -1,0 +1,39 @@
+import { renderWithProviders } from "@/tests/render";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AccountCreationSaaSForm from "./AccountCreationSaaSForm";
+
+describe("AccountCreationSaaSForm", () => {
+  const user = userEvent.setup();
+
+  it("renders the form correctly", () => {
+    renderWithProviders(<AccountCreationSaaSForm />);
+
+    expect(
+      screen.getByText("Create a new Landscape SaaS account"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "There is no Landscape organization related to your account.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Organization name")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This will be the name of the Landscape account for your organization.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Create account" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows validation error for empty title", async () => {
+    renderWithProviders(<AccountCreationSaaSForm />);
+
+    const submitButton = screen.getByRole("button", { name: "Create account" });
+    await user.click(submitButton);
+
+    expect(screen.getByText("This field is required.")).toBeInTheDocument();
+  });
+});

--- a/src/features/account-creation/components/AccountCreationSaaSForm/AccountCreationSaaSForm.tsx
+++ b/src/features/account-creation/components/AccountCreationSaaSForm/AccountCreationSaaSForm.tsx
@@ -1,0 +1,68 @@
+import {
+  ActionButton,
+  Form,
+  Input,
+  Notification,
+} from "@canonical/react-components";
+import type { FC } from "react";
+import AuthTemplate from "@/templates/auth/AuthTemplate";
+import { useFormik } from "formik";
+import { getFormikError } from "@/utils/formikErrors";
+import { useCreateSaaSAccount } from "../../api";
+import useDebug from "@/hooks/useDebug";
+import { INITIAL_VALUES, VALIDATION_SCHEMA } from "./constants";
+import type { FormValues } from "./types";
+import classes from "./AccountCreationSaaSForm.module.scss";
+import classNames from "classnames";
+
+const AccountCreationSaaSForm: FC = () => {
+  const debug = useDebug();
+  const {
+    createSaaSAccount: createAccount,
+    isCreatingSaaSAccount: isCreatingAccount,
+  } = useCreateSaaSAccount();
+
+  const handleSubmit = async (values: FormValues) => {
+    try {
+      await createAccount({ title: values.title });
+    } catch (error) {
+      debug(error);
+    }
+  };
+
+  const formik = useFormik<FormValues>({
+    initialValues: INITIAL_VALUES,
+    validationSchema: VALIDATION_SCHEMA,
+    onSubmit: handleSubmit,
+  });
+
+  return (
+    <AuthTemplate title="Create a new Landscape SaaS account">
+      <Notification severity="caution">
+        There is no Landscape organization related to your account.
+      </Notification>
+      <Form onSubmit={formik.handleSubmit} noValidate>
+        <Input
+          type="text"
+          label="Organization name"
+          required
+          help="This will be the name of the Landscape account for your organization."
+          {...formik.getFieldProps("title")}
+          error={getFormikError(formik, "title")}
+        />
+
+        <ActionButton
+          className={classNames("u-no-margin--bottom", classes.button)}
+          appearance="positive"
+          type="submit"
+          loading={isCreatingAccount}
+          disabled={isCreatingAccount}
+        >
+          Create account
+        </ActionButton>
+      </Form>
+    </AuthTemplate>
+  );
+};
+
+export default AccountCreationSaaSForm;

--- a/src/features/account-creation/components/AccountCreationSaaSForm/constants.ts
+++ b/src/features/account-creation/components/AccountCreationSaaSForm/constants.ts
@@ -1,0 +1,10 @@
+import * as Yup from "yup";
+import type { FormValues } from "./types";
+
+export const VALIDATION_SCHEMA = Yup.object().shape({
+  title: Yup.string().required("This field is required."),
+});
+
+export const INITIAL_VALUES: FormValues = {
+  title: "",
+};

--- a/src/features/account-creation/components/AccountCreationSaaSForm/index.ts
+++ b/src/features/account-creation/components/AccountCreationSaaSForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AccountCreationSaaSForm";

--- a/src/features/account-creation/components/AccountCreationSaaSForm/types.ts
+++ b/src/features/account-creation/components/AccountCreationSaaSForm/types.ts
@@ -1,0 +1,3 @@
+export interface FormValues {
+  title: string;
+}

--- a/src/features/account-creation/components/AccountCreationSelfHostedForm/AccountCreationSelfHostedForm.module.scss
+++ b/src/features/account-creation/components/AccountCreationSelfHostedForm/AccountCreationSelfHostedForm.module.scss
@@ -1,0 +1,5 @@
+@import "vanilla-framework/scss/settings_spacing";
+
+.button {
+  margin-top: $spv--large;
+}

--- a/src/features/account-creation/components/AccountCreationSelfHostedForm/AccountCreationSelfHostedForm.test.tsx
+++ b/src/features/account-creation/components/AccountCreationSelfHostedForm/AccountCreationSelfHostedForm.test.tsx
@@ -1,0 +1,42 @@
+import { renderWithProviders } from "@/tests/render";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AccountCreationSelfHostedForm from "./AccountCreationSelfHostedForm";
+
+describe("AccountCreationSelfHostedForm", () => {
+  it("renders the form correctly", () => {
+    renderWithProviders(<AccountCreationSelfHostedForm />);
+
+    expect(
+      screen.getByText("Create a new Landscape account"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Full name")).toBeInTheDocument();
+    expect(screen.getByLabelText("Email address")).toBeInTheDocument();
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Create account" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows validation errors for empty fields", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AccountCreationSelfHostedForm />);
+
+    const submitButton = screen.getByRole("button", { name: "Create account" });
+    await user.click(submitButton);
+
+    expect(screen.getAllByText("This field is required")).toHaveLength(2);
+  });
+
+  it("shows validation error for invalid email", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AccountCreationSelfHostedForm />);
+
+    await user.type(screen.getByLabelText("Email address"), "invalid-email");
+
+    const submitButton = screen.getByRole("button", { name: "Create account" });
+    await user.click(submitButton);
+
+    expect(screen.getByText("Invalid email address")).toBeInTheDocument();
+  });
+});

--- a/src/features/account-creation/components/AccountCreationSelfHostedForm/AccountCreationSelfHostedForm.tsx
+++ b/src/features/account-creation/components/AccountCreationSelfHostedForm/AccountCreationSelfHostedForm.tsx
@@ -1,0 +1,112 @@
+import PasswordConstraints from "@/components/form/PasswordConstraints";
+import useDebug from "@/hooks/useDebug";
+import AuthTemplate from "@/templates/auth/AuthTemplate";
+import { getFormikError } from "@/utils/formikErrors";
+import {
+  ActionButton,
+  Form,
+  Input,
+  PasswordToggle,
+} from "@canonical/react-components";
+import { useFormik } from "formik";
+import type { FC } from "react";
+import { useNavigate } from "react-router";
+import { useCreateStandaloneAccount } from "../../api";
+import { INITIAL_VALUES, VALIDATION_SCHEMA } from "./constants";
+import { ROUTES } from "@/libs/routes";
+import type { FormValues } from "./types";
+import useAuth from "@/hooks/useAuth";
+import { HOMEPAGE_PATH } from "@/constants";
+import { useUnsigned } from "@/features/auth";
+import classNames from "classnames";
+import classes from "./AccountCreationSelfHostedForm.module.scss";
+
+const AccountCreationSelfHostedForm: FC = () => {
+  const debug = useDebug();
+  const navigate = useNavigate();
+  const { createStandaloneAccount, isCreatingStandaloneAccount } =
+    useCreateStandaloneAccount();
+  const { setUser } = useAuth();
+  const { signInWithEmailAndPasswordQuery } = useUnsigned();
+  const { mutateAsync: signIn } = signInWithEmailAndPasswordQuery;
+
+  const handleSubmit = async (values: FormValues) => {
+    try {
+      await createStandaloneAccount({
+        name: values.fullName,
+        email: values.email,
+        password: values.password,
+      });
+
+      const { data } = await signIn({
+        email: values.email,
+        password: values.password,
+      });
+
+      if ("current_account" in data) {
+        setUser(data);
+        navigate(HOMEPAGE_PATH, { replace: true });
+      } else {
+        navigate(ROUTES.auth.login(), { replace: true });
+      }
+    } catch (error) {
+      debug(error);
+    }
+  };
+
+  const formik = useFormik<FormValues>({
+    initialValues: INITIAL_VALUES,
+    validationSchema: VALIDATION_SCHEMA,
+    onSubmit: handleSubmit,
+  });
+
+  return (
+    <AuthTemplate title="Create a new Landscape account">
+      <Form onSubmit={formik.handleSubmit} noValidate>
+        <Input
+          type="text"
+          label="Full name"
+          required
+          autoComplete="name"
+          {...formik.getFieldProps("fullName")}
+          error={getFormikError(formik, "fullName")}
+        />
+
+        <Input
+          type="email"
+          label="Email address"
+          required
+          autoComplete="email"
+          {...formik.getFieldProps("email")}
+          error={getFormikError(formik, "email")}
+        />
+
+        <PasswordToggle
+          id="password"
+          label="Password"
+          required
+          autoComplete="new-password"
+          {...formik.getFieldProps("password")}
+        />
+
+        <PasswordConstraints
+          password={formik.values.password}
+          touched={!!formik.touched.password}
+          hasError={!!formik.errors.password}
+        />
+
+        <ActionButton
+          className={classNames(classes.button, "u-no-margin--bottom")}
+          appearance="positive"
+          type="submit"
+          loading={isCreatingStandaloneAccount}
+          disabled={isCreatingStandaloneAccount}
+        >
+          Create account
+        </ActionButton>
+      </Form>
+    </AuthTemplate>
+  );
+};
+
+export default AccountCreationSelfHostedForm;

--- a/src/features/account-creation/components/AccountCreationSelfHostedForm/constants.ts
+++ b/src/features/account-creation/components/AccountCreationSelfHostedForm/constants.ts
@@ -1,0 +1,17 @@
+import { passwordValidationSchema } from "@/components/form/PasswordConstraints";
+import * as Yup from "yup";
+import type { FormValues } from "./types";
+
+export const INITIAL_VALUES: FormValues = {
+  fullName: "",
+  email: "",
+  password: "",
+};
+
+export const VALIDATION_SCHEMA = Yup.object().shape({
+  ...passwordValidationSchema,
+  fullName: Yup.string().required("This field is required"),
+  email: Yup.string()
+    .required("This field is required")
+    .email("Invalid email address"),
+});

--- a/src/features/account-creation/components/AccountCreationSelfHostedForm/index.ts
+++ b/src/features/account-creation/components/AccountCreationSelfHostedForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AccountCreationSelfHostedForm";

--- a/src/features/account-creation/components/AccountCreationSelfHostedForm/types.ts
+++ b/src/features/account-creation/components/AccountCreationSelfHostedForm/types.ts
@@ -1,0 +1,5 @@
+export interface FormValues {
+  fullName: string;
+  email: string;
+  password: string;
+}

--- a/src/features/account-creation/index.ts
+++ b/src/features/account-creation/index.ts
@@ -1,0 +1,3 @@
+export { default as AccountCreationSaaSForm } from "./components/AccountCreationSaaSForm";
+export { default as AccountCreationSelfHostedForm } from "./components/AccountCreationSelfHostedForm";
+export { useGetStandaloneAccount } from "./api";

--- a/src/features/alerts/components/AlertsList/AlertsList.test.tsx
+++ b/src/features/alerts/components/AlertsList/AlertsList.test.tsx
@@ -25,6 +25,7 @@ const authProps: AuthContextProps = {
   user: authUser,
   redirectToExternalUrl: vi.fn(),
   isFeatureEnabled: vi.fn(),
+  hasAccounts: true,
 };
 
 describe("AlertsList", () => {

--- a/src/features/auth/components/AvailableProviderList/AvailableProviderList.test.tsx
+++ b/src/features/auth/components/AvailableProviderList/AvailableProviderList.test.tsx
@@ -5,7 +5,7 @@ import type { ComponentProps } from "react";
 import { screen } from "@testing-library/react";
 import {
   identityProviders,
-  locationToRedirectTo,
+  oidcLocationToRedirectTo,
 } from "@/tests/mocks/identityProviders";
 import userEvent from "@testing-library/user-event";
 
@@ -37,6 +37,8 @@ describe("AvailableProviderList", () => {
       await screen.findByRole("button", { name: "Sign in with Okta Enabled" }),
     );
 
-    expect(redirectToExternalUrl).toHaveBeenCalledWith(locationToRedirectTo);
+    expect(redirectToExternalUrl).toHaveBeenCalledWith(
+      `${window.location.origin}${oidcLocationToRedirectTo}`,
+    );
   });
 });

--- a/src/features/auth/components/AvailableProviderList/AvailableProviderList.tsx
+++ b/src/features/auth/components/AvailableProviderList/AvailableProviderList.tsx
@@ -43,6 +43,7 @@ const AvailableProviderList: FC<AvailableProviderListProps> = ({
 
   if (invitationId) {
     params.invitation_id = invitationId;
+    params.return_to = `/accept-invitation/${invitationId}`;
   }
 
   if (external) {
@@ -73,6 +74,7 @@ const AvailableProviderList: FC<AvailableProviderListProps> = ({
 
   if (invitationId) {
     ubuntuOneParams.invitation_id = invitationId;
+    ubuntuOneParams.return_to = `/accept-invitation/${invitationId}`;
   }
 
   if (external) {

--- a/src/features/auth/hooks/useInvitation.ts
+++ b/src/features/auth/hooks/useInvitation.ts
@@ -1,14 +1,19 @@
-import { useSearchParams } from "react-router";
+import { useParams, useSearchParams } from "react-router";
 import { useUnsigned } from "@/features/auth";
+import useAuth from "@/hooks/useAuth";
 
 export default function useInvitation() {
   const { getInvitationSummaryQuery } = useUnsigned();
+  const { user } = useAuth();
 
+  const { secureId } = useParams<{ secureId: string }>();
   const [searchParams] = useSearchParams();
-  const invitationId = searchParams.get("invitation_id") ?? "";
+
+  const invitationId =
+    user?.invitation_id || secureId || searchParams.get("invitation_id") || "";
 
   const { data, isLoading } = getInvitationSummaryQuery(
-    { invitationId: invitationId ?? "" },
+    { invitationId },
     { enabled: !!invitationId },
   );
 

--- a/src/features/auth/types/AuthUser.d.ts
+++ b/src/features/auth/types/AuthUser.d.ts
@@ -13,4 +13,5 @@ export interface AuthUser {
   has_password: boolean;
   name: string;
   token: string;
+  invitation_id?: string;
 }

--- a/src/features/general-settings/components/ChangePasswordForm/ChangePasswordForm.tsx
+++ b/src/features/general-settings/components/ChangePasswordForm/ChangePasswordForm.tsx
@@ -1,15 +1,13 @@
 import SidePanelFormButtons from "@/components/form/SidePanelFormButtons";
+import PasswordConstraints from "@/components/form/PasswordConstraints";
 import useDebug from "@/hooks/useDebug";
 import useNotify from "@/hooks/useNotify";
 import useSidePanel from "@/hooks/useSidePanel";
-import { Form, Icon, Input, PasswordToggle } from "@canonical/react-components";
-import classNames from "classnames";
+import { Form, Input, PasswordToggle } from "@canonical/react-components";
 import { useFormik } from "formik";
 import type { FC } from "react";
 import { useUserGeneralSettings } from "../../hooks";
-import classes from "./ChangePasswordForm.module.scss";
 import { VALIDATION_SCHEMA } from "./constants";
-import { MAX_PASSWORD_LENGTH } from "@/constants";
 
 interface FormProps {
   currentPassword: string;
@@ -45,26 +43,6 @@ const ChangePasswordForm: FC = () => {
     },
   });
 
-  const checkConstraints = () => [
-    {
-      label: "8-50 characters",
-      passed:
-        formik.values.newPassword.length >= 8 &&
-        formik.values.newPassword.length <= MAX_PASSWORD_LENGTH,
-    },
-    {
-      label: "Lower case letters (a-z)",
-      passed: /[a-z]/.test(formik.values.newPassword),
-    },
-    {
-      label: "Upper case letters (A-Z)",
-      passed: /[A-Z]/.test(formik.values.newPassword),
-    },
-    { label: "Numbers (0-9)", passed: /[0-9]/.test(formik.values.newPassword) },
-  ];
-
-  const constraints = checkConstraints();
-
   return (
     <Form noValidate onSubmit={formik.handleSubmit}>
       <Input
@@ -94,36 +72,13 @@ const ChangePasswordForm: FC = () => {
         }
         {...formik.getFieldProps("newPassword")}
       />
-      <>
-        <span className={classNames("u-text--muted")}>
-          Password must contain
-        </span>
-        {constraints.map((constraint) => (
-          <span
-            key={constraint.label}
-            className={classNames(classes.passwordConstraint, {
-              [classes.passed]: constraint.passed,
-              [classes.default]:
-                !constraint.passed && !formik.touched.newPassword,
-              [classes.failed]:
-                !constraint.passed &&
-                formik.errors.newPassword &&
-                formik.touched.newPassword,
-            })}
-          >
-            <Icon
-              name={
-                constraint.passed
-                  ? "success"
-                  : formik.errors.newPassword && formik.touched.newPassword
-                    ? "error"
-                    : "information"
-              }
-            />
-            {constraint.label}
-          </span>
-        ))}
-      </>
+
+      <PasswordConstraints
+        password={formik.values.newPassword}
+        touched={!!formik.touched.newPassword}
+        hasError={!!formik.errors.newPassword}
+      />
+
       <SidePanelFormButtons
         submitButtonDisabled={formik.isSubmitting}
         submitButtonText="Save changes"

--- a/src/features/general-settings/components/ChangePasswordForm/constants.ts
+++ b/src/features/general-settings/components/ChangePasswordForm/constants.ts
@@ -1,16 +1,7 @@
 import * as Yup from "yup";
-import { MAX_PASSWORD_LENGTH } from "@/constants";
+import { passwordValidationSchema } from "@/components/form/PasswordConstraints";
 
 export const VALIDATION_SCHEMA = Yup.object().shape({
   currentPassword: Yup.string().required("This field is required"),
-  newPassword: Yup.string()
-    .required("This field is required")
-    .min(8, "Password must be at least 8 characters long")
-    .max(
-      MAX_PASSWORD_LENGTH,
-      `Password must be at most ${MAX_PASSWORD_LENGTH} characters long`,
-    )
-    .matches(/[a-z]/, "Password must contain at least one lowercase letter")
-    .matches(/[A-Z]/, "Password must contain at least one uppercase letter")
-    .matches(/[0-9]/, "Password must contain at least one number"),
+  newPassword: passwordValidationSchema.password,
 });

--- a/src/features/general-settings/components/EditUserForm/EditUserForm.test.tsx
+++ b/src/features/general-settings/components/EditUserForm/EditUserForm.test.tsx
@@ -63,6 +63,7 @@ const authContextValues: AuthContextProps = {
   user: authUser,
   redirectToExternalUrl: vi.fn(),
   isFeatureEnabled: vi.fn(),
+  hasAccounts: true,
 };
 
 const mockSelfHosted: EnvContextState = {

--- a/src/features/general-settings/components/EditUserForm/EditUserForm.tsx
+++ b/src/features/general-settings/components/EditUserForm/EditUserForm.tsx
@@ -158,7 +158,7 @@ const EditUserForm: FC<EditUserFormProps> = ({ userDetails }) => {
           help={
             isSaas ? (
               <>
-                To change your passphrase, go to{" "}
+                To change your password, go to{" "}
                 <Link
                   href="https://login.ubuntu.com/"
                   target="_blank"

--- a/src/features/invitation/api/index.ts
+++ b/src/features/invitation/api/index.ts
@@ -1,0 +1,2 @@
+export * from "./useAcceptInvitation";
+export * from "./useRejectInvitation";

--- a/src/features/invitation/api/useAcceptInvitation.ts
+++ b/src/features/invitation/api/useAcceptInvitation.ts
@@ -1,0 +1,29 @@
+import useFetch from "@/hooks/useFetch";
+import type { ApiError } from "@/types/api/ApiError";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { AxiosError, AxiosResponse } from "axios";
+
+export interface AcceptInvitationParams {
+  invitation_id: string;
+}
+
+export const useAcceptInvitation = () => {
+  const authFetch = useFetch();
+  const queryClient = useQueryClient();
+
+  const { isPending, mutateAsync } = useMutation<
+    AxiosResponse<void>,
+    AxiosError<ApiError>,
+    AcceptInvitationParams
+  >({
+    mutationFn: async (params) => authFetch.post("accept-invitation", params),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["authUser"] });
+    },
+  });
+
+  return {
+    acceptInvitation: mutateAsync,
+    isAcceptingInvitation: isPending,
+  };
+};

--- a/src/features/invitation/api/useRejectInvitation.ts
+++ b/src/features/invitation/api/useRejectInvitation.ts
@@ -1,0 +1,25 @@
+import useFetch from "@/hooks/useFetch";
+import type { ApiError } from "@/types/api/ApiError";
+import { useMutation } from "@tanstack/react-query";
+import type { AxiosError, AxiosResponse } from "axios";
+
+export interface RejectInvitationParams {
+  invitation_id: string;
+}
+
+export const useRejectInvitation = () => {
+  const authFetch = useFetch();
+
+  const { isPending, mutateAsync } = useMutation<
+    AxiosResponse<void>,
+    AxiosError<ApiError>,
+    RejectInvitationParams
+  >({
+    mutationFn: async (params) => authFetch.post("reject-invitation", params),
+  });
+
+  return {
+    rejectInvitation: mutateAsync,
+    isRejectingInvitation: isPending,
+  };
+};

--- a/src/features/invitation/components/InvitationError/InvitationError.test.tsx
+++ b/src/features/invitation/components/InvitationError/InvitationError.test.tsx
@@ -1,0 +1,43 @@
+import { renderWithProviders } from "@/tests/render";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { describe } from "vitest";
+import { vi } from "vitest";
+import InvitationError from "./InvitationError";
+
+const props: ComponentProps<typeof InvitationError> = {
+  onBackToLogin: vi.fn(),
+};
+
+describe("InvitationError", () => {
+  const user = userEvent.setup();
+
+  it("should render the invitation error message", () => {
+    renderWithProviders(<InvitationError {...props} />);
+
+    expect(screen.getByText("Invitation not found")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Unable to load invitation details. Please check your invitation link.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("should render the back to login button", () => {
+    renderWithProviders(<InvitationError {...props} />);
+
+    expect(
+      screen.getByRole("button", { name: "Back to login" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should call onBackToLogin when button is clicked", async () => {
+    renderWithProviders(<InvitationError {...props} />);
+
+    const backButton = screen.getByRole("button", { name: "Back to login" });
+    await user.click(backButton);
+
+    expect(props.onBackToLogin).toHaveBeenCalled();
+  });
+});

--- a/src/features/invitation/components/InvitationError/InvitationError.tsx
+++ b/src/features/invitation/components/InvitationError/InvitationError.tsx
@@ -1,0 +1,24 @@
+import { Button } from "@canonical/react-components";
+import type { FC } from "react";
+import AuthTemplate from "@/templates/auth/AuthTemplate";
+
+interface InvitationErrorProps {
+  readonly onBackToLogin: () => void;
+}
+
+const InvitationError: FC<InvitationErrorProps> = ({ onBackToLogin }) => {
+  return (
+    <AuthTemplate title="Invitation not found">
+      <div>
+        <p className="p-text--small">
+          Unable to load invitation details. Please check your invitation link.
+        </p>
+        <Button appearance="positive" onClick={onBackToLogin}>
+          Back to login
+        </Button>
+      </div>
+    </AuthTemplate>
+  );
+};
+
+export default InvitationError;

--- a/src/features/invitation/components/InvitationError/index.ts
+++ b/src/features/invitation/components/InvitationError/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./InvitationError";

--- a/src/features/invitation/components/InvitationForm/InvitationForm.module.scss
+++ b/src/features/invitation/components/InvitationForm/InvitationForm.module.scss
@@ -1,0 +1,5 @@
+@import "vanilla-framework/scss/settings_spacing";
+
+.button {
+  margin-top: $spv--large;
+}

--- a/src/features/invitation/components/InvitationForm/InvitationForm.test.tsx
+++ b/src/features/invitation/components/InvitationForm/InvitationForm.test.tsx
@@ -1,0 +1,86 @@
+import { renderWithProviders } from "@/tests/render";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { describe } from "vitest";
+import { vi } from "vitest";
+import InvitationForm from "./InvitationForm";
+import useAuth from "@/hooks/useAuth";
+import { PATHS } from "@/libs/routes";
+import type { AuthContextProps } from "@/context/auth";
+import { authUser } from "@/tests/mocks/auth";
+import { invitationsSummary } from "@/tests/mocks/invitations";
+
+vi.mock("@/hooks/useAuth");
+
+const authProps: AuthContextProps = {
+  logout: vi.fn(),
+  authorized: true,
+  authLoading: false,
+  setAuthLoading: vi.fn(),
+  setUser: vi.fn(),
+  user: { ...authUser, invitation_id: "1" },
+  redirectToExternalUrl: vi.fn(),
+  isFeatureEnabled: vi.fn(),
+  hasAccounts: true,
+};
+
+const props: ComponentProps<typeof InvitationForm> = {
+  accountTitle: "Test Account",
+  onReject: vi.fn(),
+};
+
+const inviteId = invitationsSummary[0].secure_id;
+
+describe("InvitationForm", () => {
+  beforeEach(() => {
+    vi.mocked(useAuth).mockReturnValue(authProps);
+  });
+
+  it("should render the invitation form with account title", () => {
+    renderWithProviders(
+      <InvitationForm {...props} />,
+      {},
+      `/accept-invitation/${inviteId}`,
+      PATHS.auth.invitation,
+    );
+
+    expect(
+      screen.getByText(
+        "You have been invited as an administrator for Test Account",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Accepting this invitation will make you an administrator for the Test Account organization.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("should render accept and reject buttons", () => {
+    renderWithProviders(
+      <InvitationForm {...props} />,
+      {},
+      `/accept-invitation/${inviteId}`,
+      PATHS.auth.invitation,
+    );
+
+    expect(screen.getByRole("button", { name: "Accept" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reject" })).toBeInTheDocument();
+  });
+
+  it("should call onReject when reject button is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <InvitationForm {...props} />,
+      {},
+      `/accept-invitation/${inviteId}`,
+      PATHS.auth.invitation,
+    );
+
+    const rejectButton = screen.getByRole("button", { name: "Reject" });
+    await user.click(rejectButton);
+
+    expect(props.onReject).toHaveBeenCalled();
+  });
+});

--- a/src/features/invitation/components/InvitationForm/InvitationForm.tsx
+++ b/src/features/invitation/components/InvitationForm/InvitationForm.tsx
@@ -1,0 +1,72 @@
+import { ActionButton } from "@canonical/react-components";
+import type { FC } from "react";
+import AuthTemplate from "@/templates/auth/AuthTemplate";
+import useDebug from "@/hooks/useDebug";
+import { useInvitation } from "@/features/auth";
+import { useAcceptInvitation, useRejectInvitation } from "../../api";
+import classNames from "classnames";
+import classes from "./InvitationForm.module.scss";
+
+interface InvitationFormProps {
+  readonly accountTitle: string;
+  readonly onReject: () => void;
+}
+
+const InvitationForm: FC<InvitationFormProps> = ({
+  accountTitle,
+  onReject,
+}) => {
+  const debug = useDebug();
+  const { invitationId } = useInvitation();
+  const { acceptInvitation, isAcceptingInvitation } = useAcceptInvitation();
+  const { rejectInvitation, isRejectingInvitation } = useRejectInvitation();
+
+  const handleReject = async () => {
+    try {
+      await rejectInvitation({ invitation_id: invitationId });
+      onReject();
+    } catch (error) {
+      debug(error);
+    }
+  };
+
+  const handleAccept = async () => {
+    try {
+      await acceptInvitation({ invitation_id: invitationId });
+    } catch (error) {
+      debug(error);
+    }
+  };
+
+  return (
+    <AuthTemplate
+      title={`You have been invited as an administrator for ${accountTitle}`}
+    >
+      <p className="p-text--small">
+        Accepting this invitation will make you an administrator for the{" "}
+        {accountTitle} organization.
+      </p>
+      <ActionButton
+        appearance="positive"
+        className={classNames(classes.button, "u-no-margin--bottom")}
+        onClick={handleAccept}
+        type="button"
+        disabled={isAcceptingInvitation}
+        loading={isAcceptingInvitation}
+      >
+        Accept
+      </ActionButton>
+      <ActionButton
+        type="button"
+        className={classNames(classes.button, "u-no-margin--bottom")}
+        onClick={handleReject}
+        disabled={isRejectingInvitation}
+        loading={isRejectingInvitation}
+      >
+        Reject
+      </ActionButton>
+    </AuthTemplate>
+  );
+};
+
+export default InvitationForm;

--- a/src/features/invitation/components/InvitationForm/index.ts
+++ b/src/features/invitation/components/InvitationForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./InvitationForm";

--- a/src/features/invitation/components/InvitationRejected/InvitationRejected.test.tsx
+++ b/src/features/invitation/components/InvitationRejected/InvitationRejected.test.tsx
@@ -1,0 +1,14 @@
+import { renderWithProviders } from "@/tests/render";
+import { screen } from "@testing-library/react";
+import { describe } from "vitest";
+import InvitationRejected from "./InvitationRejected";
+
+describe("InvitationRejected", () => {
+  it("should render the rejection message", () => {
+    renderWithProviders(<InvitationRejected />);
+
+    expect(
+      screen.getByText("You have rejected the invitation"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/features/invitation/components/InvitationRejected/InvitationRejected.tsx
+++ b/src/features/invitation/components/InvitationRejected/InvitationRejected.tsx
@@ -1,0 +1,17 @@
+import AuthTemplate from "@/templates/auth/AuthTemplate";
+import type { FC } from "react";
+
+const InvitationRejected: FC = () => {
+  return (
+    <AuthTemplate title="You have rejected the invitation">
+      <p className="u-text--muted u-no-margin--bottom">
+        If this was a mistake, please contact your administrator.
+      </p>
+      <p className="u-text--muted u-no-margin--bottom">
+        You can now close this tab.
+      </p>
+    </AuthTemplate>
+  );
+};
+
+export default InvitationRejected;

--- a/src/features/invitation/components/InvitationRejected/index.ts
+++ b/src/features/invitation/components/InvitationRejected/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./InvitationRejected";

--- a/src/features/invitation/components/InvitationWelcome/InvitationWelcome.test.tsx
+++ b/src/features/invitation/components/InvitationWelcome/InvitationWelcome.test.tsx
@@ -1,0 +1,39 @@
+import { renderWithProviders } from "@/tests/render";
+import { screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { describe } from "vitest";
+import { setEndpointStatus } from "@/tests/controllers/controller";
+import InvitationWelcome from "./InvitationWelcome";
+import { expectLoadingState } from "@/tests/helpers";
+import { CONTACT_SUPPORT_TEAM_MESSAGE } from "@/constants";
+
+describe("InvitationWelcome", () => {
+  const defaultProps: ComponentProps<typeof InvitationWelcome> = {
+    accountTitle: "Test Account",
+  };
+
+  it("should render the welcome message", async () => {
+    renderWithProviders(<InvitationWelcome {...defaultProps} />);
+    await expectLoadingState();
+
+    expect(
+      screen.getByText("You have been invited to Test Account"),
+    ).toBeInTheDocument();
+  });
+
+  it("should show login methods when loaded successfully", async () => {
+    renderWithProviders(<InvitationWelcome {...defaultProps} />);
+    await expectLoadingState();
+
+    expect(screen.getByText("Sign in with Ubuntu One")).toBeInTheDocument();
+  });
+
+  it("should show error message when login methods fail to load", async () => {
+    setEndpointStatus("error");
+
+    renderWithProviders(<InvitationWelcome {...defaultProps} />);
+    await expectLoadingState();
+
+    expect(screen.getByText(CONTACT_SUPPORT_TEAM_MESSAGE)).toBeInTheDocument();
+  });
+});

--- a/src/features/invitation/components/InvitationWelcome/InvitationWelcome.tsx
+++ b/src/features/invitation/components/InvitationWelcome/InvitationWelcome.tsx
@@ -1,0 +1,28 @@
+import LoadingState from "@/components/layout/LoadingState";
+import { CONTACT_SUPPORT_TEAM_MESSAGE } from "@/constants";
+import { LoginMethodsLayout, useGetLoginMethods } from "@/features/auth";
+import AuthTemplate from "@/templates/auth/AuthTemplate";
+import { type FC } from "react";
+
+interface InvitationWelcomeProps {
+  readonly accountTitle: string;
+}
+
+const InvitationWelcome: FC<InvitationWelcomeProps> = ({ accountTitle }) => {
+  const { loginMethods, loginMethodsLoading, isLoginMethodsError } =
+    useGetLoginMethods();
+
+  return (
+    <AuthTemplate title={`You have been invited to ${accountTitle}`}>
+      {loginMethodsLoading && <LoadingState />}
+
+      {isLoginMethodsError ? (
+        <p className="u-no-margin--bottom">{CONTACT_SUPPORT_TEAM_MESSAGE}</p>
+      ) : (
+        <LoginMethodsLayout methods={loginMethods} />
+      )}
+    </AuthTemplate>
+  );
+};
+
+export default InvitationWelcome;

--- a/src/features/invitation/components/InvitationWelcome/index.ts
+++ b/src/features/invitation/components/InvitationWelcome/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./InvitationWelcome";

--- a/src/features/invitation/index.ts
+++ b/src/features/invitation/index.ts
@@ -1,0 +1,4 @@
+export { default as InvitationForm } from "./components/InvitationForm";
+export { default as InvitationError } from "./components/InvitationError";
+export { default as InvitationRejected } from "./components/InvitationRejected";
+export { default as InvitationWelcome } from "./components/InvitationWelcome";

--- a/src/features/scripts/components/ScriptList/ScriptList.test.tsx
+++ b/src/features/scripts/components/ScriptList/ScriptList.test.tsx
@@ -25,6 +25,7 @@ const authContextValues: AuthContextProps = {
   user: null,
   redirectToExternalUrl: vi.fn(),
   isFeatureEnabled: () => true,
+  hasAccounts: true,
 };
 
 const authContextValuesWithoutFeatureFlag: AuthContextProps = {

--- a/src/libs/routes/auth.ts
+++ b/src/libs/routes/auth.ts
@@ -1,4 +1,8 @@
-import { createCustomRoute, createRoute } from "./_helpers";
+import {
+  createCustomRoute,
+  createRoute,
+  createRouteWithParams,
+} from "./_helpers";
 
 export const AUTH_PATHS = {
   login: "/login",
@@ -6,9 +10,15 @@ export const AUTH_PATHS = {
   attach: "/attach",
   handleOidc: "/handle-auth/oidc",
   handleUbuntuOne: "/handle-auth/ubuntu-one",
+  invitation: "/accept-invitation/:secureId",
+  createAccount: "/create-account",
 } as const;
 
 export const AUTH_ROUTES = {
   login: createCustomRoute(AUTH_PATHS.login),
   attach: createRoute(AUTH_PATHS.attach),
+  invitation: createRouteWithParams<{ secureId: string }>(
+    AUTH_PATHS.invitation,
+  ),
+  createAccount: createRoute(AUTH_PATHS.createAccount),
 } as const;

--- a/src/pages/auth/account-creation/AccountCreationPage/AccountCreationPage.tsx
+++ b/src/pages/auth/account-creation/AccountCreationPage/AccountCreationPage.tsx
@@ -1,0 +1,57 @@
+import LoadingState from "@/components/layout/LoadingState";
+import Redirecting from "@/components/layout/Redirecting";
+import {
+  AccountCreationSaaSForm,
+  AccountCreationSelfHostedForm,
+} from "@/features/account-creation";
+import useAuth from "@/hooks/useAuth";
+import useEnv from "@/hooks/useEnv";
+import type { FC } from "react";
+import { useEffect } from "react";
+import { useNavigate } from "react-router";
+import { HOMEPAGE_PATH } from "@/constants";
+import { ROUTES } from "@/libs/routes";
+
+const AccountCreationPage: FC = () => {
+  const { authorized, authLoading, hasAccounts } = useAuth();
+  const { isSelfHosted, envLoading } = useEnv();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (authLoading || envLoading) {
+      return;
+    }
+
+    if (!isSelfHosted && !authorized) {
+      navigate(ROUTES.auth.login(), { replace: true });
+      return;
+    }
+
+    if (hasAccounts) {
+      navigate(HOMEPAGE_PATH, { replace: true });
+    }
+  }, [
+    authorized,
+    authLoading,
+    envLoading,
+    hasAccounts,
+    isSelfHosted,
+    navigate,
+  ]);
+
+  if (authLoading || envLoading) {
+    return <LoadingState />;
+  }
+
+  if (!isSelfHosted && !authorized) {
+    return <Redirecting />;
+  }
+
+  if (isSelfHosted) {
+    return <AccountCreationSelfHostedForm />;
+  }
+
+  return <AccountCreationSaaSForm />;
+};
+
+export default AccountCreationPage;

--- a/src/pages/auth/account-creation/AccountCreationPage/index.ts
+++ b/src/pages/auth/account-creation/AccountCreationPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AccountCreationPage";

--- a/src/pages/auth/account-creation/index.ts
+++ b/src/pages/auth/account-creation/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AccountCreationPage";

--- a/src/pages/auth/handle/oidc/OidcAuthPage/OidcAuthPage.test.tsx
+++ b/src/pages/auth/handle/oidc/OidcAuthPage/OidcAuthPage.test.tsx
@@ -83,6 +83,16 @@ describe("OidcAuthPage", () => {
         ...authUser,
         return_to: null,
       },
+      {
+        ...authUser,
+        accounts: [],
+        current_account: "",
+        return_to: null,
+      },
+      {
+        ...authUser,
+        invitation_id: "test-secure-id",
+      },
     ];
 
     beforeEach(async ({ task: { id } }) => {
@@ -126,6 +136,19 @@ describe("OidcAuthPage", () => {
     it("should redirect to internal URL when return_to is not provided", async () => {
       expect(navigate).toHaveBeenCalledWith(
         new URL(HOMEPAGE_PATH, location.origin).pathname,
+        { replace: true },
+      );
+    });
+
+    it("should redirect to create-account when user has no accounts", async () => {
+      expect(navigate).toHaveBeenCalledWith("/create-account", {
+        replace: true,
+      });
+    });
+
+    it("should redirect to invitation when invitation_id is present", async () => {
+      expect(navigate).toHaveBeenCalledWith(
+        "/accept-invitation/test-secure-id",
         { replace: true },
       );
     });

--- a/src/pages/auth/handle/oidc/OidcAuthPage/OidcAuthPage.tsx
+++ b/src/pages/auth/handle/oidc/OidcAuthPage/OidcAuthPage.tsx
@@ -36,6 +36,28 @@ const OidcAuthPage: FC = () => {
       return;
     }
 
+    setAuthLoading(true);
+    setUser(getAuthStateQueryResult.data);
+
+    if (getAuthStateQueryResult.data.invitation_id) {
+      navigate(
+        ROUTES.auth.invitation({
+          secureId: getAuthStateQueryResult.data.invitation_id,
+        }),
+        {
+          replace: true,
+        },
+      );
+      return;
+    }
+
+    if (getAuthStateQueryResult.data.accounts.length === 0) {
+      navigate(ROUTES.auth.createAccount(), { replace: true });
+      return;
+    }
+
+    const returnToUrl = getAuthStateQueryResult.data.return_to?.url;
+
     if (
       getAuthStateQueryResult.data.return_to?.external &&
       getAuthStateQueryResult.data.return_to.url
@@ -44,17 +66,17 @@ const OidcAuthPage: FC = () => {
         replace: true,
       });
     } else {
-      setAuthLoading(true);
-      setUser(getAuthStateQueryResult.data);
-
-      const url = new URL(
-        getAuthStateQueryResult.data.return_to?.url ?? HOMEPAGE_PATH,
-        location.origin,
-      );
+      const url = new URL(returnToUrl ?? HOMEPAGE_PATH, location.origin);
 
       navigate(url.toString().replace(url.origin, ""), { replace: true });
     }
-  }, [getAuthStateQueryResult, redirectToExternalUrl]);
+  }, [
+    getAuthStateQueryResult,
+    redirectToExternalUrl,
+    navigate,
+    setAuthLoading,
+    setUser,
+  ]);
 
   return (
     <div className={classes.container}>

--- a/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.test.tsx
+++ b/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.test.tsx
@@ -83,6 +83,16 @@ describe("UbuntuOneAuthPage", () => {
         ...authUser,
         return_to: null,
       },
+      {
+        ...authUser,
+        accounts: [],
+        current_account: "",
+        return_to: null,
+      },
+      {
+        ...authUser,
+        invitation_id: "test-secure-id",
+      },
     ];
 
     beforeEach(async ({ task: { id } }) => {
@@ -126,6 +136,19 @@ describe("UbuntuOneAuthPage", () => {
     it("should redirect to internal URL when return_to is not provided", async () => {
       expect(navigate).toHaveBeenCalledWith(
         new URL(HOMEPAGE_PATH, location.origin).pathname,
+        { replace: true },
+      );
+    });
+
+    it("should redirect to create-account when user has no accounts", async () => {
+      expect(navigate).toHaveBeenCalledWith("/create-account", {
+        replace: true,
+      });
+    });
+
+    it("should redirect to invitation when invitation_id is present", async () => {
+      expect(navigate).toHaveBeenCalledWith(
+        "/accept-invitation/test-secure-id",
         { replace: true },
       );
     });

--- a/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.tsx
+++ b/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.tsx
@@ -41,14 +41,36 @@ const UbuntuOneAuthPage: FC = () => {
       setAuthLoading(true);
       setUser(getUbuntuOneStateQueryResult.data);
 
-      const url = new URL(
-        getUbuntuOneStateQueryResult.data.return_to?.url ?? HOMEPAGE_PATH,
-        location.origin,
-      );
+      if (getUbuntuOneStateQueryResult.data.invitation_id) {
+        navigate(
+          ROUTES.auth.invitation({
+            secureId: getUbuntuOneStateQueryResult.data.invitation_id,
+          }),
+          {
+            replace: true,
+          },
+        );
+        return;
+      }
+
+      if (getUbuntuOneStateQueryResult.data.accounts.length === 0) {
+        navigate(ROUTES.auth.createAccount(), { replace: true });
+        return;
+      }
+
+      const returnToUrl = getUbuntuOneStateQueryResult.data.return_to?.url;
+
+      const url = new URL(returnToUrl ?? HOMEPAGE_PATH, location.origin);
 
       navigate(url.toString().replace(url.origin, ""), { replace: true });
     }
-  }, [getUbuntuOneStateQueryResult, redirectToExternalUrl]);
+  }, [
+    getUbuntuOneStateQueryResult,
+    redirectToExternalUrl,
+    navigate,
+    setAuthLoading,
+    setUser,
+  ]);
 
   return (
     <div className={classes.container}>

--- a/src/pages/auth/invitation/InvitationPage/InvitationPage.tsx
+++ b/src/pages/auth/invitation/InvitationPage/InvitationPage.tsx
@@ -1,0 +1,56 @@
+import LoadingState from "@/components/layout/LoadingState";
+import { useInvitation } from "@/features/auth";
+import {
+  InvitationError,
+  InvitationWelcome,
+  InvitationRejected,
+  InvitationForm,
+} from "@/features/invitation";
+import useAuth from "@/hooks/useAuth";
+import { ROUTES } from "@/libs/routes";
+import type { FC } from "react";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+
+const InvitationPage: FC = () => {
+  const navigate = useNavigate();
+  const { user, authorized } = useAuth();
+  const [hasRejected, setHasRejected] = useState(false);
+
+  const { invitationId, invitationAccount, isLoading } = useInvitation();
+
+  useEffect(() => {
+    if (!invitationId) {
+      navigate(ROUTES.auth.login(), { replace: true });
+    }
+  }, [invitationId, navigate]);
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (!invitationAccount) {
+    return (
+      <InvitationError onBackToLogin={() => navigate(ROUTES.auth.login())} />
+    );
+  }
+
+  if (hasRejected) {
+    return <InvitationRejected />;
+  }
+
+  if (authorized && user?.invitation_id) {
+    return (
+      <InvitationForm
+        accountTitle={invitationAccount.account_title}
+        onReject={() => {
+          setHasRejected(true);
+        }}
+      />
+    );
+  }
+
+  return <InvitationWelcome accountTitle={invitationAccount.account_title} />;
+};
+
+export default InvitationPage;

--- a/src/pages/auth/invitation/InvitationPage/index.ts
+++ b/src/pages/auth/invitation/InvitationPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./InvitationPage";

--- a/src/pages/auth/invitation/index.ts
+++ b/src/pages/auth/invitation/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./InvitationPage";

--- a/src/pages/auth/login/LoginPage.tsx
+++ b/src/pages/auth/login/LoginPage.tsx
@@ -1,21 +1,61 @@
 import type { FC } from "react";
+import { useEffect } from "react";
+import { useNavigate } from "react-router";
 import LoadingState from "@/components/layout/LoadingState";
 import {
   ConsentBannerModal,
   LoginMethodsLayout,
   useGetLoginMethods,
 } from "@/features/auth";
+import { useGetStandaloneAccount } from "@/features/account-creation";
 import AuthTemplate from "@/templates/auth";
 import { CONTACT_SUPPORT_TEAM_MESSAGE } from "@/constants";
 import useEnv from "@/hooks/useEnv";
 import { useBoolean } from "usehooks-ts";
+import { ROUTES } from "@/libs/routes";
 
 const LoginPage: FC = () => {
-  const { displayDisaStigBanner } = useEnv();
+  const navigate = useNavigate();
+  const { displayDisaStigBanner, isSelfHosted } = useEnv();
   const { value: bannerHidden, setTrue: hideBanner } = useBoolean();
+
+  const { accountExists, isLoading: isCheckingStandaloneAccount } =
+    useGetStandaloneAccount();
 
   const { loginMethods, loginMethodsLoading, isLoginMethodsError } =
     useGetLoginMethods();
+
+  useEffect(() => {
+    if (!isSelfHosted) {
+      return;
+    }
+
+    if (isCheckingStandaloneAccount || loginMethodsLoading) {
+      return;
+    }
+
+    const needsFirstAdmin = !accountExists;
+    const isPasswordAuthEnabled = loginMethods?.password?.enabled ?? false;
+
+    if (needsFirstAdmin && isPasswordAuthEnabled) {
+      navigate(ROUTES.auth.createAccount(), { replace: true });
+    }
+  }, [
+    isSelfHosted,
+    accountExists,
+    isCheckingStandaloneAccount,
+    loginMethods,
+    loginMethodsLoading,
+    navigate,
+  ]);
+
+  const needsFirstAdmin = isSelfHosted && !accountExists;
+  const isPasswordAuthEnabled = loginMethods?.password?.enabled ?? false;
+  const shouldRedirect = needsFirstAdmin && isPasswordAuthEnabled;
+
+  if (isCheckingStandaloneAccount || loginMethodsLoading || shouldRedirect) {
+    return <LoadingState />;
+  }
 
   return (
     <>
@@ -23,9 +63,7 @@ const LoginPage: FC = () => {
         <ConsentBannerModal onClose={hideBanner} />
       )}
       <AuthTemplate title="Sign in to Landscape">
-        {loginMethodsLoading ? (
-          <LoadingState />
-        ) : isLoginMethodsError ? (
+        {isLoginMethodsError ? (
           <p className="u-no-margin--bottom">{CONTACT_SUPPORT_TEAM_MESSAGE}</p>
         ) : (
           <LoginMethodsLayout methods={loginMethods} />

--- a/src/pages/dashboard/instances/[single]/SingleInstanceTabs/SingleInstanceTabs.test.tsx
+++ b/src/pages/dashboard/instances/[single]/SingleInstanceTabs/SingleInstanceTabs.test.tsx
@@ -46,6 +46,7 @@ describe("SingleInstanceTabs", () => {
         setAuthLoading: vi.fn(),
         setUser: vi.fn(),
         user: authUser,
+        hasAccounts: true,
       });
     });
 

--- a/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.test.tsx
@@ -24,6 +24,7 @@ const authProps: AuthContextProps = {
   user: authUser,
   redirectToExternalUrl: vi.fn(),
   isFeatureEnabled: vi.fn(),
+  hasAccounts: true,
 };
 
 vi.mock("@/hooks/useAuth");

--- a/src/pages/dashboard/instances/[single]/tabs/users/EditUserForm/EditUserForm.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/EditUserForm/EditUserForm.test.tsx
@@ -23,8 +23,8 @@ describe("EditUserForm", () => {
     expect(form).toHaveTexts([
       "Username",
       "Name",
-      "Passphrase",
-      "Confirm passphrase",
+      "Password",
+      "Confirm password",
       "Primary Group",
       "Additional Groups",
       "Location",
@@ -51,7 +51,7 @@ describe("EditUserForm", () => {
       const inputs = await within(form).findAllByDisplayValue(
         props.user.username,
       );
-      username = inputs[0];
+      [username] = inputs;
     } else {
       username = await within(form).findByDisplayValue(props.user.username);
     }

--- a/src/pages/dashboard/instances/[single]/tabs/users/EditUserForm/EditUserForm.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/EditUserForm/EditUserForm.tsx
@@ -11,6 +11,7 @@ import useUsers from "@/hooks/useUsers";
 import type { User } from "@/types/User";
 import { useParams } from "react-router";
 import type { UrlParams } from "@/types/UrlParams";
+import { getFormikError } from "@/utils/formikErrors";
 
 interface FormProps {
   name: string;
@@ -82,8 +83,8 @@ const EditUserForm: FC<EditUserFormProps> = ({ user }) => {
         return password && password.length > 0
           ? schema
               .trim()
-              .required("Confirm passphrase is required")
-              .oneOf([Yup.ref("password"), ""], "Passphrases must match")
+              .required("Confirm password is required")
+              .oneOf([Yup.ref("password"), ""], "Passwords must match")
           : schema.notRequired();
       }),
       location: Yup.string(),
@@ -154,43 +155,27 @@ const EditUserForm: FC<EditUserFormProps> = ({ user }) => {
         label="Username"
         required
         autoComplete="new-username"
-        error={
-          formik.touched.username && formik.errors.username
-            ? formik.errors.username
-            : undefined
-        }
+        error={getFormikError(formik, "username")}
         {...formik.getFieldProps("username")}
       />
       <Input
         type="text"
         label="Name"
-        error={
-          formik.touched.name && formik.errors.name
-            ? formik.errors.name
-            : undefined
-        }
+        error={getFormikError(formik, "name")}
         {...formik.getFieldProps("name")}
       />
       <Input
         type="password"
-        label="Passphrase"
+        label="Password"
         autoComplete="new-password"
-        error={
-          formik.touched.password && formik.errors.password
-            ? formik.errors.password
-            : undefined
-        }
+        error={getFormikError(formik, "password")}
         {...formik.getFieldProps("password")}
       />
       <Input
         type="password"
-        label="Confirm passphrase"
+        label="Confirm password"
         autoComplete="new-password"
-        error={
-          formik.touched.confirmPassword && formik.errors.confirmPassword
-            ? formik.errors.confirmPassword
-            : undefined
-        }
+        error={getFormikError(formik, "confirmPassword")}
         {...formik.getFieldProps("confirmPassword")}
       />
       <Select
@@ -200,11 +185,7 @@ const EditUserForm: FC<EditUserFormProps> = ({ user }) => {
         disabled={isLoadingGroups}
         options={groups}
         {...formik.getFieldProps("primaryGroupValue")}
-        error={
-          formik.touched.primaryGroupValue && formik.errors.primaryGroupValue
-            ? formik.errors.primaryGroupValue
-            : undefined
-        }
+        error={getFormikError(formik, "primaryGroupValue")}
       />
       <MultiSelectField
         variant="condensed"
@@ -220,42 +201,24 @@ const EditUserForm: FC<EditUserFormProps> = ({ user }) => {
             items.map(({ value }) => value),
           );
         }}
-        error={
-          (formik.touched.additionalGroupValue &&
-            (Array.isArray(formik.errors.additionalGroupValue)
-              ? formik.errors.additionalGroupValue.join(", ")
-              : formik.errors.additionalGroupValue)) ||
-          undefined
-        }
+        error={getFormikError(formik, "additionalGroupValue")}
       />
       <Input
         type="text"
         label="Location"
-        error={
-          formik.touched.location && formik.errors.location
-            ? formik.errors.location
-            : undefined
-        }
+        error={getFormikError(formik, "location")}
         {...formik.getFieldProps("location")}
       />
       <Input
         type="text"
         label="Home phone"
-        error={
-          formik.touched.homePhoneNumber && formik.errors.homePhoneNumber
-            ? formik.errors.homePhoneNumber
-            : undefined
-        }
+        error={getFormikError(formik, "homePhoneNumber")}
         {...formik.getFieldProps("homePhoneNumber")}
       />
       <Input
         type="text"
         label="Work phone"
-        error={
-          formik.touched.workPhoneNumber && formik.errors.workPhoneNumber
-            ? formik.errors.workPhoneNumber
-            : undefined
-        }
+        error={getFormikError(formik, "workPhoneNumber")}
         {...formik.getFieldProps("workPhoneNumber")}
       />
       <SidePanelFormButtons

--- a/src/pages/dashboard/instances/[single]/tabs/users/NewUserForm/NewUserForm.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/NewUserForm/NewUserForm.test.tsx
@@ -16,8 +16,8 @@ describe("NewUserForm", () => {
     expect(form).toHaveTexts([
       "Username",
       "Name",
-      "Passphrase",
-      "Confirm passphrase",
+      "Password",
+      "Confirm password",
       "Primary Group",
       "Location",
       "Home phone",

--- a/src/pages/dashboard/instances/[single]/tabs/users/NewUserForm/NewUserForm.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/NewUserForm/NewUserForm.tsx
@@ -112,7 +112,7 @@ const NewUserForm: FC = () => {
       />
       <Input
         type="password"
-        label="Passphrase"
+        label="Password"
         autoComplete="new-password"
         required
         error={
@@ -124,7 +124,7 @@ const NewUserForm: FC = () => {
       />
       <Input
         type="password"
-        label="Confirm passphrase"
+        label="Confirm password"
         autoComplete="new-password"
         required
         error={
@@ -136,7 +136,7 @@ const NewUserForm: FC = () => {
       />
       <Input
         type="checkbox"
-        label="Require passphrase reset"
+        label="Require password reset"
         help="User must change password at first login."
         {...formik.getFieldProps("requirePasswordReset")}
         checked={formik.values.requirePasswordReset}

--- a/src/pages/dashboard/instances/[single]/tabs/users/UserDetails/UserDetails.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/UserDetails/UserDetails.test.tsx
@@ -3,7 +3,6 @@ import "@/tests/matcher";
 import { users } from "@/tests/mocks/user";
 import { userGroups } from "@/tests/mocks/userGroup";
 import { renderWithProviders } from "@/tests/render";
-import type { User } from "@/types/User";
 import { screen } from "@testing-library/react";
 import { describe } from "vitest";
 import UserDetails from "./UserDetails";
@@ -23,19 +22,18 @@ describe("user details", () => {
     const groupsData = userGroups.map((group) => group.name).join(", ");
     const loaded = await screen.findByText(primaryGroup);
     expect(loaded).toBeInTheDocument();
-    const getFieldsToCheck = (user: User) => {
-      return [
-        { label: "Username", value: user.username },
-        { label: "Name", value: user?.name ?? <NoData /> },
-        { label: "Passphrase", value: "****************" },
-        { label: "Primary group", value: primaryGroup ?? <NoData /> },
-        { label: "Additional groups", value: groupsData },
-        { label: "Location", value: user?.location ?? <NoData /> },
-        { label: "Home phone", value: user?.home_phone ?? <NoData /> },
-        { label: "Work phone", value: user?.work_phone ?? <NoData /> },
-      ];
-    };
-    const fieldsToCheck = getFieldsToCheck(user);
+
+    const fieldsToCheck = [
+      { label: "Username", value: user.username },
+      { label: "Name", value: user?.name ?? <NoData /> },
+      { label: "Password", value: "****************" },
+      { label: "Primary group", value: primaryGroup ?? <NoData /> },
+      { label: "Additional groups", value: groupsData },
+      { label: "Location", value: user?.location ?? <NoData /> },
+      { label: "Home phone", value: user?.home_phone ?? <NoData /> },
+      { label: "Work phone", value: user?.work_phone ?? <NoData /> },
+    ];
+
     fieldsToCheck.forEach((field) => {
       expect(container).toHaveInfoItem(field.label, field.value);
     });

--- a/src/pages/dashboard/instances/[single]/tabs/users/UserDetails/UserDetails.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/UserDetails/UserDetails.tsx
@@ -38,7 +38,7 @@ const UserDetails: FC<UserDetailsProps> = ({ user }) => {
 
         <InfoGrid.Item label="Name" large value={user.name || null} />
 
-        <InfoGrid.Item label="Passphrase" large type="password" />
+        <InfoGrid.Item label="Password" large type="password" />
 
         <InfoGrid.Item label="Primary group" large value={primaryGroup} />
 

--- a/src/pages/dashboard/instances/[single]/tabs/users/UserList/UserList.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/UserList/UserList.test.tsx
@@ -153,7 +153,7 @@ describe("UserList", () => {
         return [
           { label: "Username", value: item.username },
           { label: "Name", value: item?.name ?? <NoData /> },
-          { label: "Passphrase", value: "****************" },
+          { label: "Password", value: "****************" },
           { label: "Primary group", value: primaryGroup ?? <NoData /> },
           { label: "Additional groups", value: groupsData },
           { label: "Location", value: item?.location ?? <NoData /> },

--- a/src/styles/partials/icons.scss
+++ b/src/styles/partials/icons.scss
@@ -293,3 +293,8 @@
   @extend %icon;
   @include vf-icon-security-tick($color-negative);
 }
+
+.p-icon--information--muted {
+  @extend %icon;
+  @include vf-icon-info($color-mid-dark);
+}

--- a/src/templates/auth/AuthTemplate.tsx
+++ b/src/templates/auth/AuthTemplate.tsx
@@ -1,7 +1,6 @@
 import Logo from "@/assets/images/logo-white-character.svg";
 import { APP_TITLE } from "@/constants";
-import { useInvitation } from "@/features/auth";
-import { LoginPageLayout, Notification } from "@canonical/react-components";
+import { LoginPageLayout } from "@canonical/react-components";
 import type { FC, ReactNode } from "react";
 import classes from "./AuthTemplate.module.scss";
 
@@ -11,8 +10,6 @@ interface AuthTemplateProps {
 }
 
 const AuthTemplate: FC<AuthTemplateProps> = ({ title, children }) => {
-  const { invitationAccount } = useInvitation();
-
   return (
     <div className={classes.root}>
       <LoginPageLayout
@@ -23,11 +20,6 @@ const AuthTemplate: FC<AuthTemplateProps> = ({ title, children }) => {
           url: "/",
         }}
       >
-        {invitationAccount?.account_title && (
-          <Notification severity="information">
-            {`You've been invited to ${invitationAccount?.account_title}`}
-          </Notification>
-        )}
         <>{children}</>
       </LoginPageLayout>
     </div>

--- a/src/templates/dashboard/Navigation/Navigation.test.tsx
+++ b/src/templates/dashboard/Navigation/Navigation.test.tsx
@@ -23,6 +23,7 @@ const authProps: AuthContextProps = {
   user: authUser,
   redirectToExternalUrl: vi.fn(),
   isFeatureEnabled: vi.fn(),
+  hasAccounts: true,
 };
 
 const envCommon: Omit<EnvContextState, "isSaas" | "isSelfHosted"> = {

--- a/src/tests/mocks/auth.ts
+++ b/src/tests/mocks/auth.ts
@@ -22,4 +22,5 @@ export const authUser: AuthUser = {
 export const authResponse: AuthStateResponse = {
   ...authUser,
   return_to: null,
+  attach_code: null,
 };

--- a/src/tests/mocks/authUbuntuOneNoAccounts.ts
+++ b/src/tests/mocks/authUbuntuOneNoAccounts.ts
@@ -1,0 +1,14 @@
+import type { AuthStateResponse } from "@/features/auth";
+
+export const authUbuntuOneNoAccountsResponse: AuthStateResponse = {
+  accounts: [],
+  current_account: "",
+  email: "new-user@example.com",
+  has_password: false,
+  name: "New Ubuntu One User",
+  token: "new-user-token",
+  return_to: null,
+  self_hosted: false,
+  identity_source: "ubuntu-one",
+  attach_code: null,
+};

--- a/src/tests/mocks/identityProviders.ts
+++ b/src/tests/mocks/identityProviders.ts
@@ -1,3 +1,4 @@
+import { ROOT_PATH } from "@/constants";
 import type {
   IdentityProvider,
   SingleIdentityProvider,
@@ -60,4 +61,4 @@ export const supportedProviders: SupportedIdentityProvider[] = [
   },
 ];
 
-export const locationToRedirectTo = "http://example.com";
+export const oidcLocationToRedirectTo = `${ROOT_PATH}handle-auth/oidc?code=oidc-code&state=state123`;

--- a/src/tests/mocks/loginMethods.ts
+++ b/src/tests/mocks/loginMethods.ts
@@ -24,29 +24,6 @@ export const allLoginMethods: LoginMethods = {
   },
 };
 
-export const employeeLoginMethods: LoginMethods = {
-  oidc: {
-    available: true,
-    configurations: identityProviders,
-  },
-  standalone_oidc: {
-    available: true,
-    enabled: true,
-  },
-  ubuntu_one: {
-    available: true,
-    enabled: true,
-  },
-  password: {
-    available: false,
-    enabled: false,
-  },
-  pam: {
-    available: false,
-    enabled: false,
-  },
-};
-
 export const noneLoginMethods: LoginMethods = {
   oidc: {
     available: false,

--- a/src/tests/server/handlers/about.ts
+++ b/src/tests/server/handlers/about.ts
@@ -1,0 +1,13 @@
+import { http, HttpResponse } from "msw";
+import { API_URL } from "@/constants";
+
+export default [
+  http.get(`${API_URL}about`, () => {
+    return HttpResponse.json({
+      self_hosted: false,
+      package_version: "0.0.0-dev",
+      revision: "dev-rev",
+      display_disa_stig_banner: false,
+    });
+  }),
+];

--- a/src/tests/server/handlers/index.ts
+++ b/src/tests/server/handlers/index.ts
@@ -1,5 +1,6 @@
 import savedSearches from "@/tests/server/handlers/savedSearches";
 import script from "@/tests/server/handlers/script";
+import about from "./about";
 import accessGroup from "./accessGroup";
 import activity from "./activity";
 import administrators from "./administrators";
@@ -29,6 +30,7 @@ import roles from "./roles";
 import scriptProfiles from "./scriptProfiles";
 import securityProfiles from "./securityProfiles";
 import snap from "./snap";
+import standaloneAccount from "./standaloneAccount";
 import tag from "./tag";
 import upgradeProfile from "./upgradeProfile";
 import user from "./user";
@@ -38,6 +40,7 @@ import wsl from "./wsl";
 import wslProfiles from "./wslProfiles";
 
 export default [
+  ...about,
   ...accessGroup,
   ...administrators,
   ...autoinstallFiles,
@@ -68,6 +71,7 @@ export default [
   ...script,
   ...scriptProfiles,
   ...snap,
+  ...standaloneAccount,
   ...tag,
   ...upgradeProfile,
   ...user,

--- a/src/tests/server/handlers/invitations.ts
+++ b/src/tests/server/handlers/invitations.ts
@@ -6,6 +6,10 @@ import { http, HttpResponse } from "msw";
 import { generatePaginatedResponse } from "./_helpers";
 import { invitations, invitationsSummary } from "@/tests/mocks/invitations";
 
+export const invitationState = {
+  accepted: false,
+};
+
 export default [
   http.get<never, never, ApiPaginatedResponse<Invitation>>(
     `${API_URL}invitations`,
@@ -40,4 +44,16 @@ export default [
       );
     },
   ),
+
+  http.post(`${API_URL}accept-invitation`, () => {
+    invitationState.accepted = true;
+    return HttpResponse.json({
+      account_id: 4,
+      account_title: "My Account",
+    });
+  }),
+
+  http.post(`${API_URL}reject-invitation`, () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
 ];

--- a/src/tests/server/handlers/standaloneAccount.ts
+++ b/src/tests/server/handlers/standaloneAccount.ts
@@ -1,0 +1,63 @@
+import { http, HttpResponse } from "msw";
+import { API_URL } from "@/constants";
+
+interface CreateStandaloneAccountParams {
+  email: string;
+  name: string;
+  password: string;
+}
+
+let standaloneAccountExists = false;
+
+export default [
+  http.get(`${API_URL}standalone-account`, () => {
+    if (standaloneAccountExists) {
+      return HttpResponse.json({ exists: true });
+    }
+
+    return HttpResponse.json({ exists: false });
+  }),
+
+  http.post<never, CreateStandaloneAccountParams>(
+    `${API_URL}standalone-account`,
+    async ({ request }) => {
+      const { email, name } = await request.json();
+
+      if (standaloneAccountExists) {
+        return HttpResponse.json(
+          {
+            error: "BadRequest",
+            message: "Standalone account already exists",
+          },
+          { status: 400 },
+        );
+      }
+
+      standaloneAccountExists = true;
+
+      return HttpResponse.json(
+        {
+          account: "standalone",
+          creation_time: new Date().toISOString(),
+          administrators: [
+            {
+              name,
+              email,
+              openid: null,
+            },
+          ],
+          disabled: false,
+          disabled_reason: null,
+          computers: 0,
+          company: "Organization",
+          last_login_time: new Date().toISOString(),
+          licenses: [],
+          salesforce_account_key: null,
+          enabled_features: [],
+          subdomain: null,
+        },
+        { status: 201 },
+      );
+    },
+  ),
+];


### PR DESCRIPTION
This PR introduces 2 features
- Account creation
- Invitation acceptance / rejection

--- 
Before there were 2 user states handled: Logged in / Not logged in. 
Now there are 3. Not logged in, authenticated but with no organization, logged in (has organization).

## Account creation:
For SaaS, the user tries to log in via any method (tested and mocked with Ubuntu One). If they have no organization associated to their Landscape account, then they are redirected to `/create-account` page. Where they can create a new organization for themselves, and they would then be redirected to the dashboard. *Known issue mentioned above applies here

For Self hosted, when the user opens Landscape for the first time, they are redirected to the `/create-account` page. We know this by consuming an endpoint telling us if this user has an account or not. After the user creates their account, they are redirected to the login page and can then enter the dashboard normally. *can consider immediately logging the user in the dashboard when creating account

## Invitation:
The user opens the email link which redirects them to `/accept-invitation/<id>`. E.g can be `/accept-invitation/1` If the user is unauthenticated, we prompt them to log in (again tested and mocked with Ubuntu One). Once they have authenticated themselves, they are presented with the option to accept or reject an invitation to an organization. Once they accept they are redirected inside the dashboard. If they reject the flow ends there.



## To test:
For account creation:
1. Login page
2. Click on Sign in with Ubuntu One
3. Fill in organization form
4. End

Self-hosted
1. Login page -> redirects to /create-account (is done automatically with the mocks and handlers of msw)
2. Fill out form
3. Navigated to Login page

For invitation
1. Manually go to `/new_dashboard/accept-invitation/1`
2. Sign in with Ubuntu One
3. Accept invitation -> Dashboard // Reject invitation -> confirmation that rejection was done


## Untested flows:
Creating an organization with OIDC
Accepting an invite when signing in with OIDC