### PR TITLE
refactor: make account creation flow changes, make pro enablement fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ const InvitationPage = lazy(async () => import("@/pages/auth/invitation"));
 const AccountCreationPage = lazy(
   async () => import("@/pages/auth/account-creation"),
 );
+const NoAccessPage = lazy(async () => import("@/pages/auth/NoAccess"));
 const EnvError = lazy(async () => import("@/pages/EnvError"));
 const PageNotFound = lazy(async () => import("@/pages/PageNotFound"));
 const LoginPage = lazy(async () => import("@/pages/auth/login"));
@@ -559,6 +560,14 @@ const App: FC = () => {
               element={
                 <Suspense key="/create-account" fallback={<LoadingState />}>
                   <AccountCreationPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path={PATHS.auth.noAccess}
+              element={
+                <Suspense key="/no-access" fallback={<LoadingState />}>
+                  <NoAccessPage />
                 </Suspense>
               }
             />

--- a/src/components/layout/SearchHelpPopup.module.scss
+++ b/src/components/layout/SearchHelpPopup.module.scss
@@ -1,3 +1,9 @@
 .term {
   width: 30%;
 }
+
+:global(.p-modal) {
+  table {
+    width: 60rem;
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,3 +40,4 @@ export const MAX_MINUTES_IN_HOUR = 59;
 export const MAX_HOURS_IN_DAY = 23;
 export const MAX_PASSWORD_LENGTH = 50;
 export const DEFAULT_MODAL_PAGE_SIZE = 10;
+export const GENERIC_DOMAIN = "landscape.canonical.com";

--- a/src/features/auth/hooks/useInvitation.ts
+++ b/src/features/auth/hooks/useInvitation.ts
@@ -1,16 +1,13 @@
 import { useParams, useSearchParams } from "react-router";
 import { useUnsigned } from "@/features/auth";
-import useAuth from "@/hooks/useAuth";
 
 export default function useInvitation() {
   const { getInvitationSummaryQuery } = useUnsigned();
-  const { user } = useAuth();
 
   const { secureId } = useParams<{ secureId: string }>();
   const [searchParams] = useSearchParams();
 
-  const invitationId =
-    user?.invitation_id || secureId || searchParams.get("invitation_id") || "";
+  const invitationId = secureId || searchParams.get("invitation_id") || "";
 
   const { data, isLoading } = getInvitationSummaryQuery(
     { invitationId },

--- a/src/features/auth/hooks/useUnsigned.ts
+++ b/src/features/auth/hooks/useUnsigned.ts
@@ -45,6 +45,7 @@ export type AuthStateResponse =
       self_hosted: boolean;
       identity_source: string;
       attach_code: string | null;
+      invitation_id: string | null;
     });
 
 export interface LoginRequestParams {

--- a/src/features/auth/types/AuthUser.d.ts
+++ b/src/features/auth/types/AuthUser.d.ts
@@ -13,5 +13,4 @@ export interface AuthUser {
   has_password: boolean;
   name: string;
   token: string;
-  invitation_id?: string;
 }

--- a/src/features/instances/components/InstancesHeader/hooks/useInstanceSearchHelpTerms.tsx
+++ b/src/features/instances/components/InstancesHeader/hooks/useInstanceSearchHelpTerms.tsx
@@ -200,6 +200,15 @@ const useInstanceSearchHelpTerms = () => {
         "Search for instances that do not have a Landscape license, and, as a result, are not managed",
     },
     {
+      term: "has-pro-management:<option>",
+      description: (
+        <span>
+          Instances with pro management enabled if <code>&lt;option&gt;</code>{" "}
+          is a truthy value or disabled if falsy.
+        </span>
+      ),
+    },
+    {
       term: "annotation:<key>",
       description: (
         <span>

--- a/src/features/invitation/components/InvitationForm/InvitationForm.test.tsx
+++ b/src/features/invitation/components/InvitationForm/InvitationForm.test.tsx
@@ -19,7 +19,7 @@ const authProps: AuthContextProps = {
   authLoading: false,
   setAuthLoading: vi.fn(),
   setUser: vi.fn(),
-  user: { ...authUser, invitation_id: "1" },
+  user: { ...authUser },
   redirectToExternalUrl: vi.fn(),
   isFeatureEnabled: vi.fn(),
   hasAccounts: true,

--- a/src/features/ubuntupro/api/useDetachToken.ts
+++ b/src/features/ubuntupro/api/useDetachToken.ts
@@ -8,12 +8,18 @@ interface DetachTokenParams {
   computer_ids: number[];
 }
 
+interface DetachTokenResponse {
+  activity: Activity;
+  invalid_computer_ids: number[];
+  nonexistent_computer_ids: number[];
+}
+
 export default function useDetachToken() {
   const authFetch = useFetch();
   const queryClient = useQueryClient();
 
   const detachTokenQuery = useMutation<
-    AxiosResponse<Activity>,
+    AxiosResponse<DetachTokenResponse>,
     AxiosError<ApiError>,
     DetachTokenParams
   >({

--- a/src/features/ubuntupro/components/DetachTokenModal/DetachTokenModal.tsx
+++ b/src/features/ubuntupro/components/DetachTokenModal/DetachTokenModal.tsx
@@ -32,7 +32,9 @@ const DetachTokenModal: FC<DetachTokenModalProps> = ({
 
   const handleDetachToken = async () => {
     try {
-      const { data: detachActivity } = await detachToken({
+      const {
+        data: { activity },
+      } = await detachToken({
         computer_ids: computerIds,
       });
 
@@ -51,7 +53,7 @@ const DetachTokenModal: FC<DetachTokenModalProps> = ({
           {
             label: "View details",
             onClick: () => {
-              openActivityDetails(detachActivity);
+              openActivityDetails(activity);
             },
           },
         ],

--- a/src/features/ubuntupro/components/TokenFormBase/types.ts
+++ b/src/features/ubuntupro/components/TokenFormBase/types.ts
@@ -1,0 +1,3 @@
+export interface FormProps {
+  token: string;
+}

--- a/src/libs/routes/auth.ts
+++ b/src/libs/routes/auth.ts
@@ -12,6 +12,7 @@ export const AUTH_PATHS = {
   handleUbuntuOne: "/handle-auth/ubuntu-one",
   invitation: "/accept-invitation/:secureId",
   createAccount: "/create-account",
+  noAccess: "/no-access",
 } as const;
 
 export const AUTH_ROUTES = {
@@ -21,4 +22,5 @@ export const AUTH_ROUTES = {
     AUTH_PATHS.invitation,
   ),
   createAccount: createRoute(AUTH_PATHS.createAccount),
+  noAccess: createRoute(AUTH_PATHS.noAccess),
 } as const;

--- a/src/pages/auth/NoAccess/NoAccess.test.tsx
+++ b/src/pages/auth/NoAccess/NoAccess.test.tsx
@@ -1,0 +1,18 @@
+import { renderWithProviders } from "@/tests/render";
+import { screen } from "@testing-library/react";
+import { describe } from "vitest";
+import NoAccess from "./NoAccess";
+
+describe("NoAccess", () => {
+  it("should render the no access message", () => {
+    renderWithProviders(<NoAccess />);
+
+    expect(
+      screen.getByText(
+        "Contact an administrator to get invited to this organization.",
+      ),
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: "Log out" })).toBeInTheDocument();
+  });
+});

--- a/src/pages/auth/NoAccess/NoAccess.tsx
+++ b/src/pages/auth/NoAccess/NoAccess.tsx
@@ -1,0 +1,26 @@
+import useAuth from "@/hooks/useAuth";
+import AuthTemplate from "@/templates/auth/AuthTemplate";
+import { Button } from "@canonical/react-components";
+import type { FC } from "react";
+
+const NoAccess: FC = () => {
+  const { logout } = useAuth();
+
+  return (
+    <AuthTemplate title="You don't have access to this organization">
+      <p className="u-text--muted">
+        Contact an administrator to get invited to this organization.
+      </p>
+      <Button
+        appearance="positive"
+        className="u-no-margin--bottom"
+        onClick={logout}
+        type="button"
+      >
+        Log out
+      </Button>
+    </AuthTemplate>
+  );
+};
+
+export default NoAccess;

--- a/src/pages/auth/NoAccess/index.ts
+++ b/src/pages/auth/NoAccess/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NoAccess";

--- a/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.test.tsx
+++ b/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.test.tsx
@@ -4,9 +4,33 @@ import { screen } from "@testing-library/react";
 import type { AuthStateResponse } from "@/features/auth";
 import { authUser } from "@/tests/mocks/auth";
 import { HOMEPAGE_PATH } from "@/constants";
+import type { EnvContextState } from "@/context/env";
+import useEnv from "@/hooks/useEnv";
 
 const redirectToExternalUrl = vi.fn();
 const navigate = vi.fn();
+
+vi.mock("@/hooks/useEnv");
+
+const mockSelfHosted: EnvContextState = {
+  envLoading: false,
+  isSaas: false,
+  isSelfHosted: true,
+  packageVersion: "",
+  revision: "",
+  displayDisaStigBanner: false,
+};
+
+const mockSaas: EnvContextState = {
+  envLoading: false,
+  isSaas: true,
+  isSelfHosted: false,
+  packageVersion: "",
+  revision: "",
+  displayDisaStigBanner: false,
+};
+
+vi.mocked(useEnv).mockReturnValue(mockSaas);
 
 const mockTestParams = (response: AuthStateResponse | Error) => {
   vi.doMock("react-router", async () => ({
@@ -83,12 +107,7 @@ describe("UbuntuOneAuthPage", () => {
         ...authUser,
         return_to: null,
       },
-      {
-        ...authUser,
-        accounts: [],
-        current_account: "",
-        return_to: null,
-      },
+
       {
         ...authUser,
         invitation_id: "test-secure-id",
@@ -140,17 +159,119 @@ describe("UbuntuOneAuthPage", () => {
       );
     });
 
-    it("should redirect to create-account when user has no accounts", async () => {
+    it("should redirect to invitation when invitation_id is present", async () => {
+      mockTestParams({
+        ...authUser,
+        accounts: [],
+        current_account: "",
+        return_to: null,
+        invitation_id: "test-secure-id",
+      });
+
+      expect(navigate).toHaveBeenCalledWith(
+        "/accept-invitation/test-secure-id",
+        { replace: true },
+      );
+    });
+  });
+
+  describe("SaaS environment", () => {
+    beforeEach(() => {
+      vi.resetModules();
+      vi.mocked(useEnv).mockReturnValue(mockSaas);
+      vi.doMock("@/features/account-creation", () => ({
+        useGetStandaloneAccount: () => ({ accountExists: false }),
+      }));
+
+      vi.doMock("@/constants", async (importOriginal) => ({
+        ...(await importOriginal()),
+        GENERIC_DOMAIN: "localhost",
+      }));
+
+      mockTestParams({
+        ...authUser,
+        accounts: [],
+        current_account: "",
+        return_to: null,
+      });
+    });
+
+    it("should redirect to create-account when user has no accounts and GENERIC_DOMAIN matches hostname", async () => {
+      const { default: Component } = await import("./UbuntuOneAuthPage");
+      renderWithProviders(<Component />);
+
       expect(navigate).toHaveBeenCalledWith("/create-account", {
         replace: true,
       });
     });
 
-    it("should redirect to invitation when invitation_id is present", async () => {
-      expect(navigate).toHaveBeenCalledWith(
-        "/accept-invitation/test-secure-id",
-        { replace: true },
-      );
+    it("should redirect to no-access when user has no accounts and GENERIC_DOMAIN does not match hostname", async () => {
+      vi.resetModules();
+      vi.doMock("@/constants", async (importOriginal) => ({
+        ...(await importOriginal()),
+        GENERIC_DOMAIN: "example.com",
+      }));
+
+      mockTestParams({
+        ...authUser,
+        accounts: [],
+        current_account: "",
+        return_to: null,
+      });
+
+      const { default: Component } = await import("./UbuntuOneAuthPage");
+      renderWithProviders(<Component />);
+
+      expect(navigate).toHaveBeenCalledWith("/no-access", {
+        replace: true,
+      });
+    });
+  });
+
+  describe("Self-hosted environment", () => {
+    beforeEach(() => {
+      vi.resetModules();
+      vi.mocked(useEnv).mockReturnValue(mockSelfHosted);
+
+      vi.doMock("@/features/account-creation", () => ({
+        useGetStandaloneAccount: () => ({ accountExists: false }),
+      }));
+
+      mockTestParams({
+        ...authUser,
+        accounts: [],
+        current_account: "",
+        return_to: null,
+      });
+    });
+
+    it("should redirect to create-account when user has no accounts and accountExists is false", async () => {
+      const { default: Component } = await import("./UbuntuOneAuthPage");
+      renderWithProviders(<Component />);
+
+      expect(navigate).toHaveBeenCalledWith("/create-account", {
+        replace: true,
+      });
+    });
+
+    it("should redirect to no-access when accountExists is true", async () => {
+      vi.resetModules();
+      vi.mocked(useEnv).mockReturnValue(mockSelfHosted);
+      vi.doMock("@/features/account-creation", () => ({
+        useGetStandaloneAccount: () => ({ accountExists: true }),
+      }));
+
+      mockTestParams({
+        ...authUser,
+        accounts: [],
+        current_account: "",
+        return_to: null,
+      });
+
+      const { default: Component } = await import("./UbuntuOneAuthPage");
+      renderWithProviders(<Component />);
+
+      expect(navigate).toHaveBeenCalledWith("/no-access", { replace: true });
     });
   });
 });

--- a/src/pages/auth/invitation/InvitationPage/InvitationPage.tsx
+++ b/src/pages/auth/invitation/InvitationPage/InvitationPage.tsx
@@ -14,7 +14,7 @@ import { useNavigate } from "react-router";
 
 const InvitationPage: FC = () => {
   const navigate = useNavigate();
-  const { user, authorized } = useAuth();
+  const { authorized } = useAuth();
   const [hasRejected, setHasRejected] = useState(false);
 
   const { invitationId, invitationAccount, isLoading } = useInvitation();
@@ -39,7 +39,7 @@ const InvitationPage: FC = () => {
     return <InvitationRejected />;
   }
 
-  if (authorized && user?.invitation_id) {
+  if (authorized) {
     return (
       <InvitationForm
         accountTitle={invitationAccount.account_title}

--- a/src/templates/dashboard/OrganisationSwitch/OrganisationSwitch.module.scss
+++ b/src/templates/dashboard/OrganisationSwitch/OrganisationSwitch.module.scss
@@ -18,6 +18,10 @@
   }
 }
 
+.marginBottom {
+  margin-bottom: $spv--large;
+}
+
 :global(.l-navigation) {
   &:hover,
   &:focus-within {

--- a/src/templates/dashboard/OrganisationSwitch/OrganisationSwitch.tsx
+++ b/src/templates/dashboard/OrganisationSwitch/OrganisationSwitch.tsx
@@ -17,7 +17,7 @@ const OrganisationSwitch = () => {
 
   if (isOnSubdomain || options.length === 1) {
     return (
-      <div className={classes.container}>
+      <div className={classNames(classes.container, classes.marginBottom)}>
         <InfoItem
           label="Organization"
           value={currentAccount.title}

--- a/src/tests/mocks/ubuntuPro.ts
+++ b/src/tests/mocks/ubuntuPro.ts
@@ -3,9 +3,11 @@ import { activities } from "./activity";
 export const attachUbuntuProActivity = {
   activity: activities[0],
   invalid_computer_ids: [],
+  nonexistent_computer_ids: [],
 };
 
 export const detachUbuntuProActivity = {
   activity: activities[1],
   invalid_computer_ids: [],
+  nonexistent_computer_ids: [],
 };

--- a/src/tests/server/handlers/auth.ts
+++ b/src/tests/server/handlers/auth.ts
@@ -45,7 +45,6 @@ interface CreatedAccount {
 }
 
 let createdAccount: CreatedAccount | null = null;
-let pendingInvitationId: string | null = null;
 
 export default [
   http.post<never, LoginRequestParams, AuthStateResponse>(
@@ -130,12 +129,7 @@ export default [
 
   http.get(`${API_URL}auth/start`, ({ request }) => {
     const url = new URL(request.url);
-    const invitationId = url.searchParams.get("invitation_id");
     const returnTo = url.searchParams.get("return_to");
-
-    if (invitationId) {
-      pendingInvitationId = invitationId;
-    }
 
     let redirectUrl = `${location.origin}${oidcLocationToRedirectTo}`;
 
@@ -186,6 +180,27 @@ export default [
       });
     }
 
+    /**
+     * Simulate an invited user logging in via OIDC for the first time
+     */
+    // const baseResponse: AuthStateResponse = {
+    //   accounts: [],
+    //   current_account: "",
+    //   email: "new-oidc-user@example.com",
+    //   has_password: false,
+    //   name: "New OIDC User",
+    //   token: "new-oidc-token",
+    //   return_to: {
+    //     external: false,
+    //     url: `${ROOT_PATH}accept-invitation/1`,
+    //   },
+    //   attach_code: null,
+    //   invitation_id: 1,
+    // };
+
+    /**
+     * Simulate OIDC create account
+     */
     const baseResponse: AuthStateResponse = {
       accounts: [],
       current_account: "",
@@ -195,8 +210,29 @@ export default [
       token: "new-oidc-token",
       return_to: null,
       attach_code: null,
-      ...(pendingInvitationId && { invitation_id: pendingInvitationId }),
     };
+
+    /**
+     * Simulate normal OIDC login
+     */
+    // const baseResponse: AuthStateResponse = {
+    //   accounts: [
+    //     {
+    //       classic_dashboard_url: "",
+    //       default: true,
+    //       name: "existing-account",
+    //       subdomain: null,
+    //       title: "Existing Account Inc.",
+    //     },
+    //   ],
+    //   current_account: "existing-account",
+    //   email: "existing-account@example.com",
+    //   has_password: true,
+    //   name: "Existing Account",
+    //   token: "existing-account-token",
+    //   return_to: null,
+    //   attach_code: null,
+    // };
 
     return HttpResponse.json(baseResponse);
   }),
@@ -218,7 +254,9 @@ export default [
         }
       }
     }
-
+    /**
+     * Simulate a user logging in via Ubuntu One with no associated account
+     */
     const baseResponse = {
       accounts: [],
       current_account: "",
@@ -230,8 +268,29 @@ export default [
       attach_code: null,
     };
 
+    /**
+     * Simulate a user logging in via Ubuntu One with an associated account
+     */
+    // const baseResponse = {
+    //   accounts: [
+    //     {
+    //       classic_dashboard_url: "",
+    //       default: true,
+    //       name: "standalone",
+    //       subdomain: null,
+    //       title: "Organization",
+    //     },
+    //   ],
+    //   current_account: "",
+    //   email: "new-user@example.com",
+    //   has_password: false,
+    //   name: "New Ubuntu One User",
+    //   token: "new-user-token",
+    //   return_to: null,
+    //   attach_code: null,
+    // };
+
     if (invitationIdFromUrl) {
-      pendingInvitationId = invitationIdFromUrl;
       return HttpResponse.json({
         ...baseResponse,
         invitation_id: invitationIdFromUrl,
@@ -265,7 +324,7 @@ export default [
         token: "new-user-token",
         return_to: null,
         attach_code: null,
-        ...(pendingInvitationId && { invitation_id: pendingInvitationId }),
+        invitation_id: null,
       });
     }
 
@@ -280,7 +339,16 @@ export default [
               title: createdAccount.company,
             },
           ]
-        : [];
+        : [
+            {
+              classic_dashboard_url: "",
+              default: true,
+              name: "8xag1afp",
+              subdomain: null,
+              title: "Onward, Inc.",
+            },
+          ];
+
       return HttpResponse.json({
         accounts,
         current_account: createdAccount ? createdAccount.account : "",
@@ -290,25 +358,17 @@ export default [
         token: "new-oidc-token",
         return_to: null,
         attach_code: null,
-        ...(pendingInvitationId && { invitation_id: pendingInvitationId }),
+        invitation_id: null,
       });
     }
 
     if (!token) {
-      const accounts = createdAccount
-        ? [
-            {
-              classic_dashboard_url: "",
-              default: true,
-              name: createdAccount.account,
-              subdomain: null,
-              title: createdAccount.company,
-            },
-          ]
-        : [];
+      if (createdAccount === null) {
+        return HttpResponse.json({});
+      }
 
       return HttpResponse.json({
-        accounts,
+        accounts: [createdAccount],
         current_account: createdAccount ? createdAccount.account : "",
         email: "new-user@example.com",
         has_password: false,
@@ -316,7 +376,7 @@ export default [
         token: "new-user-token",
         return_to: null,
         attach_code: null,
-        ...(pendingInvitationId && { invitation_id: pendingInvitationId }),
+        invitation_id: null,
       });
     }
     return HttpResponse.json(authResponse);

--- a/src/tests/server/handlers/standaloneAccount.ts
+++ b/src/tests/server/handlers/standaloneAccount.ts
@@ -15,7 +15,15 @@ export default [
       return HttpResponse.json({ exists: true });
     }
 
-    return HttpResponse.json({ exists: false });
+    /**
+     * Existing standalone account flow
+     */
+    return HttpResponse.json({ exists: true });
+
+    /**
+     * First time standalone account creation flow
+     */
+    // return HttpResponse.json({ exists: false });
   }),
 
   http.post<never, CreateStandaloneAccountParams>(


### PR DESCRIPTION
Main changes:
## Pro enablement:
When the "attach" action the user is trying to perform has no effect on any of the instances, we show a modal informing the user of that information and only allow them to close the modal.

## Invitation flow / Account creation
### In SaaS:
The user only sees the "create organization" page if the url is `landscape.canonical.com`. Otherwise they are met with a `No access` page informing them they need an invitation to get in the organization.
### In self-hosted:
The user only sees the "create account" page if there is no existing account coming from `GET /standalone-account`. Otherwise they are again met with a `No access` page like in SaaS.

Invitation flow remains unchanged for both.

---

To make testing easier, you can toggle responses in the handlers `auth.ts` and `standaloneAccounts.ts`. They are labeled for invites / account creation and even if you want to test normally logging in with OIDC / Ubuntu One.

I recommend mocking every msw endpoint with `/`

To test "create account" in SaaS, you would need to modify our hosts file in your computer, and then point vite server to that url. E.g adding 127.0.0.1 to etc/hosts and pointing it to `landscape.canonical.com` should prompt the user to create account if they are not associated with an organization. While any other url should not cause that.
