### PR TITLE
docs: remove incorrect bracket on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Follow these instructions to set up the project on your local machine for develo
 1.  **Clone the repository:**
 
     ```bash
-    git clone https://github.com/canonical/landscape-ui.git)
+    git clone https://github.com/canonical/landscape-ui.git
     cd landscape-ui
     ```
 


### PR DESCRIPTION
Changes:
- Removed a stray closing bracket from the readme `git clone` command.
  
  
Before:
<img width="930" height="205" alt="image" src="https://github.com/user-attachments/assets/32a640fc-8061-427a-a76a-9871d75a1663" />

After:
<img width="965" height="209" alt="image" src="https://github.com/user-attachments/assets/bbf28815-fe7f-48bd-901c-3fa0b9f89d44" />
