### PR TITLE
hotfix: tag dropdown bugs

### DIFF
--- a/src/components/form/TagMultiSelect/TagList/TagList.module.scss
+++ b/src/components/form/TagMultiSelect/TagList/TagList.module.scss
@@ -12,7 +12,7 @@
 }
 
 .listItem {
-  box-shadow: 0 1px 0 0 $color-mid-x-light;
+  box-shadow: 0 1px 0 0 $colors--theme--border-low-contrast;
   column-gap: $sph--small;
   display: flex;
 }

--- a/src/components/form/TagMultiSelect/TagMultiSelect/TagMultiSelect.module.scss
+++ b/src/components/form/TagMultiSelect/TagMultiSelect/TagMultiSelect.module.scss
@@ -1,5 +1,6 @@
 @import "vanilla-framework/scss/settings_placeholders";
 @import "vanilla-framework/scss/settings_spacing";
+@import "vanilla-framework/scss/settings_colors";
 
 .root {
   margin-bottom: $sp-unit * 2.5;
@@ -12,7 +13,7 @@
   ) !important;
 
   & + :global(.p-search-and-filter__panel) {
-    background-color: $color-x-light;
+    background-color: $colors--theme--background-default;
   }
 }
 

--- a/src/pages/dashboard/instances/[single]/tabs/info/EditInstance/EditInstance.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/info/EditInstance/EditInstance.tsx
@@ -4,7 +4,7 @@ import {
   TagsAddConfirmationModal,
   useEditInstance,
 } from "@/features/instances";
-import { useGetProfileChanges, useGetTags } from "@/features/tags";
+import { useGetProfileChanges } from "@/features/tags";
 import useDebug from "@/hooks/useDebug";
 import useNotify from "@/hooks/useNotify";
 import useRoles from "@/hooks/useRoles";
@@ -33,7 +33,6 @@ const EditInstance: FC<EditInstanceProps> = ({ instance }) => {
 
   const { data: getAccessGroupQueryResult, isPending: isGettingAccessGroups } =
     getAccessGroupQuery();
-  const { tags, isGettingTags } = useGetTags();
   const { editInstance } = useEditInstance();
 
   const {
@@ -99,7 +98,7 @@ const EditInstance: FC<EditInstanceProps> = ({ instance }) => {
     }
   };
 
-  if (isGettingAccessGroups || isGettingTags) {
+  if (isGettingAccessGroups) {
     return <LoadingState />;
   }
 
@@ -107,12 +106,6 @@ const EditInstance: FC<EditInstanceProps> = ({ instance }) => {
     getAccessGroupQueryResult?.data.map(({ name, title }) => ({
       label: title,
       value: name,
-    })) ?? [];
-
-  const tagOptions: SelectOption[] =
-    tags.map((tag) => ({
-      label: tag,
-      value: tag,
     })) ?? [];
 
   return (
@@ -144,9 +137,7 @@ const EditInstance: FC<EditInstanceProps> = ({ instance }) => {
 
         <TagMultiSelect
           onTagsChange={async (items) => formik.setFieldValue("tags", items)}
-          tags={tagOptions
-            .filter(({ value }) => formik.values.tags.includes(value))
-            .map(({ value }) => value)}
+          tags={formik.values.tags}
         />
 
         <Textarea

--- a/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.tsx
@@ -52,6 +52,7 @@ import { useNavigate } from "react-router";
 import { useBoolean } from "usehooks-ts";
 import ProfileLink from "../ProfileLink";
 import { INITIAL_VALUES, VALIDATION_SCHEMA } from "./constants";
+import { getInstanceKeyForRemount } from "./helpers";
 import classes from "./InfoPanel.module.scss";
 import type { ModalConfirmationFormProps } from "./types";
 
@@ -287,7 +288,7 @@ const InfoPanel: FC<InfoPanelProps> = ({ instance }) => {
   return (
     <>
       <HeaderActions
-        key={instance.employee_id ?? "no-employee"}
+        key={getInstanceKeyForRemount(instance)}
         title={
           <div className={classes.headerContainer}>
             <h2

--- a/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/helpers.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/helpers.tsx
@@ -86,3 +86,12 @@ export const getInstanceInfoItems = (
     },
   ];
 };
+
+export const getInstanceKeyForRemount = (
+  instance: InstanceWithoutRelation,
+): string => {
+  const employeeId = instance.employee_id ?? "no-employee";
+  const tagsKey = instance.tags.join(",");
+
+  return `${employeeId}-${tagsKey}`;
+};


### PR DESCRIPTION
This PR addresses fixes when editing an instance from the instance Info tab (specifically the tags).
## Fixes:
- dark mode and light mode in tags dropdown
- editing tags and reopening the sidepanel immediately shows the updated state
- added tags are immediately shown as a Chip in the input box