### PR TITLE
Disable ResponsiveButtons when all items are disabled

### DIFF
--- a/.changeset/wet-maps-report.md
+++ b/.changeset/wet-maps-report.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Disable ResponsiveButtons when all items are disabled

--- a/src/components/ui/ResponsiveButtons/ResponsiveButtons.tsx
+++ b/src/components/ui/ResponsiveButtons/ResponsiveButtons.tsx
@@ -4,6 +4,7 @@ import {
   isContextualMenu,
   textFromNode,
 } from "@/components/ui/ResponsiveButtons/helpers";
+import ResponsiveDropdownItem from "@/components/ui/ResponsiveDropdownItem";
 import { BREAKPOINT_PX } from "@/constants";
 import type {
   ConfirmationButtonProps,
@@ -14,7 +15,6 @@ import classNames from "classnames";
 import type { FC, ReactElement, ReactNode } from "react";
 import { isValidElement, useMemo } from "react";
 import { useMediaQuery } from "usehooks-ts";
-import ResponsiveDropdownItem from "@/components/ui/ResponsiveDropdownItem";
 import classes from "./ResponsiveButtons.module.scss";
 import type { ButtonLikeProps, CollapsedLink, CollapsedNode } from "./types";
 
@@ -154,6 +154,7 @@ const ResponsiveButtons: FC<ResponsiveButtonGroupProps> = ({
           hasToggleIcon
           toggleLabel={menuLabel}
           toggleClassName="u-no-margin--bottom"
+          toggleDisabled={collapsedItems.every((item) => item.disabled)}
         >
           {(close: () => void) => (
             <>

--- a/src/components/ui/ResponsiveButtons/types.d.ts
+++ b/src/components/ui/ResponsiveButtons/types.d.ts
@@ -1,5 +1,5 @@
-import type { ReactNode } from "react";
 import type { MenuLink, Position } from "@canonical/react-components";
+import type { ReactNode } from "react";
 
 export interface ButtonLikeProps {
   children?: ReactNode;
@@ -30,4 +30,4 @@ export interface CollapsedNode {
   position?: Position;
 }
 
-export type CollapsedLink = MenuLink & { key: string };
+export type CollapsedLink = MenuLink & { key: string; disabled?: boolean };


### PR DESCRIPTION
## Summary

When `ResponsiveButtons` shrinks on smaller screens, the contextual menu will be disabled if every collapsed item is disabled.

## Release Impact

According to the [Landscape Server Release Cycle](https://docs.google.com/document/d/1sKAp5IvArpfArhMNojFwKOHm9LEdHKB4Et6tu1_-0GY/edit?tab=t.0), this change will target the following release cycle:
- **Target Branch**: `dev`
- **Version Impact**:
  - [x] Patch (Fix)
  - [ ] Minor (Feature)
  - [ ] Major (Breaking)

## Checklist
- [x] **Changeset Added**: I have run `pnpm changeset` and committed the resulting `.md` file.
- [x] **UI Verified**: I have verified the changes locally.
- [x] **Linting**: No linting errors are present (especially in `scripts/`).

## Versioning Reminder
> [!IMPORTANT]
> This repository now uses **CalVer** ($YY.0M.Point.Patch$).
> Please ensure your changeset description is clear, as it will be automatically added to the `CHANGELOG.md` upon merging to `main`.