### PR TITLE
fix: make upgrade profile schedule message UTC time

### DIFF
--- a/src/features/upgrade-profiles/components/UpgradeProfileDetailsSidePanel/helpers.ts
+++ b/src/features/upgrade-profiles/components/UpgradeProfileDetailsSidePanel/helpers.ts
@@ -38,9 +38,7 @@ export const getScheduleInfo = (profile: UpgradeProfile) => {
       return { scheduleMessage: "Every week", nextRunMessage };
     }
 
-    const atHour = parseInt(at_hour);
-
-    scheduleMessage += `${getScheduledDays(on_days)} at ${atHour > 9 ? atHour : `0${atHour}`}:${atMinute > 9 ? atMinute : `0${atMinute}`} UTC`;
+    scheduleMessage += `${getScheduledDays(on_days)} at ${moment(next_run).utc().format("HH:mm")} UTC`;
   }
 
   return { scheduleMessage, nextRunMessage };


### PR DESCRIPTION
This PR fixes the upgrade profiles panel to show the schedule in UTC time, instead of the timezone it was set in.

This fixes https://bugs.launchpad.net/landscape/+bug/2107659

