### PR TITLE
chore: suppress scss deprecation warnings

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     preprocessorOptions: {
       scss: {
         quietDeps: true,
+        silenceDeprecations: ["import", "global-builtin"],
       },
     },
   },


### PR DESCRIPTION
A small quality of life change to suppress `import` and `global-builtin` deprecation warnings coming from scss. These warnings flood the development terminal and produce a lot of noise.