### PR TITLE
test: vitest fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist-ssr
 .venv
 .vite-node
 coverage
+reports
 
 # Cache
 .eslintcache

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -48,7 +48,6 @@ export default defineConfig({
         "**/*.d.ts",
         "**/virtual:*",
         "**/__x00__*",
-        "**/\x00*",
         "**/*{.,-}{test,spec}.{ts,tsx}",
         "**/__tests__/**",
         "**/vitest.{workspace,projects}.ts",


### PR DESCRIPTION
- Remove an `exclude` entry from coverage config, which was preventing coverage from appearing
- Add `reports` to `.gitignore`