### PR TITLE
fix: secondary navigation styling on medium screens

### DIFF
--- a/src/styles/partials/layout.scss
+++ b/src/styles/partials/layout.scss
@@ -23,6 +23,12 @@
   }
 }
 
+.l-navigation-bar {
+  @media (width >= 620px) {
+    width: 3rem;
+  }
+}
+
 .divided-blocks {
   display: flex;
   justify-content: end;


### PR DESCRIPTION
This PR is related to [this ticket](https://warthogs.atlassian.net/browse/LNDENG-3147)

Before:
<img width="1039" height="1056" alt="image" src="https://github.com/user-attachments/assets/a328a6d7-620e-495b-9f0d-a552ae6889e8" />

After:
<img width="1036" height="967" alt="image" src="https://github.com/user-attachments/assets/b214ada5-19e4-48b2-a0cb-e8c39c042622" />
