### PR TITLE
fix: show installed packages in the packages panel when no upgrades are available

### DIFF
--- a/src/pages/dashboard/instances/[single]/tabs/packages/PackagesPanel/PackagesPanel.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/packages/PackagesPanel/PackagesPanel.test.tsx
@@ -1,0 +1,38 @@
+import { renderWithProviders } from "@/tests/render";
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import PackagesPanel from "./PackagesPanel";
+
+describe("PackagesPanel", () => {
+  it("shows installed packages on the All filter when there are no upgrades", async () => {
+    renderWithProviders(
+      <PackagesPanel />,
+      undefined,
+      "/instances/999",
+      "/instances/:instanceId",
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "no-upgrades-pkg" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("No packages have been found yet."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows upgrade empty message (not global empty state) when installed packages exist", async () => {
+    renderWithProviders(
+      <PackagesPanel />,
+      undefined,
+      "/instances/999?status=upgrade",
+      "/instances/:instanceId",
+    );
+
+    expect(
+      await screen.findByText("No available upgrades found."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("No packages have been found yet."),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/instances/[single]/tabs/packages/PackagesPanel/PackagesPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/packages/PackagesPanel/PackagesPanel.tsx
@@ -32,6 +32,7 @@ const PackagesPanel: FC = () => {
   } = getInstancePackagesQuery({
     limit: 1,
     instance_id: instanceId,
+    installed: true,
   });
 
   const {

--- a/src/tests/mocks/packages.ts
+++ b/src/tests/mocks/packages.ts
@@ -319,6 +319,19 @@ export const packages = [
       },
     ],
   },
+  {
+    id: 99999,
+    name: "no-upgrades-pkg",
+    summary: "package without available upgrades",
+    computers: [
+      {
+        id: 999,
+        status: "installed",
+        current_version: "1.0.0",
+        available_version: null,
+      },
+    ],
+  },
 ] as const satisfies Package[];
 
 export const getInstancePackages = (instanceId: number): InstancePackage[] => {


### PR DESCRIPTION
Jira: [LNDENG-3905](https://warthogs.atlassian.net/browse/LNDENG-3905)

## Problem
- In the new dashboard, the Packages tab could show the global empty state (`No packages have been found yet.`) even when installed packages exist.
## Expected behavior
- All filter: show installed packages, even if no upgrades are available.
- Upgrades filter: show `No available upgrades found.`
- Show global empty state only when the instance truly has zero packages.

## Root cause
- The existence check in `PackagesPanel` did not explicitly request installed packages, so in this scenario it effectively behaved like an upgrades-only check.

## Changes
- Updated `PackagesPanel` to query installed packages for the unfiltered/existence check (`installed: true`).
- Updated package MSW handler boolean parsing/filtering so "false" is not treated as truthy and filter behavior matches query intent.
- Added regression coverage for:
    - installed packages visible on All when no upgrades exist
    - upgrades empty message on Upgrades without triggering global empty state

[LNDENG-3905]: https://warthogs.atlassian.net/browse/LNDENG-3905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ