### PR TITLE
feat: rename instance statuses

### DIFF
--- a/src/features/instances/components/InstanceList/helpers.tsx
+++ b/src/features/instances/components/InstanceList/helpers.tsx
@@ -90,7 +90,13 @@ export const getStatusCellIconAndLabel = (
   if (1 === filteredAlerts.length) {
     return {
       icon: `${STATUSES[filteredAlerts[0].type].icon.color ?? STATUSES.Unknown.icon.color}`,
-      label: <>{filteredAlerts[0].summary}</>,
+      label: (
+        <>
+          {STATUSES[filteredAlerts[0].type].alternateLabel ??
+            STATUSES[filteredAlerts[0].type].label ??
+            filteredAlerts[0].summary}
+        </>
+      ),
     };
   }
 
@@ -99,7 +105,11 @@ export const getStatusCellIconAndLabel = (
       <span className={classes.statusContainer}>
         {filteredAlerts.map(({ type, summary }) => (
           <span className={classes.statusListItem} key={type}>
-            <Tooltip message={summary}>
+            <Tooltip
+              message={
+                STATUSES[type].alternateLabel ?? STATUSES[type].label ?? summary
+              }
+            >
               <Icon
                 className="u-no-margin--left"
                 name={`${STATUSES[type]?.icon.color ?? STATUSES.Unknown.icon.color}`}

--- a/src/features/instances/constants.ts
+++ b/src/features/instances/constants.ts
@@ -5,7 +5,7 @@ import type { Status } from "./types/Status";
 export const STATUSES: Record<string, Status> = {
   Online: {
     alertType: "ComputerOnlineAlert",
-    label: "Computers online",
+    label: "Online instances",
     alternateLabel: "Online",
     filterValue: "computer-online",
     query: "NOT alert:computer-offline",
@@ -16,7 +16,7 @@ export const STATUSES: Record<string, Status> = {
   },
   ComputerDuplicateAlert: {
     alertType: "ComputerDuplicateAlert",
-    label: "Computer duplicates",
+    label: "Duplicate instances",
     alternateLabel: "Duplicate",
     filterValue: "computer-duplicates",
     query: "alert:computer-duplicates",
@@ -24,7 +24,7 @@ export const STATUSES: Record<string, Status> = {
   },
   ComputerOfflineAlert: {
     alertType: "ComputerOfflineAlert",
-    label: "Computers offline",
+    label: "Offline instances",
     alternateLabel: "Offline",
     filterValue: "computer-offline",
     query: "alert:computer-offline",
@@ -32,8 +32,8 @@ export const STATUSES: Record<string, Status> = {
   },
   ComputerRebootAlert: {
     alertType: "ComputerRebootAlert",
-    label: "Computer reboot",
-    alternateLabel: "Reboot required",
+    label: "Needs reboot",
+    alternateLabel: "Needs reboot",
     filterValue: "computer-reboot",
     query: "alert:computer-reboot",
     icon: {
@@ -54,7 +54,7 @@ export const STATUSES: Record<string, Status> = {
   },
   PackageProfilesAlert: {
     alertType: "PackageProfilesAlert",
-    label: "Package profiles",
+    label: "Package profile alert",
     filterValue: "package-profiles",
     query: "alert:package-profiles",
     icon: {
@@ -63,14 +63,14 @@ export const STATUSES: Record<string, Status> = {
   },
   PackageReporterAlert: {
     alertType: "PackageReporterAlert",
-    label: "Package reporter",
+    label: "Package reporter alert",
     filterValue: "package-reporter",
     query: "alert:package-reporter",
     icon: { color: "package-reporter-alert" },
   },
   PackageUpgradesAlert: {
     alertType: "PackageUpgradesAlert",
-    label: "Package upgrades",
+    label: "Package upgrades alert",
     alternateLabel: "Regular",
     filterValue: "package-upgrades",
     query: "alert:package-upgrades",
@@ -78,7 +78,7 @@ export const STATUSES: Record<string, Status> = {
   },
   SecurityUpgradesAlert: {
     alertType: "SecurityUpgradesAlert",
-    label: "Security upgrades",
+    label: "Security upgrades alert",
     alternateLabel: "Security",
     filterValue: "security-upgrades",
     query: "alert:security-upgrades",
@@ -86,14 +86,14 @@ export const STATUSES: Record<string, Status> = {
   },
   UnapprovedActivitiesAlert: {
     alertType: "UnapprovedActivitiesAlert",
-    label: "Unapproved activities",
+    label: "Unapproved activities alert",
     filterValue: "unapproved-activities",
     query: "alert:unapproved-activities",
     icon: { gray: "status-queued" },
   },
   UpToDate: {
     alertType: "UpToDate",
-    label: "Up to date",
+    label: "Packages up to date",
     alternateLabel: "Up to date",
     filterValue: "up-to-date",
     query: "NOT alert:package-upgrades",
@@ -101,7 +101,7 @@ export const STATUSES: Record<string, Status> = {
   },
   PendingComputersAlert: {
     alertType: "PendingComputersAlert",
-    label: "Pending",
+    label: "Pending acceptance",
     alternateLabel: "Pending",
     filterValue: "",
     query: "",
@@ -109,8 +109,8 @@ export const STATUSES: Record<string, Status> = {
   },
   ChildInstanceProfileAlert: {
     alertType: "ChildInstanceProfileAlert",
-    label: "Child instance profiles",
-    alternateLabel: "Child instance profiles",
+    label: "WSL profile alert",
+    alternateLabel: "WSL profile alert",
     filterValue: "child-instance-profiles",
     query: "alert:child-instance-profiles",
     icon: { gray: "machines" },


### PR DESCRIPTION
- Renamed instance statuses in the status filter dropdown
- Use our own status labels instead of backend alert summaries