### PR TITLE
[24.04] Fix scripts not appearing after first page [LNDENG-4158]

### DIFF
--- a/src/pages/dashboard/scripts/ScriptsContainer/ScriptsContainer.tsx
+++ b/src/pages/dashboard/scripts/ScriptsContainer/ScriptsContainer.tsx
@@ -29,30 +29,30 @@ const ScriptsContainer: FC<ScriptsContainerProps> = () => {
           getScriptsQueryResult.data.results.length === 0) && (
           <ScriptsEmptyState />
         )}
-      {currentPage !== 1 ||
+      {(currentPage !== 1 ||
         pageSize !== 20 ||
         (!getScriptsQueryLoading &&
           getScriptsQueryResult &&
-          getScriptsQueryResult.data.results.length > 0 && (
-            <>
-              <ScriptList
-                isScriptsLoading={getScriptsQueryLoading}
-                scripts={getScriptsQueryResult?.data.results ?? []}
-              />
-              <TablePagination
-                currentPage={currentPage}
-                totalItems={getScriptsQueryResult?.data.count}
-                paginate={(page) => {
-                  setCurrentPage(page);
-                }}
-                pageSize={pageSize}
-                setPageSize={(itemsNumber) => {
-                  setPageSize(itemsNumber);
-                }}
-                currentItemCount={getScriptsQueryResult.data.results.length}
-              />
-            </>
-          ))}
+          getScriptsQueryResult.data.results.length > 0)) && (
+        <>
+          <ScriptList
+            isScriptsLoading={getScriptsQueryLoading}
+            scripts={getScriptsQueryResult?.data.results ?? []}
+          />
+          <TablePagination
+            currentPage={currentPage}
+            totalItems={getScriptsQueryResult?.data.count}
+            paginate={(page) => {
+              setCurrentPage(page);
+            }}
+            pageSize={pageSize}
+            setPageSize={(itemsNumber) => {
+              setPageSize(itemsNumber);
+            }}
+            currentItemCount={getScriptsQueryResult?.data.results.length}
+          />
+        </>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Summary

- Fixed boolean logic to show scripts after first page

## Release Impact

According to the [Landscape Server Release Cycle](https://docs.google.com/document/d/1sKAp5IvArpfArhMNojFwKOHm9LEdHKB4Et6tu1_-0GY/edit?tab=t.0), this change will target the following release cycle:
- **Target Branch**: `dev` / `main` (Beta)
- **Version Impact**:
  - [ ] Patch (Fix)
  - [ ] Minor (Feature)
  - [ ] Major (Breaking)

## Checklist
- [ ] **Changeset Added**: I have run `pnpm changeset` and committed the resulting `.md` file.
- [ ] **UI Verified**: I have verified the changes locally.
- [ ] **Linting**: No linting errors are present (especially in `scripts/`).

## Versioning Reminder
> [!IMPORTANT]
> This repository now uses **CalVer** ($YY.0M.Point.Patch$).
> Please ensure your changeset description is clear, as it will be automatically added to the `CHANGELOG.md` upon merging to `main`.