### PR TITLE
fix: implement safeRedirect for handling external and internal redirects to prevent cross-site scripting

### DIFF
--- a/e2e/features/auth/oauth-completion.spec.ts
+++ b/e2e/features/auth/oauth-completion.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "../../support/fixtures/auth";
+import { navigateTo } from "../../support/helpers/navigation";
+
+const baseAuthResponse = {
+  accounts: [
+    {
+      classic_dashboard_url: "",
+      default: true,
+      name: "existing-account",
+      subdomain: null,
+      title: "Existing Account Inc.",
+    },
+  ],
+  current_account: "existing-account",
+  email: "existing-account@example.com",
+  has_password: true,
+  name: "Existing Account",
+  token: "existing-account-token",
+  invitation_id: null,
+  attach_code: null,
+};
+
+test("should fallback to homepage when OIDC return_to is unsafe external", async ({
+  page,
+}) => {
+  await page.route("**/auth/handle-code**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ...baseAuthResponse,
+        return_to: {
+          external: true,
+          url: "https://example.com",
+        },
+      }),
+    });
+  });
+
+  await navigateTo(page, "/handle-auth/oidc", {
+    code: "mock-code",
+    state: "mock-state",
+  });
+
+  await expect(page).toHaveURL(/overview/);
+});
+
+test("should redirect to internal return_to after OIDC completion", async ({
+  page,
+}) => {
+  await page.route("**/auth/handle-code**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ...baseAuthResponse,
+        return_to: {
+          external: false,
+          url: "/scripts",
+        },
+      }),
+    });
+  });
+
+  await navigateTo(page, "/handle-auth/oidc", {
+    code: "mock-code",
+    state: "mock-state",
+  });
+
+  await expect(page).toHaveURL(/\/scripts/);
+});
+
+test("should fallback to homepage when Ubuntu One return_to is unsafe external", async ({
+  page,
+}) => {
+  await page.route("**/auth/ubuntu-one/complete**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ...baseAuthResponse,
+        return_to: {
+          external: true,
+          url: "https://example.com",
+        },
+      }),
+    });
+  });
+
+  await navigateTo(page, "/handle-auth/ubuntu-one", {
+    code: "mock-code",
+    state: "mock-state",
+  });
+
+  await expect(page).toHaveURL(/overview/);
+});
+
+test("should redirect to internal return_to after Ubuntu One completion", async ({
+  page,
+}) => {
+  await page.route("**/auth/ubuntu-one/complete**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ...baseAuthResponse,
+        return_to: {
+          external: false,
+          url: "/scripts",
+        },
+      }),
+    });
+  });
+
+  await navigateTo(page, "/handle-auth/ubuntu-one", {
+    code: "mock-code",
+    state: "mock-state",
+  });
+
+  await expect(page).toHaveURL(/\/scripts/);
+});

--- a/src/components/guards/GuestGuard.tsx
+++ b/src/components/guards/GuestGuard.tsx
@@ -11,8 +11,7 @@ interface Props {
 }
 
 export const GuestGuard: FC<Props> = ({ children }) => {
-  const { authorized, authLoading, hasAccounts, redirectToExternalUrl } =
-    useAuth();
+  const { authorized, authLoading, hasAccounts, safeRedirect } = useAuth();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
 
@@ -27,18 +26,17 @@ export const GuestGuard: FC<Props> = ({ children }) => {
       return;
     }
 
-    if (searchParams.has("external")) {
-      redirectToExternalUrl(redirectTo, { replace: true });
-    } else {
-      navigate(redirectTo, { replace: true });
-    }
+    safeRedirect(redirectTo, {
+      external: searchParams.has("external"),
+      replace: true,
+    });
   }, [
     authorized,
     authLoading,
     hasAccounts,
     searchParams,
     navigate,
-    redirectToExternalUrl,
+    safeRedirect,
   ]);
 
   if (authLoading) return <LoadingState />;

--- a/src/components/guards/__tests__/AuthGuard.test.tsx
+++ b/src/components/guards/__tests__/AuthGuard.test.tsx
@@ -17,6 +17,7 @@ const authProps: AuthContextProps = {
   setUser: vi.fn(),
   user: authUser,
   redirectToExternalUrl: vi.fn(),
+  safeRedirect: vi.fn(),
   isFeatureEnabled: vi.fn(),
   hasAccounts: true,
 };

--- a/src/components/guards/__tests__/FeatureGuard.test.tsx
+++ b/src/components/guards/__tests__/FeatureGuard.test.tsx
@@ -17,6 +17,7 @@ const authProps: AuthContextProps = {
   setUser: vi.fn(),
   user: authUser,
   redirectToExternalUrl: vi.fn(),
+  safeRedirect: vi.fn(),
   isFeatureEnabled: vi.fn(),
   hasAccounts: true,
 };

--- a/src/components/guards/__tests__/GuestGuard.test.tsx
+++ b/src/components/guards/__tests__/GuestGuard.test.tsx
@@ -7,7 +7,7 @@ import type { AuthContextProps } from "@/context/auth";
 import { authUser } from "@/tests/mocks/auth";
 
 const navigate = vi.fn();
-const redirectToExternalUrl = vi.fn();
+const safeRedirect = vi.fn();
 
 vi.mock("@/hooks/useAuth");
 
@@ -18,6 +18,7 @@ const authProps: AuthContextProps = {
   setUser: vi.fn(),
   user: authUser,
   redirectToExternalUrl: vi.fn(),
+  safeRedirect: vi.fn(),
   isFeatureEnabled: vi.fn(),
   hasAccounts: true,
 };
@@ -47,7 +48,7 @@ describe("GuestGuard", () => {
 
     vi.mocked(useAuth).mockReturnValue({
       ...authState,
-      redirectToExternalUrl,
+      safeRedirect,
     });
 
     renderWithProviders(<Guard>Guest Content</Guard>);
@@ -107,22 +108,22 @@ describe("GuestGuard", () => {
     it("should redirect to internal 'redirect-to' url", async () => {
       await setup(authorizedState, { "redirect-to": "/dashboard/settings" });
 
-      expect(navigate).toHaveBeenCalledWith("/dashboard/settings", {
+      expect(safeRedirect).toHaveBeenCalledWith("/dashboard/settings", {
+        external: false,
         replace: true,
       });
-      expect(redirectToExternalUrl).not.toHaveBeenCalled();
     });
 
-    it("should redirect to external url if 'external' param is present", async () => {
+    it("should request external redirect when external param is present", async () => {
       await setup(authorizedState, {
         "redirect-to": "https://google.com",
         external: "true",
       });
 
-      expect(redirectToExternalUrl).toHaveBeenCalledWith("https://google.com", {
+      expect(safeRedirect).toHaveBeenCalledWith("https://google.com", {
+        external: true,
         replace: true,
       });
-      expect(navigate).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/alerts/components/AlertsList/AlertsList.test.tsx
+++ b/src/features/alerts/components/AlertsList/AlertsList.test.tsx
@@ -23,6 +23,7 @@ const authProps: AuthContextProps = {
   setUser: vi.fn(),
   user: authUser,
   redirectToExternalUrl: vi.fn(),
+  safeRedirect: vi.fn(),
   isFeatureEnabled: vi.fn(),
   hasAccounts: true,
 };

--- a/src/features/auth/components/LoginForm/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm/LoginForm.tsx
@@ -10,7 +10,7 @@ import {
 } from "@canonical/react-components";
 import { useFormik } from "formik";
 import type { FC } from "react";
-import { useNavigate, useSearchParams } from "react-router";
+import { useSearchParams } from "react-router";
 import * as Yup from "yup";
 import classes from "./LoginForm.module.scss";
 import { getFormikError } from "@/utils/formikErrors";
@@ -30,8 +30,7 @@ const LoginForm: FC<LoginFormProps> = ({ isIdentityAvailable }) => {
   const debug = useDebug();
   const { login: signInWithEmailAndPassword, isLoggingIn } = useLogin();
 
-  const { redirectToExternalUrl, setUser } = useAuth();
-  const navigate = useNavigate();
+  const { safeRedirect, setUser } = useAuth();
 
   const redirectTo = searchParams.get("redirect-to");
   const isExternalRedirect = searchParams.has("external");
@@ -89,15 +88,14 @@ const LoginForm: FC<LoginFormProps> = ({ isIdentityAvailable }) => {
           password: values.password,
         });
 
-        if (isExternalRedirect && redirectTo) {
-          redirectToExternalUrl(redirectTo, { replace: true });
-        } else {
-          if ("current_account" in data) {
-            setUser(data);
-          }
-
-          navigate(redirectTo ?? HOMEPAGE_PATH, { replace: true });
+        if ("current_account" in data) {
+          setUser(data);
         }
+
+        safeRedirect(redirectTo ?? HOMEPAGE_PATH, {
+          external: isExternalRedirect,
+          replace: true,
+        });
       } catch (error) {
         debug(error);
       }

--- a/src/features/auth/helpers.ts
+++ b/src/features/auth/helpers.ts
@@ -12,6 +12,34 @@ export const redirectToExternalUrl = (
   }
 };
 
+export const getSameOriginUrl = (input?: string | null) => {
+  if (!input) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(input, window.location.origin);
+
+    if (parsed.origin !== window.location.origin) {
+      return null;
+    }
+
+    return parsed;
+  } catch {
+    return null;
+  }
+};
+
+export const getSameOriginPath = (input?: string | null) => {
+  const parsed = getSameOriginUrl(input);
+
+  if (!parsed) {
+    return null;
+  }
+
+  return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+};
+
 export const getProviderIcon = (slug: string) => {
   return hasProperty(SUPPORTED_PROVIDERS, slug)
     ? SUPPORTED_PROVIDERS[slug].icon

--- a/src/features/auth/index.tsx
+++ b/src/features/auth/index.tsx
@@ -8,7 +8,11 @@ export { default as LoginForm } from "./components/LoginForm";
 export { default as ProvidersEmptyState } from "./components/ProvidersEmptyState";
 export { default as ProviderList } from "./components/ProviderList";
 export { default as ConsentBannerModal } from "./components/consent-banner/ConsentBannerModal";
-export { redirectToExternalUrl } from "./helpers";
+export {
+  redirectToExternalUrl,
+  getSameOriginPath,
+  getSameOriginUrl,
+} from "./helpers";
 export { useAuthHandle, useInvitation } from "./hooks";
 export { getProviderIcon } from "./helpers";
 export type {

--- a/src/features/general-settings/components/EditUserForm/EditUserForm.test.tsx
+++ b/src/features/general-settings/components/EditUserForm/EditUserForm.test.tsx
@@ -61,6 +61,7 @@ const authContextValues: AuthContextProps = {
   setUser: vi.fn(),
   user: authUser,
   redirectToExternalUrl: vi.fn(),
+  safeRedirect: vi.fn(),
   isFeatureEnabled: vi.fn(),
   hasAccounts: true,
 };

--- a/src/features/invitation/components/InvitationForm/InvitationForm.test.tsx
+++ b/src/features/invitation/components/InvitationForm/InvitationForm.test.tsx
@@ -19,6 +19,7 @@ const authProps: AuthContextProps = {
   setUser: vi.fn(),
   user: { ...authUser },
   redirectToExternalUrl: vi.fn(),
+  safeRedirect: vi.fn(),
   isFeatureEnabled: vi.fn(),
   hasAccounts: true,
 };

--- a/src/features/saved-searches/components/SavedSearchForm/SavedSearchForm.test.tsx
+++ b/src/features/saved-searches/components/SavedSearchForm/SavedSearchForm.test.tsx
@@ -47,6 +47,7 @@ const authContextValues: AuthContextProps = {
   setUser: vi.fn(),
   user: null,
   redirectToExternalUrl: vi.fn(),
+  safeRedirect: vi.fn(),
   isFeatureEnabled: vi.fn(() => false),
   hasAccounts: true,
 };

--- a/src/features/scripts/components/ScriptList/ScriptList.test.tsx
+++ b/src/features/scripts/components/ScriptList/ScriptList.test.tsx
@@ -23,6 +23,7 @@ const authContextValues: AuthContextProps = {
   setUser: vi.fn(),
   user: null,
   redirectToExternalUrl: vi.fn(),
+  safeRedirect: vi.fn(),
   isFeatureEnabled: () => true,
   hasAccounts: true,
 };

--- a/src/pages/auth/handle/oidc/OidcAuthPage/OidcAuthPage.test.tsx
+++ b/src/pages/auth/handle/oidc/OidcAuthPage/OidcAuthPage.test.tsx
@@ -7,7 +7,7 @@ import { renderWithProviders } from "@/tests/render";
 import { screen } from "@testing-library/react";
 import { beforeEach, describe, expect } from "vitest";
 
-const redirectToExternalUrl = vi.fn();
+const safeRedirect = vi.fn();
 const navigate = vi.fn();
 const setUser = vi.fn();
 
@@ -62,7 +62,7 @@ const mockTestParams = (response: AuthStateResponse | Error) => {
   vi.doMock("@/hooks/useAuth", async () => ({
     default: () => ({
       setUser,
-      redirectToExternalUrl,
+      safeRedirect,
     }),
   }));
 };
@@ -142,22 +142,25 @@ describe("OidcAuthPage", () => {
       ).toBeInTheDocument();
     });
 
-    it("should redirect to external URL when return_to is external", async () => {
-      expect(redirectToExternalUrl).toHaveBeenCalledWith(
-        "https://example.com",
-        { replace: true },
-      );
+    it("should request external redirect when return_to is external", async () => {
+      expect(safeRedirect).toHaveBeenCalledWith("https://example.com", {
+        external: true,
+        replace: true,
+      });
     });
 
     it("should redirect to internal URL when return_to is not external", async () => {
-      expect(navigate).toHaveBeenCalledWith("/dashboard", { replace: true });
+      expect(safeRedirect).toHaveBeenCalledWith("/dashboard", {
+        external: false,
+        replace: true,
+      });
     });
 
     it("should redirect to internal URL when return_to is not provided", async () => {
-      expect(navigate).toHaveBeenCalledWith(
-        new URL(HOMEPAGE_PATH, location.origin).pathname,
-        { replace: true },
-      );
+      expect(safeRedirect).toHaveBeenCalledWith(HOMEPAGE_PATH, {
+        external: false,
+        replace: true,
+      });
     });
 
     it("should redirect to invitation when invitation_id is present", async () => {

--- a/src/pages/auth/handle/oidc/OidcAuthPage/OidcAuthPage.tsx
+++ b/src/pages/auth/handle/oidc/OidcAuthPage/OidcAuthPage.tsx
@@ -16,7 +16,7 @@ import { ROUTES } from "@/libs/routes";
 const OidcAuthPage: FC = () => {
   const [searchParams] = useSearchParams();
 
-  const { redirectToExternalUrl, setUser } = useAuth();
+  const { safeRedirect, setUser } = useAuth();
   const { isSelfHosted, isSaas } = useEnv();
   const { accountExists } = useGetStandaloneAccount();
   const navigate = useNavigate();
@@ -67,20 +67,14 @@ const OidcAuthPage: FC = () => {
       return;
     }
 
-    const returnToUrl = authData.return_to?.url;
-
-    if (authData.return_to?.external && authData.return_to.url) {
-      redirectToExternalUrl(authData.return_to.url, {
-        replace: true,
-      });
-    } else {
-      const url = new URL(returnToUrl ?? HOMEPAGE_PATH, location.origin);
-      navigate(url.toString().replace(url.origin, ""), { replace: true });
-    }
+    safeRedirect(authData.return_to?.url ?? HOMEPAGE_PATH, {
+      external: authData.return_to?.external ?? false,
+      replace: true,
+    });
   }, [
     authData,
-    redirectToExternalUrl,
     navigate,
+    safeRedirect,
     setUser,
     isSelfHosted,
     accountExists,

--- a/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.test.tsx
+++ b/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.test.tsx
@@ -7,7 +7,7 @@ import { renderWithProviders } from "@/tests/render";
 import { screen } from "@testing-library/react";
 import { beforeEach, describe, expect, vi } from "vitest";
 
-const redirectToExternalUrl = vi.fn();
+const safeRedirect = vi.fn();
 const navigate = vi.fn();
 const setUser = vi.fn();
 
@@ -55,7 +55,7 @@ const mockTestParams = (response: AuthStateResponse | Error) => {
   });
 
   vi.doMock("@/hooks/useAuth", async () => ({
-    default: () => ({ setUser, redirectToExternalUrl }),
+    default: () => ({ setUser, safeRedirect }),
   }));
 };
 
@@ -127,22 +127,25 @@ describe("UbuntuOneAuthPage", () => {
       ).toBeInTheDocument();
     });
 
-    it("should redirect to external URL when return_to is external", async () => {
-      expect(redirectToExternalUrl).toHaveBeenCalledWith(
-        "https://example.com",
-        { replace: true },
-      );
+    it("should request external redirect when return_to is external", async () => {
+      expect(safeRedirect).toHaveBeenCalledWith("https://example.com", {
+        external: true,
+        replace: true,
+      });
     });
 
     it("should redirect to internal URL when return_to is not external", () => {
-      expect(navigate).toHaveBeenCalledWith("/dashboard", { replace: true });
+      expect(safeRedirect).toHaveBeenCalledWith("/dashboard", {
+        external: false,
+        replace: true,
+      });
     });
 
     it("should redirect to internal URL when return_to is not provided", async () => {
-      expect(navigate).toHaveBeenCalledWith(
-        new URL(HOMEPAGE_PATH, location.origin).pathname,
-        { replace: true },
-      );
+      expect(safeRedirect).toHaveBeenCalledWith(HOMEPAGE_PATH, {
+        external: false,
+        replace: true,
+      });
     });
 
     it("should redirect to invitation when invitation_id is present", async () => {

--- a/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.tsx
+++ b/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.tsx
@@ -17,7 +17,7 @@ const UbuntuOneAuthPage: FC = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
 
-  const { redirectToExternalUrl, setUser } = useAuth();
+  const { safeRedirect, setUser } = useAuth();
   const { isSelfHosted, isSaas } = useEnv();
   const { accountExists } = useGetStandaloneAccount();
 
@@ -28,13 +28,6 @@ const UbuntuOneAuthPage: FC = () => {
 
   useEffect(() => {
     if (!authData || !("current_account" in authData)) {
-      return;
-    }
-
-    if (authData.return_to?.external && authData.return_to.url) {
-      redirectToExternalUrl(authData.return_to.url, {
-        replace: true,
-      });
       return;
     }
 
@@ -63,14 +56,14 @@ const UbuntuOneAuthPage: FC = () => {
       return;
     }
 
-    const returnToUrl = authData.return_to?.url;
-    const url = new URL(returnToUrl ?? HOMEPAGE_PATH, location.origin);
-
-    navigate(url.toString().replace(url.origin, ""), { replace: true });
+    safeRedirect(authData.return_to?.url ?? HOMEPAGE_PATH, {
+      external: authData.return_to?.external ?? false,
+      replace: true,
+    });
   }, [
     authData,
-    redirectToExternalUrl,
     navigate,
+    safeRedirect,
     setUser,
     isSelfHosted,
     accountExists,

--- a/src/pages/dashboard/instances/[single]/SingleInstanceTabs/SingleInstanceTabs.test.tsx
+++ b/src/pages/dashboard/instances/[single]/SingleInstanceTabs/SingleInstanceTabs.test.tsx
@@ -46,6 +46,7 @@ describe("SingleInstanceTabs", () => {
         redirectToExternalUrl: vi.fn(),
         setUser: vi.fn(),
         user: authUser,
+        safeRedirect: vi.fn(),
         hasAccounts: true,
       });
     });

--- a/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.test.tsx
@@ -22,6 +22,7 @@ const authProps: AuthContextProps = {
   setUser: vi.fn(),
   user: authUser,
   redirectToExternalUrl: vi.fn(),
+  safeRedirect: vi.fn(),
   isFeatureEnabled: vi.fn(),
   hasAccounts: true,
 };

--- a/src/templates/dashboard/Navigation/Navigation.test.tsx
+++ b/src/templates/dashboard/Navigation/Navigation.test.tsx
@@ -21,6 +21,7 @@ const authProps: AuthContextProps = {
   setUser: vi.fn(),
   user: authUser,
   redirectToExternalUrl: vi.fn(),
+  safeRedirect: vi.fn(),
   isFeatureEnabled: vi.fn(),
   hasAccounts: true,
 };


### PR DESCRIPTION
Jira: [WD-3734](https://warthogs.atlassian.net/browse/LNDENG-3734)

### Summary

- Prevent open redirects by forcing all user-controlled redirects to stay on the same origin (domain).
- Centralize redirect validation in auth context via a "safeRedirect" function and update login/guest/OAuth flows.
- Add e2e coverage for login, OAuth completion, and guest redirect cases.

[WD-3734]: https://warthogs.atlassian.net/browse/WD-3734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ