### PR TITLE
fix: packages tab incorrectly shows upgrades for packages

### DIFF
--- a/src/features/packages/components/PackageList/PackageList.test.tsx
+++ b/src/features/packages/components/PackageList/PackageList.test.tsx
@@ -1,6 +1,6 @@
 import { getInstancePackages } from "@/tests/mocks/packages";
 import { renderWithProviders } from "@/tests/render";
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -69,5 +69,36 @@ describe("PackageList", () => {
     renderWithProviders(<PackageList {...props} selectAll />);
 
     expect(props.onPackagesSelect).toHaveBeenCalledWith(packagesWithUpgrade);
+  });
+
+  it("shows Installed status when installed packages have no available version", () => {
+    const packageWithoutUpgrade = {
+      id: 999,
+      name: "adduser",
+      summary: "add and remove users and groups",
+      status: "installed" as const,
+      current_version: "3.118ubuntu5",
+      available_version: null,
+    };
+    const packageWithUpgrade = {
+      id: 1000,
+      name: "bash",
+      summary: "GNU Bourne Again SHell",
+      status: "installed" as const,
+      current_version: "5.1-6ubuntu1.1",
+      available_version: "5.1-6ubuntu1.2",
+    };
+
+    renderWithProviders(
+      <PackageList
+        {...props}
+        packages={[packageWithoutUpgrade, packageWithUpgrade]}
+      />,
+    );
+
+    const row = screen.getByText(packageWithoutUpgrade.name).closest("tr");
+    assert(row);
+    expect(within(row).getByText("Installed")).toBeInTheDocument();
+    expect(within(row).queryByText("Regular upgrade")).not.toBeInTheDocument();
   });
 });

--- a/src/features/packages/components/PackageList/helpers.ts
+++ b/src/features/packages/components/PackageList/helpers.ts
@@ -27,7 +27,10 @@ export const getPackageStatusInfo = (pkg: InstancePackage) => {
     pkgStatusInfo.label = "Security upgrade";
     pkgStatusInfo.icon = "status-failed-small";
   } else if (pkg.status === "installed") {
-    if (pkg.available_version !== pkg.current_version) {
+    if (
+      !!pkg.available_version &&
+      pkg.available_version !== pkg.current_version
+    ) {
       pkgStatusInfo.label = "Regular upgrade";
       pkgStatusInfo.icon = "status-waiting-small";
     } else {


### PR DESCRIPTION
This bug is related to [this Jira ticket](https://warthogs.atlassian.net/browse/LNDENG-2864)

The bug was in the UI’s status labeling logic for installed packages. It treated “has an upgrade” as `available_version !== current_version`. When the API returns `available_version: null` (meaning no upgrade), that comparison is still true (`null !== "3.118ubuntu5"`), so the UI incorrectly labeled these packages with “Regular upgrade.”

The fix is to require a real `available_version` before showing an upgrade, so installed packages with `available_version: null` are labeled “Installed” instead.

Before:
<img width="2302" height="1300" alt="image" src="https://github.com/user-attachments/assets/6e02cdef-cb5b-4cbd-814a-193ad3e80d7b" />
After:
<img width="2302" height="1300" alt="image" src="https://github.com/user-attachments/assets/6cad78d9-b3b5-4285-b8a8-0de1e07d4aeb" />
