### PR TITLE
docs: fix incorrect git clone markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ The modern web interface for Canonical's Landscape, built with React and TypeScr
 
 Landscape is available as a SaaS solution at [landscape.canonical.com](https://landscape.canonical.com/) and as a self-hosted application.
 
-
-
 ---
 
 ## About this Repository
@@ -38,18 +36,20 @@ Follow these instructions to set up the project on your local machine for develo
 
 ### Prerequisites
 
-* **Node.js** (v22 or later recommended)
-* **pnpm** package manager. If you don't have it, you can install it with `npm install -g pnpm`.
+- **Node.js** (v22 or later recommended)
+- **pnpm** package manager. If you don't have it, you can install it with `npm install -g pnpm`.
 
 ### Setup Instructions
 
 1.  **Clone the repository:**
+
     ```bash
-    git clone [https://github.com/canonical/landscape-ui.git](https://github.com/canonical/landscape-ui.git)
+    git clone https://github.com/canonical/landscape-ui.git)
     cd landscape-ui
     ```
 
 2.  **Install dependencies:**
+
     ```bash
     pnpm install
     ```
@@ -78,6 +78,7 @@ To create a production-ready build of the application, run:
 ```bash
 pnpm build
 ```
+
 This command bundles the app into static files for production in the `dist/` directory.
 
 ---
@@ -86,15 +87,15 @@ This command bundles the app into static files for production in the `dist/` dir
 
 This project is built with a modern, robust set of tools:
 
-* **Framework/Library**: [React](https://reactjs.org/)
-* **Language**: [TypeScript](https://www.typescriptlang.org/)
-* **Build Tool**: [Vite](https://vitejs.dev/)
-* **Package Manager**: [PNPM](https://pnpm.io/)
-* **Data Fetching**: [React Query](https://tanstack.com/query/latest)
-* **Unit & Integration Testing**: [Vitest](https://vitest.dev/)
-* **End-to-End Testing**: [Playwright](https://playwright.dev/)
-* **API Mocking**: [MSW (Mock Service Worker)](https://mswjs.io/)
-* **Containerization**: [Docker](https://www.docker.com/)
+- **Framework/Library**: [React](https://reactjs.org/)
+- **Language**: [TypeScript](https://www.typescriptlang.org/)
+- **Build Tool**: [Vite](https://vitejs.dev/)
+- **Package Manager**: [PNPM](https://pnpm.io/)
+- **Data Fetching**: [React Query](https://tanstack.com/query/latest)
+- **Unit & Integration Testing**: [Vitest](https://vitest.dev/)
+- **End-to-End Testing**: [Playwright](https://playwright.dev/)
+- **API Mocking**: [MSW (Mock Service Worker)](https://mswjs.io/)
+- **Containerization**: [Docker](https://www.docker.com/)
 
 ---
 
@@ -102,8 +103,8 @@ This project is built with a modern, robust set of tools:
 
 We welcome your feedback! The best way to share your thoughts, report issues, or request features is through one of the following channels:
 
-* **Create an issue** directly on our [GitHub Issues page](https://github.com/canonical/landscape-ui/issues).
-* **Report a bug** on our [Launchpad project](https://bugs.launchpad.net/landscape).
+- **Create an issue** directly on our [GitHub Issues page](https://github.com/canonical/landscape-ui/issues).
+- **Report a bug** on our [Launchpad project](https://bugs.launchpad.net/landscape).
 
 ---
 


### PR DESCRIPTION
### Description:
The setup instructions previously wrapped the git clone command in Markdown link syntax ([text](url)), which caused the brackets and parentheses to render literally in the code block. This update replaces it with the correct plain command format to ensure proper copy-paste behavior.

### Changes:
Updated README.md setup section to use plain git clone command syntax.
Fixed formatting for the file.

Before:
<img width="900" height="230" alt="image" src="https://github.com/user-attachments/assets/6f49275d-adfd-4d33-8c38-5d8f9340c00d" />

After:
<img width="525" height="179" alt="image" src="https://github.com/user-attachments/assets/7019a3a1-362b-4de3-86de-da9ba45f452a" />
