### PR TITLE
fix: revert ppa build action

### DIFF
--- a/.github/workflows/ppa-build.yaml
+++ b/.github/workflows/ppa-build.yaml
@@ -66,7 +66,10 @@ jobs:
           path: dist
 
       - name: Extract dist
-        run: rsync -av --delete --exclude='.git/' dist/ .
+        run: |
+          mv ./dist ../
+          rm -rf ./*
+          mv ../dist/* ./
 
       - name: Commit and Push
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
rsync was failing due to deleting the source directory

reverts to the old steps