### PR TITLE
feat: add associated instance links for upgrade and removal profiles [LNDENG-2538, LNDENG-2535]

### DIFF
--- a/src/features/removal-profiles/components/RemovalProfileList/RemovalProfileList.tsx
+++ b/src/features/removal-profiles/components/RemovalProfileList/RemovalProfileList.tsx
@@ -1,3 +1,4 @@
+import ProfileAssociatedInstancesLink from "@/components/form/ProfileAssociatedInstancesLink";
 import { LIST_ACTIONS_COLUMN_PROPS } from "@/components/layout/ListActions";
 import ListTitle, {
   LIST_TITLE_COLUMN_PROPS,
@@ -108,6 +109,17 @@ const RemovalProfileList: FC<RemovalProfileListProps> = ({ profiles }) => {
         meta: {
           ariaLabel: (row) =>
             `${row.original.title} profile associated instances`,
+        },
+        Cell: ({
+          row: { original: removalProfile },
+        }: CellProps<RemovalProfile>) => {
+          return (
+            <ProfileAssociatedInstancesLink
+              count={removalProfile.computers.num_associated_computers}
+              profile={removalProfile}
+              query={`removal:${removalProfile.id}`}
+            />
+          );
         },
       },
       {

--- a/src/features/removal-profiles/types/RemovalProfile.d.ts
+++ b/src/features/removal-profiles/types/RemovalProfile.d.ts
@@ -2,6 +2,7 @@ export interface RemovalProfile extends Record<string, unknown> {
   access_group: string;
   all_computers: boolean;
   cascade_to_children: boolean;
+  computers: { num_associated_computers: number };
   days_without_exchange: number;
   id: number;
   name: string;

--- a/src/features/upgrade-profiles/components/UpgradeProfileList/UpgradeProfileList.tsx
+++ b/src/features/upgrade-profiles/components/UpgradeProfileList/UpgradeProfileList.tsx
@@ -1,3 +1,4 @@
+import ProfileAssociatedInstancesLink from "@/components/form/ProfileAssociatedInstancesLink";
 import { LIST_ACTIONS_COLUMN_PROPS } from "@/components/layout/ListActions";
 import ListTitle, {
   LIST_TITLE_COLUMN_PROPS,
@@ -109,6 +110,17 @@ const UpgradeProfileList: FC<UpgradeProfileListProps> = ({ profiles }) => {
         meta: {
           ariaLabel: ({ original }) =>
             `${original.title} profile associated instances`,
+        },
+        Cell: ({
+          row: { original: upgradeProfile },
+        }: CellProps<UpgradeProfile>) => {
+          return (
+            <ProfileAssociatedInstancesLink
+              count={upgradeProfile.computers.num_associated_computers}
+              profile={upgradeProfile}
+              query={`upgrade:${upgradeProfile.id}`}
+            />
+          );
         },
       },
       {

--- a/src/features/upgrade-profiles/types/UpgradeProfile.d.ts
+++ b/src/features/upgrade-profiles/types/UpgradeProfile.d.ts
@@ -9,6 +9,7 @@ export interface UpgradeProfile extends Record<string, unknown> {
   all_computers: boolean;
   at_minute: `${number}`;
   autoremove: boolean;
+  computers: { num_associated_computers: number };
   deliver_delay_window: `${number}`;
   deliver_within: `${number}`;
   every: UpgradeProfileFrequency;

--- a/src/tests/mocks/removalProfiles.ts
+++ b/src/tests/mocks/removalProfiles.ts
@@ -10,6 +10,9 @@ export const removalProfiles: RemovalProfile[] = [
     cascade_to_children: false,
     days_without_exchange: 30,
     tags: ["alpha", "beta"],
+    computers: {
+      num_associated_computers: 1,
+    },
   },
   {
     id: 2,
@@ -20,5 +23,8 @@ export const removalProfiles: RemovalProfile[] = [
     cascade_to_children: false,
     days_without_exchange: 14,
     tags: [],
+    computers: {
+      num_associated_computers: 1,
+    },
   },
 ];

--- a/src/tests/mocks/upgrade-profiles.ts
+++ b/src/tests/mocks/upgrade-profiles.ts
@@ -16,6 +16,9 @@ export const upgradeProfiles: UpgradeProfile[] = [
     every: "hour",
     on_days: ["mo", "th"],
     at_minute: "30",
+    computers: {
+      num_associated_computers: 1,
+    },
   },
   {
     id: 1,
@@ -31,6 +34,9 @@ export const upgradeProfiles: UpgradeProfile[] = [
     next_run: "2023-11-29T19:30:00Z",
     every: "hour",
     at_minute: "30",
+    computers: {
+      num_associated_computers: 1,
+    },
   },
   {
     id: 12,
@@ -48,5 +54,8 @@ export const upgradeProfiles: UpgradeProfile[] = [
     on_days: ["mo", "th"],
     at_minute: "30",
     at_hour: "10",
+    computers: {
+      num_associated_computers: 1,
+    },
   },
 ];


### PR DESCRIPTION
The tables for upgrade profiles and removal profiles include the associated instance count, which links to the instances table.