### PR TITLE
test: add tests for all non profile related files with under 60% coverage

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,15 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { renderWithProviders } from "@/tests/render";
+import App from "./App";
+
+describe("App", () => {
+  it("renders not found route for unknown path", async () => {
+    renderWithProviders(<App />, undefined, "/does-not-exist");
+
+    expect(await screen.findByText("Page not found")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Go back to the home page" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/filter/SearchQueryEditor/SearchQueryEditor.test.tsx
+++ b/src/components/filter/SearchQueryEditor/SearchQueryEditor.test.tsx
@@ -1,0 +1,86 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import SearchQueryEditor from "./SearchQueryEditor";
+
+const codeEditorSpy = vi.fn();
+
+vi.mock("@/components/form/CodeEditor", () => ({
+  default: (props: Record<string, unknown>) => {
+    codeEditorSpy(props);
+    return <div data-testid="search-query-editor-mock" />;
+  },
+}));
+
+describe("SearchQueryEditor", () => {
+  it("configures monaco language when terms exist", () => {
+    const configureSearchLanguage = vi.fn();
+
+    render(
+      <SearchQueryEditor
+        label="Search"
+        value="status:installed"
+        languageId="landscape-query"
+        terms={["status"]}
+        languageConfig={{
+          profileTypes: ["security"],
+          usgStatuses: ["compliant"],
+          wslStatuses: ["enabled"],
+        }}
+        configureSearchLanguage={configureSearchLanguage}
+      />,
+    );
+
+    const call = codeEditorSpy.mock.calls.at(-1)?.[0] as {
+      monacoBeforeMount: (monaco: unknown) => void;
+      options: Record<string, unknown>;
+      language: string;
+    };
+
+    expect(call.language).toBe("landscape-query");
+    expect(call.options).toMatchObject({
+      fixedOverflowWidgets: true,
+      suggestOnTriggerCharacters: true,
+      quickSuggestions: true,
+    });
+
+    const monaco = { editor: {} };
+    call.monacoBeforeMount(monaco);
+
+    expect(configureSearchLanguage).toHaveBeenCalledWith(
+      monaco,
+      "landscape-query",
+      ["status"],
+      {
+        profileTypes: ["security"],
+        usgStatuses: ["compliant"],
+        wslStatuses: ["enabled"],
+      },
+    );
+  });
+
+  it("does not configure monaco language when terms are empty", () => {
+    const configureSearchLanguage = vi.fn();
+
+    render(
+      <SearchQueryEditor
+        label="Search"
+        value=""
+        languageId="landscape-query"
+        terms={[]}
+        languageConfig={{
+          profileTypes: [],
+          usgStatuses: [],
+          wslStatuses: [],
+        }}
+        configureSearchLanguage={configureSearchLanguage}
+      />,
+    );
+
+    const call = codeEditorSpy.mock.calls.at(-1)?.[0] as {
+      monacoBeforeMount: (monaco: unknown) => void;
+    };
+
+    call.monacoBeforeMount({});
+    expect(configureSearchLanguage).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/form/CheckboxGroup.test.tsx
+++ b/src/components/form/CheckboxGroup.test.tsx
@@ -1,0 +1,53 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "@/tests/render";
+import type { SelectOption } from "@/types/SelectOption";
+import CheckboxGroup from "./CheckboxGroup";
+
+const options: SelectOption[] = [
+  { label: "Alpha", value: "alpha" },
+  { label: "Beta", value: "beta" },
+];
+
+describe("CheckboxGroup", () => {
+  it("renders label, help, and error message", () => {
+    renderWithProviders(
+      <CheckboxGroup
+        name="groups"
+        label="Access groups"
+        options={options}
+        value={[]}
+        onChange={vi.fn()}
+        help="Select one or more groups"
+        error="Selection is required"
+        required
+      />,
+    );
+
+    expect(screen.getByText("Access groups")).toBeInTheDocument();
+    expect(screen.getByText("Select one or more groups")).toBeInTheDocument();
+    expect(screen.getByText("Selection is required")).toBeInTheDocument();
+  });
+
+  it("adds and removes values when options are toggled", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    renderWithProviders(
+      <CheckboxGroup
+        name="groups"
+        label="Access groups"
+        options={options}
+        value={["alpha"]}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByLabelText("Alpha"));
+    expect(onChange).toHaveBeenCalledWith([]);
+
+    await user.click(screen.getByLabelText("Beta"));
+    expect(onChange).toHaveBeenCalledWith(["alpha", "beta"]);
+  });
+});

--- a/src/components/form/CodeEditor.test.tsx
+++ b/src/components/form/CodeEditor.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import CodeEditor from "./CodeEditor";
+
+vi.mock("./CodeEditorInner", () => ({
+  default: ({ label }: { label: string }) => (
+    <div data-testid="code-editor-inner">{label}</div>
+  ),
+}));
+
+describe("CodeEditor", () => {
+  it("renders lazy inner editor", async () => {
+    render(<CodeEditor label="Script" value="echo hello" />);
+
+    expect(await screen.findByTestId("code-editor-inner")).toHaveTextContent(
+      "Script",
+    );
+  });
+});

--- a/src/components/form/CodeEditorInner.test.tsx
+++ b/src/components/form/CodeEditorInner.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import CodeEditorInner from "./CodeEditorInner";
+
+const useThemeSpy = vi.fn();
+
+vi.mock("@/context/theme", () => ({
+  useTheme: () => useThemeSpy(),
+}));
+
+vi.mock("@/libs/monaco", () => ({}));
+
+describe("CodeEditorInner", () => {
+  it("renders label and validation state, then triggers change and blur", async () => {
+    const user = userEvent.setup();
+
+    useThemeSpy.mockReturnValue({ isDarkMode: true });
+
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    const monacoBeforeMount = vi.fn();
+
+    render(
+      <>
+        <CodeEditorInner
+          label="Command"
+          value="echo hi"
+          required
+          error="invalid"
+          onChange={onChange}
+          onBlur={onBlur}
+          monacoBeforeMount={monacoBeforeMount}
+        />
+        <button>outside</button>
+      </>,
+    );
+
+    expect(screen.getByText("Command")).toBeInTheDocument();
+    expect(screen.getByText("invalid")).toBeInTheDocument();
+
+    const label = screen.getByText("Command");
+    expect(label).toHaveClass("is-required");
+
+    const editor = screen.getByTestId("mock-monaco");
+    expect(editor).toHaveAttribute("data-theme", "vs-dark");
+    expect(editor).toHaveAttribute("data-language", "shell");
+
+    await user.click(editor);
+    await user.type(editor, "abc");
+    await user.tab();
+
+    expect(onChange).toHaveBeenCalled();
+    expect(onBlur).toHaveBeenCalled();
+    expect(monacoBeforeMount).toHaveBeenCalled();
+  });
+
+  it("uses light theme when dark mode is disabled", () => {
+    useThemeSpy.mockReturnValue({ isDarkMode: false });
+
+    render(<CodeEditorInner label="Command" value="echo hi" />);
+
+    expect(screen.getByTestId("mock-monaco")).toHaveAttribute(
+      "data-theme",
+      "vs-light",
+    );
+  });
+
+  it("does not call blur callback when focus stays inside editor container", async () => {
+    const user = userEvent.setup();
+    useThemeSpy.mockReturnValue({ isDarkMode: false });
+    const onBlur = vi.fn();
+
+    render(
+      <CodeEditorInner
+        label="Command"
+        value="echo hi"
+        onBlur={onBlur}
+        headerContent={<button type="button">Inside header action</button>}
+      />,
+    );
+
+    const editor = screen.getByTestId("mock-monaco");
+    const control = editor.closest(".p-form__control");
+    assert(control);
+
+    const insideControlButton = document.createElement("button");
+    insideControlButton.type = "button";
+    insideControlButton.textContent = "Inside control";
+    control.appendChild(insideControlButton);
+
+    await user.click(editor);
+    await user.click(screen.getByRole("button", { name: "Inside control" }));
+    expect(onBlur).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole("button", { name: "Inside header action" }),
+    );
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/form/FileInput/FileInput.test.tsx
+++ b/src/components/form/FileInput/FileInput.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "@/tests/render";
@@ -79,5 +79,86 @@ describe("FileInput", () => {
     );
 
     expect(screen.getByText("Script file")).toBeInTheDocument();
+  });
+
+  it("shows help text when a file is present", () => {
+    const file = new File(["content"], "helped.txt", { type: "text/plain" });
+
+    renderWithProviders(
+      <FileInput
+        help="Only text files are allowed"
+        value={file}
+        onFileUpload={vi.fn()}
+        onFileRemove={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Only text files are allowed")).toBeInTheDocument();
+  });
+
+  it("does not call onFileUpload when no files are selected", () => {
+    const onFileUpload = vi.fn();
+
+    renderWithProviders(
+      <FileInput
+        label="Upload script"
+        value={null}
+        onFileUpload={onFileUpload}
+        onFileRemove={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Upload script"), {
+      target: { files: null },
+    });
+
+    expect(onFileUpload).not.toHaveBeenCalled();
+  });
+
+  it("uploads selected file and triggers onBlur callback", async () => {
+    const user = userEvent.setup();
+    const onFileUpload = vi.fn().mockResolvedValue(undefined);
+    const onBlur = vi.fn();
+    const file = new File(["script"], "script.sh", {
+      type: "text/x-shellscript",
+    });
+
+    renderWithProviders(
+      <FileInput
+        label="Upload script"
+        value={null}
+        onFileUpload={onFileUpload}
+        onFileRemove={vi.fn()}
+        onBlur={onBlur}
+      />,
+    );
+
+    const input = screen.getByLabelText("Upload script");
+    await user.click(input);
+    await user.upload(input, file);
+
+    expect(onFileUpload).toHaveBeenCalledWith([file]);
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it("uploads selected file when onBlur is not provided", async () => {
+    const user = userEvent.setup();
+    const onFileUpload = vi.fn().mockResolvedValue(undefined);
+    const file = new File(["script"], "script.sh", {
+      type: "text/x-shellscript",
+    });
+
+    renderWithProviders(
+      <FileInput
+        label="Upload script"
+        value={null}
+        onFileUpload={onFileUpload}
+        onFileRemove={vi.fn()}
+      />,
+    );
+
+    await user.upload(screen.getByLabelText("Upload script"), file);
+
+    expect(onFileUpload).toHaveBeenCalledWith([file]);
   });
 });

--- a/src/components/form/monacoMock.test.tsx
+++ b/src/components/form/monacoMock.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import CodeEditorMock, { Editor } from "@/tests/monacoMock";
+
+describe("monacoMock", () => {
+  it("renders editor value and invokes optional callbacks", async () => {
+    const user = userEvent.setup();
+    const beforeMount = vi.fn();
+    const onChange = vi.fn();
+
+    render(
+      <Editor
+        value="echo hi"
+        language="shell"
+        theme="vs-dark"
+        className="editor"
+        beforeMount={beforeMount}
+        onChange={onChange}
+      />,
+    );
+
+    const editor = screen.getByTestId("mock-monaco");
+    expect(editor).toHaveValue("echo hi");
+    expect(editor).toHaveAttribute("data-language", "shell");
+    expect(editor).toHaveAttribute("data-theme", "vs-dark");
+    expect(editor).toHaveClass("editor");
+    expect(beforeMount).toHaveBeenCalledWith({ mocked: true });
+
+    await user.clear(editor);
+    await user.type(editor, "updated value");
+
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("uses defaultValue when value is undefined", async () => {
+    const user = userEvent.setup();
+
+    render(<Editor defaultValue="fallback" />);
+
+    const editor = screen.getByTestId("mock-monaco");
+    expect(editor).toHaveValue("fallback");
+
+    await user.type(editor, " text");
+    expect(editor).toHaveValue("fallback");
+  });
+
+  it("renders CodeEditorMock content and conditionally renders errors", () => {
+    const { rerender } = render(
+      <CodeEditorMock
+        label="Script"
+        value="echo test"
+        error="Invalid script"
+        headerContent={<span>Header action</span>}
+      />,
+    );
+
+    expect(screen.getByText("Script")).toBeInTheDocument();
+    expect(screen.getByText("Header action")).toBeInTheDocument();
+    expect(screen.getByText("Invalid script")).toBeInTheDocument();
+
+    rerender(<CodeEditorMock label="Script" error={false} />);
+    expect(screen.queryByText("Invalid script")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/guards/__tests__/SelfHostedGuard.test.tsx
+++ b/src/components/guards/__tests__/SelfHostedGuard.test.tsx
@@ -1,0 +1,70 @@
+import EnvError from "@/pages/EnvError";
+import { EnvContext, type EnvContextState } from "@/context/env";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { describe, expect, it } from "vitest";
+import { SelfHostedGuard } from "../SelfHostedGuard";
+
+describe("SelfHostedGuard", () => {
+  const envState: EnvContextState = {
+    envLoading: false,
+    isSaas: true,
+    isSelfHosted: false,
+    packageVersion: "",
+    revision: "",
+    displayDisaStigBanner: false,
+  };
+
+  const renderWithRoutes = (value: EnvContextState) => {
+    return render(
+      <MemoryRouter initialEntries={["/"]}>
+        <EnvContext.Provider value={value}>
+          <Routes>
+            <Route
+              path="/"
+              element={
+                <SelfHostedGuard>
+                  <div>secret</div>
+                </SelfHostedGuard>
+              }
+            />
+            <Route path="/env-error" element={<EnvError />} />
+          </Routes>
+        </EnvContext.Provider>
+      </MemoryRouter>,
+    );
+  };
+
+  it("renders loading state while env is loading", () => {
+    renderWithRoutes({
+      ...envState,
+      envLoading: true,
+    });
+
+    expect(screen.queryByText("secret")).not.toBeInTheDocument();
+    expect(screen.queryByText("Environment Error")).not.toBeInTheDocument();
+  });
+
+  it("renders children when self hosted", () => {
+    renderWithRoutes({
+      ...envState,
+      isSelfHosted: true,
+      isSaas: false,
+    });
+
+    expect(screen.getByText("secret")).toBeInTheDocument();
+    expect(screen.queryByText("Environment Error")).not.toBeInTheDocument();
+  });
+
+  it("navigates away when not self hosted", () => {
+    renderWithRoutes({
+      ...envState,
+    });
+
+    expect(screen.queryByText("secret")).not.toBeInTheDocument();
+    expect(screen.getByText("Environment Error")).toBeInTheDocument();
+    expect(
+      screen.getByText("This feature is not available in SaaS mode."),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/GlobalShell/GlobalShell.test.tsx
+++ b/src/components/layout/GlobalShell/GlobalShell.test.tsx
@@ -1,8 +1,27 @@
-import { NotifyContext } from "@/context/notify";
+import useNotify from "@/hooks/useNotify";
 import { renderWithProviders } from "@/tests/render";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect } from "vitest";
 import { GlobalShell } from "./GlobalShell";
+
+const NotificationTrigger = () => {
+  const { notify } = useNotify();
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        notify.success({
+          title: "Success",
+          message: "Success notification",
+        });
+      }}
+    >
+      Trigger notification
+    </button>
+  );
+};
 
 describe("GlobalShell", () => {
   it("renders children", () => {
@@ -10,31 +29,21 @@ describe("GlobalShell", () => {
     expect(screen.getByText("Shell content")).toBeInTheDocument();
   });
 
-  it("shows a notification when notify has a message", () => {
-    const notifyValue = {
-      notify: {
-        notification: {
-          type: "positive" as const,
-          message: "Success notification",
-          title: "Success",
-        },
-        success: () => undefined,
-        error: () => undefined,
-        info: () => undefined,
-        clear: () => undefined,
-      },
-      sidePanel: {
-        open: false,
-        setOpen: () => undefined,
-      },
-    };
+  it("shows a notification when notify has a message", async () => {
+    const user = userEvent.setup();
 
     renderWithProviders(
-      <NotifyContext.Provider value={notifyValue}>
-        <GlobalShell>content</GlobalShell>
-      </NotifyContext.Provider>,
+      <GlobalShell>
+        <NotificationTrigger />
+      </GlobalShell>,
     );
 
-    expect(screen.getByText("Success notification")).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Trigger notification" }),
+    );
+
+    expect(
+      (await screen.findAllByText("Success notification")).length,
+    ).toBeGreaterThan(0);
   });
 });

--- a/src/context/auth.test.tsx
+++ b/src/context/auth.test.tsx
@@ -1,0 +1,256 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useContext, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import useFeatures from "@/hooks/useFeatures";
+import {
+  getSameOriginPath,
+  getSameOriginUrl,
+  redirectToExternalUrl,
+  useGetAuthState,
+} from "@/features/auth";
+import { authUser } from "@/tests/mocks/auth";
+import { HOMEPAGE_PATH } from "@/constants";
+import { ROUTES } from "@/libs/routes";
+import AuthProvider, { AuthContext } from "./auth";
+
+const navigate = vi.hoisted(() => vi.fn());
+const mockUseLocation = vi.hoisted(() => vi.fn());
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+    useLocation: () => mockUseLocation(),
+  };
+});
+
+vi.mock("@/hooks/useFeatures");
+vi.mock("@/features/auth");
+
+describe("AuthProvider", () => {
+  const wrapperWithProvider = (queryClient: QueryClient) => {
+    return function Wrapper({ children }: { readonly children: ReactNode }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          <AuthProvider>{children}</AuthProvider>
+        </QueryClientProvider>
+      );
+    };
+  };
+
+  const renderAuthContext = (queryClient: QueryClient) => {
+    return renderHook(() => useContext(AuthContext), {
+      wrapper: wrapperWithProvider(queryClient),
+    });
+  };
+
+  beforeEach(() => {
+    navigate.mockReset();
+
+    mockUseLocation.mockReturnValue({ pathname: "/dashboard" });
+
+    vi.mocked(useGetAuthState).mockReturnValue({
+      user: authUser,
+      isLoading: false,
+      isFetched: true,
+    });
+
+    vi.mocked(useFeatures).mockReturnValue({
+      isFeatureEnabled: vi.fn(() => true),
+      isFeaturesLoading: false,
+    });
+
+    vi.mocked(getSameOriginUrl).mockReturnValue(
+      new URL("/dashboard", window.location.origin),
+    );
+    vi.mocked(getSameOriginPath).mockReturnValue("/dashboard");
+    vi.mocked(redirectToExternalUrl).mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("disables auth-state query when handling auth callbacks", () => {
+    mockUseLocation.mockReturnValue({ pathname: "/auth/handle-auth" });
+
+    const queryClient = new QueryClient();
+    renderAuthContext(queryClient);
+
+    expect(useGetAuthState).toHaveBeenCalledWith({ enabled: false });
+  });
+
+  it("exposes computed auth flags and feature checks", () => {
+    const isFeatureEnabled = vi.fn(() => true);
+    vi.mocked(useFeatures).mockReturnValue({
+      isFeatureEnabled,
+      isFeaturesLoading: false,
+    });
+
+    const queryClient = new QueryClient();
+    const { result } = renderAuthContext(queryClient);
+
+    expect(result.current.authorized).toBe(true);
+    expect(result.current.hasAccounts).toBe(true);
+    expect(result.current.authLoading).toBe(false);
+    expect(result.current.isFeatureEnabled("spa-dashboard")).toBe(true);
+  });
+
+  it("sets auth user and clears non-auth queries on logout", () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(["authUser"], authUser);
+    queryClient.setQueryData(["features", authUser.email], [{ key: "x" }]);
+
+    const { result } = renderAuthContext(queryClient);
+
+    act(() => {
+      result.current.setUser(authUser);
+    });
+
+    expect(queryClient.getQueryData(["authUser"])).toEqual(authUser);
+
+    act(() => {
+      result.current.logout();
+    });
+
+    expect(queryClient.getQueryData(["authUser"])).toBeNull();
+    expect(
+      queryClient.getQueryData(["features", authUser.email]),
+    ).toBeUndefined();
+    expect(navigate).toHaveBeenCalledWith(ROUTES.auth.login(), {
+      replace: true,
+    });
+  });
+
+  it("navigates to homepage for unsafe redirect targets", () => {
+    vi.mocked(getSameOriginUrl).mockReturnValue(null);
+
+    const queryClient = new QueryClient();
+    const { result } = renderAuthContext(queryClient);
+
+    act(() => {
+      result.current.safeRedirect("https://google.com");
+    });
+
+    expect(navigate).toHaveBeenCalledWith(HOMEPAGE_PATH, { replace: true });
+  });
+
+  it("navigates internally with same-origin safe path", () => {
+    vi.mocked(getSameOriginUrl).mockReturnValue(
+      new URL("/dashboard/settings", window.location.origin),
+    );
+    vi.mocked(getSameOriginPath).mockReturnValue("/dashboard/settings");
+
+    const queryClient = new QueryClient();
+    const { result } = renderAuthContext(queryClient);
+
+    act(() => {
+      result.current.safeRedirect("/dashboard/settings", { replace: false });
+    });
+
+    expect(navigate).toHaveBeenCalledWith("/dashboard/settings", {
+      replace: false,
+    });
+  });
+
+  it("uses external redirect helper when external option is requested", () => {
+    const safeUrl = new URL("/dashboard/settings", window.location.origin);
+    vi.mocked(getSameOriginUrl).mockReturnValue(safeUrl);
+
+    const queryClient = new QueryClient();
+    const { result } = renderAuthContext(queryClient);
+
+    act(() => {
+      result.current.safeRedirect("/dashboard/settings", {
+        external: true,
+        replace: false,
+      });
+    });
+
+    expect(redirectToExternalUrl).toHaveBeenCalledWith(safeUrl.toString(), {
+      replace: false,
+    });
+  });
+
+  it("redirects to safe path fallback when same-origin URL has no path", () => {
+    vi.mocked(getSameOriginUrl).mockReturnValue(
+      new URL(window.location.origin),
+    );
+    vi.mocked(getSameOriginPath).mockReturnValue(null);
+
+    const queryClient = new QueryClient();
+    const { result } = renderAuthContext(queryClient);
+
+    act(() => {
+      result.current.safeRedirect(window.location.origin, { replace: false });
+    });
+
+    expect(navigate).toHaveBeenCalledWith(HOMEPAGE_PATH, { replace: false });
+  });
+
+  it("exposes hasAccounts false when user has no accounts", () => {
+    vi.mocked(useGetAuthState).mockReturnValue({
+      user: { ...authUser, accounts: [], current_account: "" },
+      isLoading: false,
+      isFetched: true,
+    });
+
+    const queryClient = new QueryClient();
+    const { result } = renderAuthContext(queryClient);
+
+    expect(result.current.authorized).toBe(true);
+    expect(result.current.hasAccounts).toBe(false);
+  });
+
+  it("renders redirecting state while external redirect is in progress", async () => {
+    const user = userEvent.setup();
+
+    const TriggerExternalRedirect = () => {
+      const { safeRedirect } = useContext(AuthContext);
+
+      return (
+        <button
+          type="button"
+          onClick={() => {
+            safeRedirect("/dashboard", { external: true });
+          }}
+        >
+          Trigger redirect
+        </button>
+      );
+    };
+
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <TriggerExternalRedirect />
+        </AuthProvider>
+      </QueryClientProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Trigger redirect" }));
+
+    expect(screen.getAllByText("Redirecting...").length).toBeGreaterThan(0);
+  });
+
+  it("provides initial auth context defaults", () => {
+    const { result } = renderHook(() => useContext(AuthContext));
+
+    expect(result.current.authLoading).toBe(false);
+    expect(result.current.authorized).toBe(false);
+    expect(result.current.hasAccounts).toBe(false);
+    expect(result.current.user).toBeNull();
+    expect(result.current.isFeatureEnabled("spa-dashboard")).toBe(false);
+    expect(result.current.logout()).toBeUndefined();
+    expect(result.current.setUser(authUser)).toBeUndefined();
+    expect(result.current.safeRedirect()).toBeUndefined();
+    expect(result.current.redirectToExternalUrl("/dashboard")).toBeUndefined();
+  });
+});

--- a/src/features/alerts/components/AlertTagsCell/AlertTagsCell.test.tsx
+++ b/src/features/alerts/components/AlertTagsCell/AlertTagsCell.test.tsx
@@ -1,12 +1,20 @@
 import { alerts } from "@/tests/mocks/alerts";
 import { renderWithProviders } from "@/tests/render";
+import { setEndpointStatus } from "@/tests/controllers/controller";
 import type { MultiSelectItem } from "@canonical/react-components";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import AlertTagsCell from "./AlertTagsCell";
 
-const mockAlert = alerts[0];
+const [mockAlert] = alerts;
+assert(mockAlert);
+const nonAllAlert = alerts.find((alert) => !alert.all_computers);
+assert(nonAllAlert);
+const taggedNonAllAlert = {
+  ...nonAllAlert,
+  tags: ["tag1", "tag2"],
+};
 
 const mockAvailableTagOptions: MultiSelectItem[] = [
   { value: "All", label: "All instances" },
@@ -16,6 +24,10 @@ const mockAvailableTagOptions: MultiSelectItem[] = [
 ];
 
 describe("AlertTagsCell", () => {
+  beforeEach(() => {
+    setEndpointStatus("default");
+  });
+
   it("allows selecting and deselecting tags", async () => {
     renderWithProviders(
       <AlertTagsCell
@@ -77,5 +89,110 @@ describe("AlertTagsCell", () => {
 
     expect(screen.getByText("Save changes")).toHaveAttribute("aria-disabled");
     expect(screen.getByText("Revert")).toHaveAttribute("aria-disabled");
+  });
+
+  it("saves all-instances selection and shows success message", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <AlertTagsCell
+        alert={mockAlert}
+        availableTagOptions={mockAvailableTagOptions}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("checkbox", { name: "All instances" }));
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(await screen.findByText("Alert tags updated")).toBeInTheDocument();
+  });
+
+  it("saves deselected all-instances tags and shows success message", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <AlertTagsCell
+        alert={mockAlert}
+        availableTagOptions={mockAvailableTagOptions}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("checkbox", { name: "All instances" }));
+    await user.click(screen.getByRole("checkbox", { name: "Tag 2" }));
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(await screen.findByText("Alert tags updated")).toBeInTheDocument();
+  });
+
+  it("saves tag additions/removals for non-all alert and shows success message", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <AlertTagsCell
+        alert={nonAllAlert}
+        availableTagOptions={mockAvailableTagOptions}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("checkbox", { name: "Tag 1" }));
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(await screen.findByText("Alert tags updated")).toBeInTheDocument();
+  });
+
+  it("saves all-instances selection for non-all alerts", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <AlertTagsCell
+        alert={nonAllAlert}
+        availableTagOptions={mockAvailableTagOptions}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("checkbox", { name: "All instances" }));
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(await screen.findByText("Alert tags updated")).toBeInTheDocument();
+  });
+
+  it("saves deselected tags for non-all alerts with preselected tags", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <AlertTagsCell
+        alert={taggedNonAllAlert}
+        availableTagOptions={mockAvailableTagOptions}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("checkbox", { name: "Tag 2" }));
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(await screen.findByText("Alert tags updated")).toBeInTheDocument();
+  });
+
+  it("shows an error notification when saving tags fails", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "error", path: "AssociateAlert" });
+
+    renderWithProviders(
+      <AlertTagsCell
+        alert={nonAllAlert}
+        availableTagOptions={mockAvailableTagOptions}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("checkbox", { name: "Tag 1" }));
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(
+      await screen.findByText('The endpoint status is set to "error".'),
+    ).toBeInTheDocument();
   });
 });

--- a/src/features/alerts/index.ts
+++ b/src/features/alerts/index.ts
@@ -1,3 +1,8 @@
 export { default as AlertsList } from "./components/AlertsList";
 export { useAlerts } from "./hooks";
-export type { Alert, SubscriptionParams } from "./types";
+export type {
+  Alert,
+  SubscriptionParams,
+  AssociateAlertParams,
+  DisassociateAlertParams,
+} from "./types";

--- a/src/features/api-credentials/index.ts
+++ b/src/features/api-credentials/index.ts
@@ -1,2 +1,3 @@
 export { default as ApiCredentialsTables } from "./components/ApiCredentialsTables";
 export { useApiCredentials } from "./hooks";
+export type { UserCredentials } from "./types";

--- a/src/features/attach/components/OTPInputContainer/OTPInputContainer.test.tsx
+++ b/src/features/attach/components/OTPInputContainer/OTPInputContainer.test.tsx
@@ -1,11 +1,17 @@
 import { renderWithProviders } from "@/tests/render";
+import { PATHS, ROUTES } from "@/libs/routes";
+import { setEndpointStatus } from "@/tests/controllers/controller";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import OTPInputContainer from "./OTPInputContainer";
 
 describe("OTPInputContainer", () => {
   const user = userEvent.setup();
+
+  beforeEach(() => {
+    setEndpointStatus("default");
+  });
 
   it("should render the component with the correct title", () => {
     renderWithProviders(<OTPInputContainer />);
@@ -29,5 +35,77 @@ describe("OTPInputContainer", () => {
 
     const errorMessage = screen.getByText("Code must be 6 characters long");
     expect(errorMessage).toBeInTheDocument();
+  });
+
+  it("does not show length validation error when code is complete", async () => {
+    renderWithProviders(<OTPInputContainer />);
+
+    const inputs = screen.getAllByRole("textbox");
+    for (let i = 0; i < 6; i++) {
+      const input = inputs[i];
+      assert(input);
+      await user.type(input, String(i + 1));
+    }
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    expect(
+      screen.queryByText("Code must be 6 characters long"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("prefills code from query string when code is incomplete", () => {
+    renderWithProviders(
+      <OTPInputContainer />,
+      undefined,
+      `${ROUTES.auth.attach({ code: "QWER1" })}`,
+      PATHS.auth.attach,
+    );
+
+    const inputs = screen.getAllByRole("textbox");
+    expect(inputs[0]).toHaveValue("Q");
+    expect(inputs[1]).toHaveValue("W");
+    expect(inputs[2]).toHaveValue("E");
+    expect(inputs[3]).toHaveValue("R");
+    expect(inputs[4]).toHaveValue("1");
+    expect(inputs[5]).toHaveValue("");
+  });
+
+  it("shows expired-code error and stays on attach page", async () => {
+    renderWithProviders(
+      <OTPInputContainer />,
+      undefined,
+      `${ROUTES.auth.attach({ code: "EXPIRE" })}`,
+      PATHS.auth.attach,
+    );
+
+    expect(
+      await screen.findByText(
+        "The code you entered has expired and is no longer valid.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: /enter code to connect to the ubuntu installer/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows endpoint error when verify request fails", async () => {
+    setEndpointStatus({
+      status: "error",
+      path: "ubuntu-installer-attach-sessions/code",
+    });
+
+    renderWithProviders(
+      <OTPInputContainer />,
+      undefined,
+      `${ROUTES.auth.attach({ code: "QWERTY" })}`,
+      PATHS.auth.attach,
+    );
+
+    expect(
+      await screen.findByText('The endpoint status is set to "error".'),
+    ).toBeInTheDocument();
   });
 });

--- a/src/features/attach/components/OTPInputContainer/OTPInputContainer.tsx
+++ b/src/features/attach/components/OTPInputContainer/OTPInputContainer.tsx
@@ -24,7 +24,7 @@ const OTPInputContainer: FC = () => {
 
   const formik = useFormik<FormikProps>({
     initialValues: {
-      code: Object.assign(Array(OTP_LENGTH).fill(""), code?.split("") || []),
+      code: Object.assign(Array(OTP_LENGTH).fill(""), code.split("")),
     },
     validationSchema: Yup.object().shape({
       code: Yup.array().test(

--- a/src/features/auth/helpers.test.ts
+++ b/src/features/auth/helpers.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ROUTES } from "@/libs/routes";
+import {
+  getProviderIcon,
+  getSameOriginPath,
+  getSameOriginUrl,
+  redirectToExternalUrl,
+} from "./helpers";
+
+describe("auth helpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses location.assign by default for external redirects", () => {
+    const assignSpy = vi.fn();
+    const replaceSpy = vi.fn();
+
+    vi.spyOn(window, "location", "get").mockReturnValue({
+      ...window.location,
+      assign: assignSpy,
+      replace: replaceSpy,
+    });
+
+    const targetUrl = "https://example.com/login";
+    redirectToExternalUrl(targetUrl);
+
+    expect(assignSpy).toHaveBeenCalledWith(targetUrl);
+  });
+
+  it("uses location.replace when replace option is set", () => {
+    const assignSpy = vi.fn();
+    const replaceSpy = vi.fn();
+
+    vi.spyOn(window, "location", "get").mockReturnValue({
+      ...window.location,
+      assign: assignSpy,
+      replace: replaceSpy,
+    });
+
+    const targetUrl = "https://example.com/login";
+    redirectToExternalUrl(targetUrl, { replace: true });
+
+    expect(replaceSpy).toHaveBeenCalledWith(targetUrl);
+  });
+
+  it("returns null for missing and cross-origin inputs", () => {
+    expect(getSameOriginUrl()).toBeNull();
+    expect(getSameOriginUrl("https://google.com")).toBeNull();
+    expect(getSameOriginUrl("http://%")).toBeNull();
+  });
+
+  it("resolves same-origin relative URLs", () => {
+    const input = `${ROUTES.settings.root({ tab: "users" })}#top`;
+    const parsed = getSameOriginUrl(input);
+
+    expect(parsed).toBeInstanceOf(URL);
+    expect(parsed?.pathname).toBe(ROUTES.settings.root());
+    expect(parsed?.search).toBe("?tab=users");
+    expect(parsed?.hash).toBe("#top");
+  });
+
+  it("returns same-origin path with query and hash", () => {
+    const input = `${ROUTES.settings.root({ tab: "users" })}#top`;
+
+    expect(getSameOriginPath(input)).toBe(
+      `${ROUTES.settings.root({ tab: "users" })}#top`,
+    );
+    expect(getSameOriginPath("https://example.com/outside")).toBeNull();
+  });
+
+  it("falls back to the default provider icon for unknown providers", () => {
+    expect(getProviderIcon("okta")).toBe("okta");
+    expect(getProviderIcon("unknown-provider")).toBe("connected");
+  });
+});

--- a/src/features/autoinstall-files/components/AutoinstallFileForm/AutoinstallFileForm.test.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFileForm/AutoinstallFileForm.test.tsx
@@ -1,22 +1,27 @@
+import { setEndpointStatus } from "@/tests/controllers/controller";
 import { ADD_AUTOINSTALL_FILE_NOTIFICATION } from "@/pages/dashboard/settings/employees/tabs/autoinstall-files";
 import { renderWithProviders } from "@/tests/render";
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
-import { describe } from "vitest";
+import { beforeEach, describe, expect, vi } from "vitest";
 import AutoinstallFileForm from "./AutoinstallFileForm";
 import { DEFAULT_FILE } from "./constants";
 
 describe("AutoinstallFileForm", () => {
-  const createAutoinstallFileProps: ComponentProps<typeof AutoinstallFileForm> =
-    {
-      buttonText: "Add",
-      description: "Add an autoinstall file.",
-      initialFile: DEFAULT_FILE,
-      notification: ADD_AUTOINSTALL_FILE_NOTIFICATION,
-      onSubmit: vi.fn(),
-    };
+  const createAutoinstallFileProps = (): ComponentProps<
+    typeof AutoinstallFileForm
+  > => ({
+    buttonText: "Add",
+    description: "Add an autoinstall file.",
+    initialFile: DEFAULT_FILE,
+    notification: ADD_AUTOINSTALL_FILE_NOTIFICATION,
+    onSubmit: vi.fn(async () => undefined),
+  });
 
-  const editAutoinstallFileProps: ComponentProps<typeof AutoinstallFileForm> = {
+  const editAutoinstallFileProps = (): ComponentProps<
+    typeof AutoinstallFileForm
+  > => ({
     buttonText: "Save changes",
     description: `The duplicated file will be assigned to the same user groups in the identity provider as the original file.`,
     initialFile: {
@@ -25,11 +30,27 @@ describe("AutoinstallFileForm", () => {
       is_default: false,
     },
     notification: ADD_AUTOINSTALL_FILE_NOTIFICATION,
-    onSubmit: vi.fn(),
-  };
+    onSubmit: vi.fn(async () => undefined),
+  });
+
+  const createAutoinstallFileWithContentsProps = (): ComponentProps<
+    typeof AutoinstallFileForm
+  > => ({
+    ...createAutoinstallFileProps(),
+    initialFile: {
+      ...DEFAULT_FILE,
+      contents: "#cloud-config\nusers:\n  - name: ubuntu",
+    },
+  });
+
+  beforeEach(() => {
+    setEndpointStatus("default");
+  });
 
   it("should not render default checkbox when editing", () => {
-    renderWithProviders(<AutoinstallFileForm {...editAutoinstallFileProps} />);
+    renderWithProviders(
+      <AutoinstallFileForm {...editAutoinstallFileProps()} />,
+    );
     expect(
       screen.queryByRole("checkbox", { name: "Default" }),
     ).not.toBeInTheDocument();
@@ -42,18 +63,215 @@ describe("AutoinstallFileForm", () => {
   });
 
   it("should show a disabled button when first creating a form", async () => {
-    renderWithProviders(
-      <AutoinstallFileForm {...createAutoinstallFileProps} />,
-    );
+    const props = createAutoinstallFileProps();
+    renderWithProviders(<AutoinstallFileForm {...props} />);
 
     expect(
       screen.getByRole("checkbox", { name: "Default" }),
     ).toBeInTheDocument();
 
     const submitButton = screen.getByRole("button", {
-      name: createAutoinstallFileProps.buttonText,
+      name: props.buttonText,
     });
 
     expect(submitButton).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("populates filename from uploaded file when creating", async () => {
+    const props = createAutoinstallFileProps();
+    const user = userEvent.setup();
+    const file = new File(["#cloud-config\nusers: []"], "custom-config.yaml", {
+      type: "text/yaml",
+    });
+
+    renderWithProviders(<AutoinstallFileForm {...props} />);
+
+    const fileInput = screen.getByTestId("autoinstall-upload-input");
+
+    await user.upload(fileInput, file);
+
+    expect(screen.getByRole("textbox", { name: "File name" })).toHaveValue(
+      "custom-config",
+    );
+    expect(screen.getByRole("button", { name: "Add" })).not.toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("keeps existing filename when uploading a file", async () => {
+    const props = createAutoinstallFileProps();
+    const user = userEvent.setup();
+    const file = new File(["#cloud-config\npackage_update: true"], "new.yaml", {
+      type: "text/yaml",
+    });
+
+    renderWithProviders(<AutoinstallFileForm {...props} />);
+
+    const fileNameInput = screen.getByRole("textbox", { name: "File name" });
+    await user.type(fileNameInput, "custom-file-name");
+
+    await user.upload(screen.getByTestId("autoinstall-upload-input"), file);
+
+    expect(fileNameInput).toHaveValue("custom-file-name");
+  });
+
+  it("enables submit when content differs from initial file content", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <AutoinstallFileForm {...createAutoinstallFileWithContentsProps()} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Add" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+
+    await user.type(screen.getByTestId("mock-monaco"), "\n# changed");
+
+    expect(screen.getByRole("button", { name: "Add" })).not.toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("submits successfully after validation", async () => {
+    const user = userEvent.setup();
+    const props = createAutoinstallFileProps();
+    renderWithProviders(<AutoinstallFileForm {...props} />);
+
+    await user.type(screen.getByRole("textbox", { name: "File name" }), "base");
+    await user.type(screen.getByTestId("mock-monaco"), "#cloud-config");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(props.onSubmit).toHaveBeenCalledWith({
+      accept_warning: false,
+      contents: "#cloud-config",
+      filename: "base.yaml",
+      is_default: false,
+    });
+  });
+
+  it("handles submit errors from creating file", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn(async () => {
+      throw new Error("submit failed");
+    });
+    const props = { ...createAutoinstallFileProps(), onSubmit };
+    renderWithProviders(<AutoinstallFileForm {...props} />);
+
+    await user.type(screen.getByRole("textbox", { name: "File name" }), "base");
+    await user.type(screen.getByTestId("mock-monaco"), "#cloud-config");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      accept_warning: false,
+      contents: "#cloud-config",
+      filename: "base.yaml",
+      is_default: false,
+    });
+    expect(await screen.findByText("submit failed")).toBeInTheDocument();
+  });
+
+  it("handles validation errors that are not override warnings", async () => {
+    const user = userEvent.setup();
+    const props = createAutoinstallFileProps();
+    setEndpointStatus({ status: "error", path: "autoinstall:validate" });
+    renderWithProviders(<AutoinstallFileForm {...props} />);
+
+    await user.type(screen.getByRole("textbox", { name: "File name" }), "base");
+    await user.type(screen.getByTestId("mock-monaco"), "#cloud-config");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(props.onSubmit).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText('The endpoint status is set to "error".'),
+    ).toBeInTheDocument();
+  });
+
+  it("shows override modal and submits when confirmed", async () => {
+    const user = userEvent.setup();
+    const props = createAutoinstallFileProps();
+    setEndpointStatus({
+      status: "error",
+      path: "autoinstall:validate-override",
+    });
+    renderWithProviders(<AutoinstallFileForm {...props} />);
+
+    await user.type(screen.getByRole("textbox", { name: "File name" }), "base");
+    await user.type(screen.getByTestId("mock-monaco"), "#cloud-config");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Override autoinstall file" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("users")).toBeInTheDocument();
+    expect(screen.getByText("identity")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Override and add file" }),
+    );
+
+    expect(props.onSubmit).toHaveBeenCalledWith({
+      accept_warning: true,
+      contents: "#cloud-config",
+      filename: "base.yaml",
+      is_default: false,
+    });
+  });
+
+  it("hides override modal when canceled", async () => {
+    const user = userEvent.setup();
+    const props = createAutoinstallFileProps();
+    setEndpointStatus({
+      status: "error",
+      path: "autoinstall:validate-override",
+    });
+    renderWithProviders(<AutoinstallFileForm {...props} />);
+
+    await user.type(screen.getByRole("textbox", { name: "File name" }), "base");
+    await user.type(screen.getByTestId("mock-monaco"), "#cloud-config");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Override autoinstall file",
+    });
+    await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
+
+    expect(
+      screen.queryByRole("heading", { name: "Override autoinstall file" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens hidden file input when clicking populate from file", async () => {
+    const user = userEvent.setup();
+    const clickSpy = vi.spyOn(HTMLInputElement.prototype, "click");
+    const props = createAutoinstallFileProps();
+    renderWithProviders(<AutoinstallFileForm {...props} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Populate from file" }),
+    );
+
+    expect(clickSpy).toHaveBeenCalled();
+    clickSpy.mockRestore();
+  });
+
+  it("ignores empty file input change", async () => {
+    const user = userEvent.setup();
+    const props = createAutoinstallFileProps();
+    const file = new File(["#cloud-config\nusers: []"], "custom-config.yaml", {
+      type: "text/yaml",
+    });
+    renderWithProviders(<AutoinstallFileForm {...props} />);
+
+    const fileInput = screen.getByTestId("autoinstall-upload-input");
+    await user.upload(fileInput, file);
+    await user.upload(fileInput, []);
+
+    expect(screen.getByRole("textbox", { name: "File name" })).toHaveValue(
+      "custom-config",
+    );
   });
 });

--- a/src/features/autoinstall-files/components/AutoinstallFileForm/AutoinstallFileForm.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFileForm/AutoinstallFileForm.tsx
@@ -185,6 +185,7 @@ const AutoinstallFileForm: FC<AutoinstallFileFormProps> = ({
         ref={inputRef}
         className="u-hide"
         type="file"
+        data-testid="autoinstall-upload-input"
         accept={AUTOINSTALL_FILE_LANGUAGES.map(
           (language) => `.${language}`,
         ).join(",")}

--- a/src/features/employees/components/EmployeeDropdown/EmployeeDropdown.test.tsx
+++ b/src/features/employees/components/EmployeeDropdown/EmployeeDropdown.test.tsx
@@ -1,53 +1,199 @@
 import { renderWithProviders } from "@/tests/render";
-import { screen } from "@testing-library/react";
+import { setEndpointStatus } from "@/tests/controllers/controller";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
-import { describe, expect, vi } from "vitest";
+import { beforeEach, describe, expect, vi } from "vitest";
+import { PATHS, ROUTES } from "@/libs/routes";
 import EmployeeDropdown from "./EmployeeDropdown";
 import { employees as mockEmployees } from "@/tests/mocks/employees";
 
-const props: ComponentProps<typeof EmployeeDropdown> = {
+const baseProps: ComponentProps<typeof EmployeeDropdown> = {
   employee: null,
   setEmployee: vi.fn(),
   error: undefined,
 };
 
 describe("EmployeeDropdown", () => {
-  beforeEach(async () => {
-    renderWithProviders(
-      <EmployeeDropdown {...props} />,
-      undefined,
-      "/instances/1",
-      "instances/:instanceId",
-    );
-  });
+  describe("component", () => {
+    beforeEach(() => {
+      setEndpointStatus("default");
+    });
 
-  it("renders employee dropdown search component", () => {
-    const searchBox = screen.getByRole("searchbox");
-    expect(searchBox).toBeInTheDocument();
-  });
+    const renderDropdown = (
+      overrideProps?: Partial<ComponentProps<typeof EmployeeDropdown>>,
+    ) => {
+      return renderWithProviders(
+        <EmployeeDropdown {...baseProps} {...overrideProps} />,
+        undefined,
+        ROUTES.instances.details.single(1),
+        `/${PATHS.instances.root}/${PATHS.instances.single}`,
+      );
+    };
 
-  describe("employee selection flow", () => {
+    it("renders employee dropdown search component", () => {
+      renderDropdown();
+      expect(screen.getByRole("searchbox")).toBeInTheDocument();
+    });
+
     it("shows matching employees after searching", async () => {
+      renderDropdown();
+
       const searchBox = screen.getByRole("searchbox");
       await userEvent.type(searchBox, "John");
       expect(searchBox).toHaveValue("John");
 
       const employees = await screen.findAllByText("John");
-      const matchinEmployees = mockEmployees.filter((employee) =>
+      const matchingEmployees = mockEmployees.filter((employee) =>
         employee.name.includes("John"),
       );
-      //expected length 2, since John Smith and John Doe should be returned
-      expect(employees).toHaveLength(matchinEmployees.length);
+      expect(employees).toHaveLength(matchingEmployees.length);
     });
 
     it("shows error if no matching employees found", async () => {
+      renderDropdown();
+
       const searchBox = screen.getByRole("searchbox");
       await userEvent.type(searchBox, "checking for error");
       expect(searchBox).toHaveValue("checking for error");
 
-      const errorText = await screen.findByText(/No employees found by/i);
-      expect(errorText).toBeVisible();
+      expect(await screen.findByText(/No employees found by/i)).toBeVisible();
+    });
+
+    it("allows removing selected employee", async () => {
+      const setEmployee = vi.fn();
+      renderDropdown({ employee: mockEmployees[0], setEmployee });
+
+      await userEvent.click(screen.getByRole("button", { name: /remove/i }));
+
+      expect(setEmployee).toHaveBeenCalledWith(null);
+    });
+
+    it("keeps dropdown open and resets search when clear button is used", async () => {
+      const user = userEvent.setup();
+      renderDropdown();
+
+      const searchBox = screen.getByRole("searchbox");
+      await user.type(searchBox, "John");
+      await user.click(
+        screen.getByRole("button", { name: /clear search field/i }),
+      );
+
+      expect(searchBox).toHaveValue("");
+      expect(
+        await screen.findByText(mockEmployees[0]?.name ?? "John Doe"),
+      ).toBeInTheDocument();
+    });
+
+    it("handles selecting an employee from the list", async () => {
+      const user = userEvent.setup();
+      const setEmployee = vi.fn();
+      renderDropdown({ setEmployee });
+
+      await user.type(screen.getByRole("searchbox"), "John");
+      const [firstEmployeeOption] =
+        await screen.findAllByTestId("dropdownElement");
+      assert(firstEmployeeOption);
+      await user.click(firstEmployeeOption);
+
+      expect(setEmployee).toHaveBeenCalledWith(mockEmployees[0]);
+      expect(screen.getByRole("searchbox")).toHaveValue("");
+    });
+
+    it("loads more results when suggestion list is scrolled near bottom", async () => {
+      const user = userEvent.setup();
+      renderDropdown();
+
+      const searchBox = screen.getByRole("searchbox");
+      await user.type(searchBox, "a");
+
+      const list = await screen.findByRole("listbox");
+      Object.defineProperty(list, "scrollHeight", {
+        configurable: true,
+        value: 120,
+      });
+      Object.defineProperty(list, "clientHeight", {
+        configurable: true,
+        value: 80,
+      });
+      Object.defineProperty(list, "scrollTop", {
+        configurable: true,
+        value: 30,
+      });
+
+      list.dispatchEvent(new Event("scroll"));
+
+      await waitFor(async () => {
+        expect((await screen.findAllByTestId("dropdownElement")).length).toBe(
+          2,
+        );
+      });
+    });
+
+    it("shows next-page loading indicator while fetching additional results", async () => {
+      const user = userEvent.setup();
+      setEndpointStatus({
+        status: "default",
+        path: "employees:next-page-loading",
+      });
+      renderDropdown();
+
+      await user.type(screen.getByRole("searchbox"), "a");
+      const list = await screen.findByRole("listbox");
+
+      Object.defineProperty(list, "scrollHeight", {
+        configurable: true,
+        value: 100,
+      });
+      Object.defineProperty(list, "clientHeight", {
+        configurable: true,
+        value: 80,
+      });
+      Object.defineProperty(list, "scrollTop", {
+        configurable: true,
+        value: 30,
+      });
+
+      list.dispatchEvent(new Event("scroll"));
+
+      expect(await screen.findByText("Loading...")).toBeInTheDocument();
+    });
+
+    it("does not fetch next page when there is no next page", async () => {
+      const user = userEvent.setup();
+      renderDropdown();
+
+      await user.type(screen.getByRole("searchbox"), "a");
+      const list = await screen.findByRole("listbox");
+      const initialSuggestionCount = (
+        await screen.findAllByTestId("dropdownElement")
+      ).length;
+
+      Object.defineProperty(list, "scrollHeight", {
+        configurable: true,
+        value: 100,
+      });
+      Object.defineProperty(list, "clientHeight", {
+        configurable: true,
+        value: 80,
+      });
+      Object.defineProperty(list, "scrollTop", {
+        configurable: true,
+        value: 0,
+      });
+
+      list.dispatchEvent(new Event("scroll"));
+
+      await waitFor(async () => {
+        expect((await screen.findAllByTestId("dropdownElement")).length).toBe(
+          initialSuggestionCount,
+        );
+      });
+    });
+
+    it("renders field-level error text", () => {
+      renderDropdown({ error: "Employee is required" });
+      expect(screen.getByText("Employee is required")).toBeInTheDocument();
     });
   });
 });

--- a/src/features/gpg-keys/components/NewGPGKeyForm/NewGPGKeyForm.test.tsx
+++ b/src/features/gpg-keys/components/NewGPGKeyForm/NewGPGKeyForm.test.tsx
@@ -1,5 +1,7 @@
 import { renderWithProviders } from "@/tests/render";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { setEndpointStatus } from "@/tests/controllers/controller";
 import NewGPGKeyForm from "./NewGPGKeyForm";
 
 describe("NewGPGKeyForm", () => {
@@ -12,5 +14,97 @@ describe("NewGPGKeyForm", () => {
       name: /import key/i,
     });
     expect(addGPGKeyButton).toBeInTheDocument();
+  });
+
+  it("shows required validation errors when submitting empty form", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<NewGPGKeyForm />);
+
+    await user.click(screen.getByRole("button", { name: /import key/i }));
+
+    expect(await screen.findAllByText("This field is required")).toHaveLength(
+      2,
+    );
+  });
+
+  it("validates name format", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<NewGPGKeyForm />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Name" }),
+      "Invalid_Name",
+    );
+    await user.type(screen.getByRole("textbox", { name: "Material" }), "ABC");
+    await user.click(screen.getByRole("button", { name: /import key/i }));
+
+    expect(
+      await screen.findByText(
+        "It has to start with an alphanumeric character and only contain lowercase letters, numbers and - or + signs.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("validates duplicate key name", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<NewGPGKeyForm />);
+
+    await user.type(screen.getByRole("textbox", { name: "Name" }), "sign-key");
+    await user.type(screen.getByRole("textbox", { name: "Material" }), "ABC");
+    await user.click(screen.getByRole("button", { name: /import key/i }));
+
+    expect(
+      await screen.findByText("It must be unique within the account."),
+    ).toBeInTheDocument();
+  });
+
+  it("allows unique names when existing keys cannot be loaded", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "empty", path: "gpgKey" });
+
+    renderWithProviders(<NewGPGKeyForm />);
+
+    await user.type(screen.getByRole("textbox", { name: "Name" }), "sign-key");
+    await user.type(screen.getByRole("textbox", { name: "Material" }), "ABC");
+    await user.click(screen.getByRole("button", { name: /import key/i }));
+
+    expect(
+      screen.queryByText("It must be unique within the account."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("submits successfully", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<NewGPGKeyForm />);
+
+    await user.type(screen.getByRole("textbox", { name: "Name" }), "newkey");
+    await user.type(screen.getByRole("textbox", { name: "Material" }), "ABC");
+    await user.click(screen.getByRole("button", { name: /import key/i }));
+
+    expect(
+      screen.queryByText("This field is required"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("It has to start with an alphanumeric character"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows endpoint error", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "error", path: "importGpgKey" });
+
+    renderWithProviders(<NewGPGKeyForm />);
+
+    await user.type(screen.getByRole("textbox", { name: "Name" }), "newkey2");
+    await user.type(screen.getByRole("textbox", { name: "Material" }), "ABC");
+    await user.click(screen.getByRole("button", { name: /import key/i }));
+
+    expect(
+      await screen.findByText('The endpoint status is set to "error".'),
+    ).toBeInTheDocument();
   });
 });

--- a/src/features/kernel/components/KernelOverview/helpers.test.ts
+++ b/src/features/kernel/components/KernelOverview/helpers.test.ts
@@ -1,0 +1,104 @@
+import { DISPLAY_DATE_FORMAT } from "@/constants";
+import moment from "moment";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getLivepatchCoverageDisplayValue,
+  getLivepatchCoverageIcon,
+  getStatusIcon,
+  getStatusTooltipMessage,
+} from "./helpers";
+
+const NOW = new Date("2026-04-02T12:00:00Z");
+const TWO_DAYS = 2;
+const TEN_DAYS = 10;
+
+describe("KernelOverview helpers", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("builds upgrade tooltip with formatted expiry date when valid", () => {
+    const expiry = "2026-04-12T00:00:00Z";
+
+    expect(
+      getStatusTooltipMessage("Kernel upgrade available", expiry),
+    ).toContain(
+      `covered by Livepatch until ${moment(expiry).format(DISPLAY_DATE_FORMAT)}`,
+    );
+  });
+
+  it("omits expiry details for invalid kernel-upgrade dates", () => {
+    expect(
+      getStatusTooltipMessage("Kernel upgrade available", "bad-date"),
+    ).toBe("A new kernel version is available.");
+  });
+
+  it("returns status icons for known and unknown statuses", () => {
+    expect(getStatusIcon("Patched by Livepatch")).toBe(
+      "status-succeeded-small",
+    );
+    expect(getStatusIcon("Fully patched")).toBe("status-succeeded-small");
+    expect(getStatusIcon("Kernel upgrade available")).toBe(
+      "status-succeeded-small",
+    );
+    expect(getStatusIcon("Restart required")).toBe("status-waiting-small");
+    expect(getStatusIcon("End of life")).toBe("status-failed-small");
+    expect(getStatusIcon("Unknown")).toBe("status-failed-small");
+  });
+
+  it("returns tooltip messages for all non-upgrade statuses and unknown states", () => {
+    expect(getStatusTooltipMessage("Fully patched", "")).toBe(
+      "All available kernel security patches have been applied. You have no pending patches.",
+    );
+    expect(getStatusTooltipMessage("Restart required", "")).toBe(
+      "Low and/or medium patches have been installed. You must restart to complete patching.",
+    );
+    expect(getStatusTooltipMessage("End of life", "")).toBe(
+      "The kernel is no longer covered by Livepatch. It is not getting high and critical security patches.",
+    );
+    expect(getStatusTooltipMessage("Livepatch disabled", "")).toBe(
+      "Livepatch is disabled. Kernel patches will not be applied automatically until you enabled Livepatch.",
+    );
+    expect(getStatusTooltipMessage("Unexpected", "")).toBe(
+      "There was an error getting the status.",
+    );
+  });
+
+  it("computes livepatch coverage icons by enablement and expiry window", () => {
+    const soonExpiry = moment(NOW).add(TWO_DAYS, "days").toISOString();
+    const laterExpiry = moment(NOW).add(TEN_DAYS, "days").toISOString();
+    const expired = moment(NOW).subtract(1, "day").toISOString();
+
+    expect(getLivepatchCoverageIcon(true, soonExpiry)).toBe(
+      "status-waiting-small",
+    );
+    expect(getLivepatchCoverageIcon(true, laterExpiry)).toBe(
+      "status-succeeded-small",
+    );
+    expect(getLivepatchCoverageIcon(true, expired)).toBe("status-failed-small");
+    expect(getLivepatchCoverageIcon(false, laterExpiry)).toBe(
+      "status-failed-small",
+    );
+    expect(getLivepatchCoverageIcon(true, "not-a-date")).toBe(
+      "status-failed-small",
+    );
+  });
+
+  it("computes display value for disabled, expired, and active coverage", () => {
+    const laterExpiry = moment(NOW).add(TEN_DAYS, "days").toISOString();
+    const expired = moment(NOW).subtract(1, "day").toISOString();
+
+    expect(getLivepatchCoverageDisplayValue(false, laterExpiry)).toBe(
+      "Livepatch is disabled",
+    );
+    expect(getLivepatchCoverageDisplayValue(true, expired)).toBe("Expired");
+    expect(getLivepatchCoverageDisplayValue(true, laterExpiry)).toBe(
+      `Expires on ${moment(laterExpiry).format(DISPLAY_DATE_FORMAT)}`,
+    );
+  });
+});

--- a/src/features/kernel/components/RestartInstanceForm/RestartInstanceForm.test.tsx
+++ b/src/features/kernel/components/RestartInstanceForm/RestartInstanceForm.test.tsx
@@ -1,32 +1,39 @@
+import { setEndpointStatus } from "@/tests/controllers/controller";
+import { ENDPOINT_STATUS_API_ERROR_MESSAGE } from "@/tests/server/handlers/_constants";
 import { renderWithProviders } from "@/tests/render";
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { PATHS, ROUTES } from "@/libs/routes";
 import RestartInstanceForm from "./RestartInstanceForm";
 
-describe("UpgradeKernelForm", () => {
-  it("renders notification message", () => {
-    renderWithProviders(
-      <RestartInstanceForm showNotification instanceName="test-instance" />,
-    );
+const props: ComponentProps<typeof RestartInstanceForm> = {
+  showNotification: true,
+  instanceName: "test-instance",
+};
+const INSTANCE_ID = 11;
+
+describe("RestartInstanceForm", () => {
+  beforeEach(() => {
+    setEndpointStatus("default");
+  });
+
+  it("renders notification when restart is recommended", () => {
+    renderWithProviders(<RestartInstanceForm {...props} />);
     expect(screen.getByText(/restart recommended/i)).toBeVisible();
   });
 
-  it("renders notification message", () => {
+  it("does not render notification when restart is not recommended", () => {
     renderWithProviders(
-      <RestartInstanceForm
-        showNotification={false}
-        instanceName="test-instance"
-      />,
+      <RestartInstanceForm {...props} showNotification={false} />,
     );
     expect(screen.queryByText(/restart recommended/i)).toBeNull();
   });
 
-  it("radio button functionalities", async () => {
+  it("shows randomization input when enabling random delivery", async () => {
+    const user = userEvent.setup();
     renderWithProviders(
-      <RestartInstanceForm
-        showNotification={false}
-        instanceName="test-instance"
-      />,
+      <RestartInstanceForm {...props} showNotification={false} />,
     );
 
     const instantDeliveryTimeRadioOption = screen.getByLabelText(
@@ -42,7 +49,101 @@ describe("UpgradeKernelForm", () => {
     expect(randomizeDeliveryTrueOption).not.toBeChecked();
     expect(randomizeDeliveryFalseOption).toBeChecked();
 
-    await userEvent.click(randomizeDeliveryTrueOption);
+    await user.click(randomizeDeliveryTrueOption);
     expect(screen.getByText(/time in minutes/i)).toBeVisible();
+  });
+
+  it("shows upgrade and restart action only when kernel id is provided", () => {
+    const { rerender } = renderWithProviders(
+      <RestartInstanceForm {...props} newKernelVersionId={123} />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Upgrade and Restart" }),
+    ).toBeInTheDocument();
+
+    rerender(<RestartInstanceForm {...props} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Upgrade and Restart" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("submits restart and shows a success notification", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <RestartInstanceForm {...props} showNotification={false} />,
+      undefined,
+      ROUTES.instances.details.single(INSTANCE_ID),
+      `/${PATHS.instances.root}/${PATHS.instances.single}`,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Restart" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Restarting instance" });
+    await user.click(within(dialog).getByRole("button", { name: "Restart" }));
+
+    expect(
+      await screen.findByText('You queued "test-instance" to be restarted.'),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "View details" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Start instance Bionic WSL" }),
+    ).toBeInTheDocument();
+  });
+
+  it("submits upgrade and restart and shows a success notification", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <RestartInstanceForm {...props} newKernelVersionId={123} />,
+      undefined,
+      ROUTES.instances.details.single(INSTANCE_ID),
+      `/${PATHS.instances.root}/${PATHS.instances.single}`,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Upgrade and Restart" }),
+    );
+
+    const dialog = screen.getByRole("dialog", {
+      name: "Upgrading kernel and restarting instance",
+    });
+    await user.click(
+      within(dialog).getByRole("button", { name: "Upgrade and Restart" }),
+    );
+
+    expect(
+      await screen.findByText('You queued kernel upgrade for "test-instance"'),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "View details" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Start instance Bionic WSL" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an error notification when restart fails", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus("error");
+
+    renderWithProviders(
+      <RestartInstanceForm {...props} showNotification={false} />,
+      undefined,
+      ROUTES.instances.details.single(INSTANCE_ID),
+      `/${PATHS.instances.root}/${PATHS.instances.single}`,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Restart" }));
+    const dialog = screen.getByRole("dialog", { name: "Restarting instance" });
+    await user.click(within(dialog).getByRole("button", { name: "Restart" }));
+
+    expect(
+      await screen.findByText(ENDPOINT_STATUS_API_ERROR_MESSAGE),
+    ).toBeInTheDocument();
   });
 });

--- a/src/features/mirrors/components/EditPocketForm/EditPocketForm.test.tsx
+++ b/src/features/mirrors/components/EditPocketForm/EditPocketForm.test.tsx
@@ -1,6 +1,8 @@
+import { setEndpointStatus } from "@/tests/controllers/controller";
 import { pockets } from "@/tests/mocks/pockets";
 import { renderWithProviders } from "@/tests/render";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { DEFAULT_SNAPSHOT_URI } from "../../constants";
 import EditPocketForm from "./EditPocketForm";
@@ -22,6 +24,31 @@ const uploadPocketProps: ComponentProps<typeof EditPocketForm> = {
   seriesName: "Focal Fossa",
   pocket: uploadPocket,
 };
+const uploadPocketAllowUnsignedProps: ComponentProps<typeof EditPocketForm> = {
+  distributionName: "Ubuntu",
+  seriesName: "Focal Fossa",
+  pocket: {
+    ...uploadPocket,
+    upload_allow_unsigned: true,
+  },
+};
+
+const uploadPocketWithKnownGpgKeysProps: ComponentProps<typeof EditPocketForm> =
+  {
+    distributionName: "Ubuntu",
+    seriesName: "Focal Fossa",
+    pocket: {
+      ...uploadPocket,
+      upload_gpg_keys: [
+        {
+          fingerprint: "",
+          id: 26,
+          has_secret: false,
+          name: "test-public",
+        },
+      ],
+    },
+  };
 
 const pullPocketWithFilterType = pockets.find(
   (p) => p.mode === "pull" && p.filter_type,
@@ -44,7 +71,16 @@ const pullPocketWithoutFilterTypeProps: ComponentProps<typeof EditPocketForm> =
     pocket: pullPocketWithoutFilterType,
   };
 
+const fillRequiredFields = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole("checkbox", { name: "Main" }));
+  await user.click(screen.getByRole("checkbox", { name: "amd64" }));
+};
+
 describe("EditPocketForm", () => {
+  beforeEach(() => {
+    setEndpointStatus("default");
+  });
+
   it("renders form fields for mirror pocket", () => {
     const { container } = renderWithProviders(
       <EditPocketForm {...mirrorPocketProps} />,
@@ -117,5 +153,163 @@ describe("EditPocketForm", () => {
         name: /save changes/i,
       }),
     ).toBeVisible();
+  });
+
+  it("disables uploader gpg keys when unsigned uploads are allowed", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<EditPocketForm {...uploadPocketProps} />);
+
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: "Allow uploaded packages to be unsigned",
+      }),
+    );
+
+    expect(
+      screen.getByRole("combobox", { name: "Uploader GPG keys" }),
+    ).toHaveAttribute("disabled");
+  });
+
+  it("normalizes filter package input by removing spaces", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<EditPocketForm {...pullPocketWithFilterTypeProps} />);
+
+    const filterInput = screen.getByRole("textbox", {
+      name: "Filter packages",
+    });
+
+    await user.clear(filterInput);
+    await user.type(filterInput, "  foo, bar ,baz ");
+
+    expect(filterInput).toHaveValue("foo,bar,baz");
+  });
+
+  it("updates checkbox groups", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<EditPocketForm {...mirrorPocketProps} />);
+
+    await fillRequiredFields(user);
+
+    expect(screen.getByRole("checkbox", { name: "Main" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "amd64" })).toBeChecked();
+  });
+
+  it("submits upload pocket changes and supports uploader gpg key selection", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<EditPocketForm {...uploadPocketProps} />);
+    await fillRequiredFields(user);
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Uploader GPG keys" }),
+    );
+    await user.click(screen.getByRole("checkbox", { name: "test-public" }));
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+  });
+
+  it("submits upload pocket changes when unsigned uploads are enabled", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<EditPocketForm {...uploadPocketProps} />);
+    await fillRequiredFields(user);
+
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: "Allow uploaded packages to be unsigned",
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+  });
+
+  it("submits upload pocket with original allow-unsigned pocket data", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<EditPocketForm {...uploadPocketAllowUnsignedProps} />);
+    await fillRequiredFields(user);
+
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: "Allow uploaded packages to be unsigned",
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+  });
+
+  it("submits upload pocket without uploader gpg key changes", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <EditPocketForm {...uploadPocketWithKnownGpgKeysProps} />,
+    );
+    await fillRequiredFields(user);
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+  });
+
+  it("submits pull pocket changes with updated filter package list", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<EditPocketForm {...pullPocketWithFilterTypeProps} />);
+    await fillRequiredFields(user);
+
+    const filterInput = screen.getByRole("textbox", {
+      name: "Filter packages",
+    });
+    await user.clear(filterInput);
+    await user.type(filterInput, "alpha,beta");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+  });
+
+  it("submits pull pocket changes without modifying filters", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<EditPocketForm {...pullPocketWithFilterTypeProps} />);
+    await fillRequiredFields(user);
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+  });
+
+  it("submits pull pocket without filter type", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <EditPocketForm {...pullPocketWithoutFilterTypeProps} />,
+    );
+    await fillRequiredFields(user);
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+  });
+
+  it("submits mirror pocket changes", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<EditPocketForm {...mirrorPocketProps} />);
+    await fillRequiredFields(user);
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+  });
+
+  it("shows notification when edit pocket submit fails", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "error", path: "EditPocket" });
+
+    renderWithProviders(<EditPocketForm {...mirrorPocketProps} />);
+    await fillRequiredFields(user);
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(
+      await screen.findByText('The endpoint status is set to "error".'),
+    ).toBeInTheDocument();
   });
 });

--- a/src/features/mirrors/components/EditPocketForm/helpers.test.ts
+++ b/src/features/mirrors/components/EditPocketForm/helpers.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { pockets } from "@/tests/mocks/pockets";
+import type { Pocket } from "../../types";
+import {
+  getEditPocketParams,
+  getInitialValues,
+  getValidationSchema,
+} from "./helpers";
+import { INITIAL_VALUES } from "./constants";
+
+const mirrorPocket = pockets.find((pocket) => pocket.mode === "mirror");
+const uploadPocket = pockets.find((pocket) => pocket.mode === "upload");
+const pullPocket = pockets.find((pocket) => pocket.mode === "pull");
+
+assert(mirrorPocket);
+assert(uploadPocket);
+assert(pullPocket);
+
+describe("EditPocketForm helpers", () => {
+  it("enforces single component for mirror suite directories", async () => {
+    const schema = getValidationSchema("mirror");
+
+    await expect(
+      schema.validate({
+        ...INITIAL_VALUES,
+        name: "Pocket",
+        distribution: "Distribution",
+        series: "Series",
+        mirror_suite: "focal/",
+        components: ["main", "restricted"],
+        architectures: ["amd64"],
+      }),
+    ).rejects.toThrowError(/single component must be passed/i);
+
+    await expect(
+      schema.validate({
+        ...INITIAL_VALUES,
+        name: "Pocket",
+        distribution: "Distribution",
+        series: "Series",
+        mirror_suite: "focal/",
+        components: ["main"],
+        architectures: ["amd64"],
+      }),
+    ).resolves.toBeTruthy();
+  });
+
+  it("allows multiple components for non-mirror modes", async () => {
+    const schema = getValidationSchema("pull");
+
+    await expect(
+      schema.validate({
+        ...INITIAL_VALUES,
+        name: "Pocket",
+        distribution: "Distribution",
+        series: "Series",
+        components: ["main", "restricted"],
+        architectures: ["amd64"],
+      }),
+    ).resolves.toBeTruthy();
+  });
+
+  it("allows multiple components in mirror mode when suite is not a directory", async () => {
+    const schema = getValidationSchema("mirror");
+
+    await expect(
+      schema.validate({
+        ...INITIAL_VALUES,
+        name: "Pocket",
+        distribution: "Distribution",
+        series: "Series",
+        mirror_suite: "focal-updates",
+        components: ["main", "restricted"],
+        architectures: ["amd64"],
+      }),
+    ).resolves.toBeTruthy();
+  });
+
+  it("builds mode-specific initial values", () => {
+    const mirrorValues = getInitialValues("Dist", "Series", mirrorPocket);
+    const uploadValues = getInitialValues("Dist", "Series", uploadPocket);
+    const pullValues = getInitialValues("Dist", "Series", pullPocket);
+
+    expect(mirrorValues.mirror_uri).toBe(mirrorPocket.mirror_uri);
+    expect(mirrorValues.mirror_suite).toBe(mirrorPocket.mirror_suite);
+    expect(uploadValues.upload_allow_unsigned).toBe(
+      uploadPocket.upload_allow_unsigned,
+    );
+    expect(uploadValues.upload_gpg_keys).toEqual(
+      uploadPocket.upload_gpg_keys.map((key) => key.name),
+    );
+    expect(pullValues.filters).toEqual(pullPocket.filters);
+  });
+
+  it("falls back to empty key names when optional key objects are missing", () => {
+    const pocketWithoutKeys = {
+      ...mirrorPocket,
+      gpg_key: undefined,
+      mirror_gpg_key: undefined,
+    } as unknown as Pocket;
+
+    const values = getInitialValues("Dist", "Series", pocketWithoutKeys);
+
+    expect(values.gpg_key).toBe("");
+    expect(values.mirror_gpg_key).toBe("");
+  });
+
+  it("returns mode-specific edit params", () => {
+    const mirrorValues = getInitialValues("Dist", "Series", mirrorPocket);
+    const uploadValues = getInitialValues("Dist", "Series", uploadPocket);
+    const pullValues = getInitialValues("Dist", "Series", pullPocket);
+
+    const mirrorParams = getEditPocketParams(mirrorValues, "mirror");
+    const uploadParams = getEditPocketParams(uploadValues, "upload");
+    const pullParams = getEditPocketParams(pullValues, "pull");
+
+    expect(mirrorParams).toHaveProperty("mirror_uri");
+    expect(mirrorParams).toHaveProperty("mirror_suite");
+    expect(uploadParams).toHaveProperty("upload_allow_unsigned");
+    expect(pullParams).not.toHaveProperty("mirror_uri");
+    expect(pullParams).not.toHaveProperty("upload_allow_unsigned");
+  });
+
+  it("throws for invalid pocket mode when building edit params", () => {
+    expect(() =>
+      getEditPocketParams(
+        getInitialValues("Dist", "Series", pullPocket),
+        "invalid" as Pocket["mode"],
+      ),
+    ).toThrowError(/provided: invalid for pocket mode/i);
+  });
+});

--- a/src/features/mirrors/components/EditPocketForm/helpers.ts
+++ b/src/features/mirrors/components/EditPocketForm/helpers.ts
@@ -28,7 +28,7 @@ export const getValidationSchema = (
         test: (value, context) => {
           const { mirror_suite } = context.parent;
 
-          if ("mirror" === mode && mirror_suite.endsWith("/")) {
+          if ("mirror" === mode && mirror_suite?.endsWith("/")) {
             return MIN_SELECTION_COUNT === value.length;
           }
 

--- a/src/features/mirrors/components/PackageList/PackageList.test.tsx
+++ b/src/features/mirrors/components/PackageList/PackageList.test.tsx
@@ -1,8 +1,11 @@
 import { expectLoadingState } from "@/tests/helpers";
+import { setEndpointStatus } from "@/tests/controllers/controller";
 import { listPockets, pockets } from "@/tests/mocks/pockets";
 import { renderWithProviders } from "@/tests/render";
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
+import { waitFor } from "@testing-library/react";
 import { describe, expect } from "vitest";
 import PackageList from "./PackageList";
 
@@ -29,8 +32,11 @@ const pullPocketProps: ComponentProps<typeof PackageList> = {
   seriesName: "Focal Fossa",
   pocket: pullPocket,
 };
-
 describe("PackageList", () => {
+  beforeEach(() => {
+    setEndpointStatus("default");
+  });
+
   it("renders common buttons", () => {
     renderWithProviders(<PackageList {...mirrorPocketProps} />);
     expect(screen.getByRole("button", { name: /edit/i })).toBeVisible();
@@ -74,5 +80,230 @@ describe("PackageList", () => {
 
     const rowCheckboxes = screen.getAllByRole("checkbox").length - 1;
     expect(rowCheckboxes).toEqual(listPockets.length);
+  });
+
+  it("does not show sync or search controls for upload pocket", async () => {
+    renderWithProviders(<PackageList {...uploadPocketProps} />);
+
+    await expectLoadingState();
+
+    expect(
+      screen.queryByRole("button", { name: /^sync$/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^pull$/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("searchbox", { name: /package search/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders empty state when no packages are returned", async () => {
+    setEndpointStatus("empty");
+
+    renderWithProviders(<PackageList {...mirrorPocketProps} />);
+
+    await expectLoadingState();
+
+    expect(screen.getByText("No packages found")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("searchbox", { name: /package search/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens the edit side panel from actions", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<PackageList {...mirrorPocketProps} />);
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    expect(
+      await screen.findByRole("heading", { name: /edit .* pocket/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("removes pocket successfully", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<PackageList {...mirrorPocketProps} />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: `Remove ${mirrorPocketProps.pocket.name} pocket of ${mirrorPocketProps.distributionName}/${mirrorPocketProps.seriesName}`,
+      }),
+    );
+    const dialog = screen.getByRole("dialog", { name: "Deleting pocket" });
+    await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Deleting pocket" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("submits mirror sync confirmation flow", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<PackageList {...mirrorPocketProps} />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: new RegExp(
+          `Synchronize ${mirrorPocketProps.pocket.name} pocket of ${mirrorPocketProps.distributionName}/${mirrorPocketProps.seriesName}`,
+          "i",
+        ),
+      }),
+    );
+
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+  });
+
+  it("submits pull sync flow", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<PackageList {...pullPocketProps} />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: new RegExp(
+          `Pull packages to ${pullPocketProps.pocket.name} pocket of ${pullPocketProps.distributionName}/${pullPocketProps.seriesName}`,
+          "i",
+        ),
+      }),
+    );
+
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+  });
+
+  it("renders pull package diffs with updates and deletions", async () => {
+    setEndpointStatus({ status: "default", path: "DiffPullPocketUpdate" });
+    renderWithProviders(<PackageList {...pullPocketProps} />);
+
+    await expectLoadingState();
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll(".p-icon--warning").length,
+      ).toBeGreaterThan(0);
+    });
+  });
+
+  it("renders pull package list when diffs contain only additions", async () => {
+    setEndpointStatus({ status: "default", path: "DiffPullPocketAddOnly" });
+
+    renderWithProviders(<PackageList {...pullPocketProps} />);
+    await expectLoadingState();
+
+    expect(await screen.findByText("pocket1")).toBeInTheDocument();
+    expect(document.querySelector(".p-icon--warning")).not.toBeInTheDocument();
+  });
+
+  it("submits upload remove-packages flow", async () => {
+    const user = userEvent.setup();
+    const [firstPackage] = listPockets;
+    assert(firstPackage);
+    renderWithProviders(<PackageList {...uploadPocketProps} />);
+
+    await expectLoadingState();
+    await user.click(screen.getByLabelText(firstPackage.name));
+    await user.click(
+      screen.getByRole("button", { name: /remove selected packages from/i }),
+    );
+    const dialog = screen.getByRole("dialog", {
+      name: /deleting packages from pocket/i,
+    });
+    await user.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+  });
+
+  it("searches and clears package search", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<PackageList {...mirrorPocketProps} />);
+
+    await expectLoadingState();
+
+    const searchInput = screen.getByRole("searchbox", {
+      name: /package search/i,
+    });
+    await user.type(searchInput, "pocket1{enter}");
+    expect(searchInput).toHaveValue("pocket1");
+
+    await user.click(
+      screen.getByRole("button", { name: /clear search field/i }),
+    );
+    expect(searchInput).toHaveValue("");
+  });
+
+  it("resets selected packages when paginating upload list", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "default", path: "ListPocketMany" });
+    renderWithProviders(<PackageList {...uploadPocketProps} />);
+
+    await screen.findByRole("checkbox", { name: "Toggle all" });
+    const [, firstRowCheckbox] = screen.getAllByRole("checkbox");
+    assert(firstRowCheckbox);
+    await user.click(firstRowCheckbox);
+    await user.click(screen.getByRole("button", { name: /next page/i }));
+    await user.click(screen.getByRole("button", { name: /previous page/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /remove selected packages from/i }),
+      ).toHaveAttribute("aria-disabled", "true");
+    });
+  });
+
+  it("changes page size via pagination select", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "default", path: "ListPocketMany" });
+    renderWithProviders(<PackageList {...uploadPocketProps} />);
+
+    await screen.findByRole("combobox", { name: "Instances per page" });
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Instances per page" }),
+      "50",
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /next page/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows error notification when removing pocket fails", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "error", path: "RemovePocket" });
+    renderWithProviders(<PackageList {...mirrorPocketProps} />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: `Remove ${mirrorPocketProps.pocket.name} pocket of ${mirrorPocketProps.distributionName}/${mirrorPocketProps.seriesName}`,
+      }),
+    );
+    const dialog = screen.getByRole("dialog", { name: "Deleting pocket" });
+    await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    expect(
+      await screen.findByText('The endpoint status is set to "error".'),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error notification when removing packages fails", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "error", path: "RemovePackagesFromPocket" });
+    renderWithProviders(<PackageList {...uploadPocketProps} />);
+
+    const [firstPocket] = listPockets;
+    assert(firstPocket);
+    await screen.findByRole("checkbox", { name: firstPocket.name });
+    await user.click(screen.getByLabelText(firstPocket.name));
+    await user.click(
+      screen.getByRole("button", { name: /remove selected packages from/i }),
+    );
+    const dialog = screen.getByRole("dialog", {
+      name: /deleting packages from pocket/i,
+    });
+    await user.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+
+    expect(
+      await screen.findByText('The endpoint status is set to "error".'),
+    ).toBeInTheDocument();
   });
 });

--- a/src/features/mirrors/components/PackageList/PackageList.tsx
+++ b/src/features/mirrors/components/PackageList/PackageList.tsx
@@ -74,19 +74,20 @@ const PackageList: FC<PackageListProps> = ({
     pullPackagesToPocketQuery;
 
   const handleSync = (): void => {
-    if ("mirror" === pocket.mode) {
-      syncMirrorPocket({
-        name: pocket.name,
-        series: seriesName,
-        distribution: distributionName,
-      });
-    } else if ("pull" === pocket.mode) {
+    if ("pull" === pocket.mode) {
       pullPackagesToPocket({
         name: pocket.name,
         series: seriesName,
         distribution: distributionName,
       });
+      return;
     }
+
+    syncMirrorPocket({
+      name: pocket.name,
+      series: seriesName,
+      distribution: distributionName,
+    });
   };
 
   const handleEditPocket = (): void => {
@@ -289,6 +290,8 @@ const PackageList: FC<PackageListProps> = ({
           size: 6,
           medium: 3,
         };
+  const isSyncButtonDisabled =
+    isSynchronizingMirrorPocket || isPullingPackagesToPocket;
 
   return (
     <>
@@ -306,9 +309,7 @@ const PackageList: FC<PackageListProps> = ({
                   className="p-segmented-control__button"
                   type="button"
                   onClick={handleSync}
-                  disabled={
-                    isSynchronizingMirrorPocket && isPullingPackagesToPocket
-                  }
+                  disabled={isSyncButtonDisabled}
                   aria-label={
                     "mirror" === pocket.mode
                       ? `Synchronize ${pocket.name} pocket of ${distributionName}/${seriesName}`

--- a/src/features/overview/components/AlertCard/AlertCard.test.tsx
+++ b/src/features/overview/components/AlertCard/AlertCard.test.tsx
@@ -1,10 +1,12 @@
 import type { Status } from "@/features/instances";
 import { ALERT_STATUSES } from "@/features/instances";
 import { setEndpointStatus } from "@/tests/controllers/controller";
-import { expectErrorNotification, expectLoadingState } from "@/tests/helpers";
+import { expectErrorNotification } from "@/tests/helpers";
 import { renderWithProviders } from "@/tests/render";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect } from "vitest";
+import { ROUTES } from "@/libs/routes";
 import AlertCard from "./AlertCard";
 
 const alert =
@@ -34,7 +36,64 @@ describe("AlertCard", () => {
     const alertLabel = screen.getByText(props.alternateLabel);
     expect(alertLabel).toBeInTheDocument();
 
-    await expectLoadingState();
+    const errorText = await screen.findByText("Error loading data.");
+    expect(errorText).toBeInTheDocument();
     await expectErrorNotification();
+  });
+
+  it("uses label fallback and icon fallback when alternateLabel and gray icon are missing", () => {
+    const fallbackAlert = ALERT_STATUSES.PackageUpgradesAlert;
+
+    renderWithProviders(
+      <AlertCard
+        alertType={fallbackAlert.alertType}
+        alternateLabel={undefined}
+        filterValue={fallbackAlert.filterValue}
+        icon={fallbackAlert.icon}
+        label={fallbackAlert.label}
+        query={fallbackAlert.query}
+      />,
+    );
+
+    expect(screen.getByText(fallbackAlert.label)).toBeInTheDocument();
+  });
+
+  it("renders a link to instances route for non-pending alerts", async () => {
+    renderWithProviders(<AlertCard {...props} />);
+
+    const link = await screen.findByRole("link", { name: /instance/i });
+    expect(link).toHaveAttribute(
+      "href",
+      ROUTES.instances.root({ status: props.filterValue }),
+    );
+  });
+
+  it("opens pending instances review in side panel", async () => {
+    const user = userEvent.setup();
+    const pendingAlert = ALERT_STATUSES.PendingComputersAlert;
+
+    renderWithProviders(<AlertCard {...pendingAlert} />);
+
+    const reviewButton = await screen.findByRole("button", {
+      name: /instance/i,
+    });
+    await user.click(reviewButton);
+
+    expect(
+      await screen.findByRole("heading", { name: "Review Pending Instances" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders zero-count state for pending alerts with no pending instances", async () => {
+    setEndpointStatus({ status: "empty", path: "GetPendingComputers" });
+    const pendingAlert = ALERT_STATUSES.PendingComputersAlert;
+
+    renderWithProviders(<AlertCard {...pendingAlert} />);
+
+    expect(await screen.findByText("0")).toBeInTheDocument();
+    expect(screen.getByText("instances")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /instance/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/features/package-profiles/components/PackageProfileAddSidePanel/PackageProfileAddSidePanel.test.tsx
+++ b/src/features/package-profiles/components/PackageProfileAddSidePanel/PackageProfileAddSidePanel.test.tsx
@@ -7,6 +7,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect } from "vitest";
 import PackageProfileAddSidePanel from "./PackageProfileAddSidePanel";
+import { NO_DATA_TEXT } from "@/components/layout/NoData";
 
 describe("PackageProfileAddSidePanel", () => {
   const user = userEvent.setup();
@@ -26,7 +27,7 @@ describe("PackageProfileAddSidePanel", () => {
     );
     await user.type(
       screen.getByRole("textbox", { name: "Description" }),
-      "---",
+      NO_DATA_TEXT,
     );
     await user.selectOptions(
       screen.getByRole("combobox", { name: "Package constraints" }),

--- a/src/features/processes/components/ProcessesHeader/ProcessesHeader.test.tsx
+++ b/src/features/processes/components/ProcessesHeader/ProcessesHeader.test.tsx
@@ -1,20 +1,28 @@
+import { setEndpointStatus } from "@/tests/controllers/controller";
+import { expectErrorNotification } from "@/tests/helpers";
 import { renderWithProviders } from "@/tests/render";
-import ProcessesHeader from "./ProcessesHeader";
-import { vi } from "vitest";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { PATHS, ROUTES } from "@/libs/routes";
+import ProcessesHeader from "./ProcessesHeader";
 
 const props = {
   selectedPids: [],
   handleClearSelection: vi.fn(),
 };
 
+const SELECTED_PID = 123;
+const INSTANCE_ID = 11;
+
 describe("ProcessesHeader", () => {
   beforeEach(() => {
-    renderWithProviders(<ProcessesHeader {...props} />);
+    setEndpointStatus("default");
   });
 
   it("should render ProcessesHeader correctly", () => {
+    renderWithProviders(<ProcessesHeader {...props} />);
+
     const buttons = ["End process", "Kill process"];
     expect(screen.getByRole("searchbox")).toBeInTheDocument();
     buttons.forEach((button) => {
@@ -23,17 +31,133 @@ describe("ProcessesHeader", () => {
   });
 
   it("should write in search", async () => {
+    renderWithProviders(<ProcessesHeader {...props} />);
+
     const searchBox = screen.getByRole("searchbox");
     await userEvent.type(searchBox, "test{enter}");
     expect(searchBox).toHaveValue("test");
   });
 
   it("should clear search box", async () => {
+    renderWithProviders(<ProcessesHeader {...props} />);
+
     const searchBox = screen.getByRole("searchbox");
     await userEvent.type(searchBox, "test");
     await userEvent.click(
       screen.getByRole("button", { name: /Clear search field/i }),
     );
     expect(searchBox).toHaveValue("");
+  });
+
+  it("disables process action buttons when no pids are selected", () => {
+    renderWithProviders(
+      <ProcessesHeader selectedPids={[]} handleClearSelection={vi.fn()} />,
+    );
+
+    expect(screen.getByRole("button", { name: "End process" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+    expect(
+      screen.getByRole("button", { name: "Kill process" }),
+    ).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("enables process action buttons when pids are selected", () => {
+    renderWithProviders(
+      <ProcessesHeader
+        selectedPids={[SELECTED_PID]}
+        handleClearSelection={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "End process" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Kill process" })).toBeEnabled();
+  });
+
+  it("ends selected processes and clears selection", async () => {
+    const user = userEvent.setup();
+    const handleClearSelection = vi.fn();
+
+    renderWithProviders(
+      <ProcessesHeader
+        selectedPids={[SELECTED_PID]}
+        handleClearSelection={handleClearSelection}
+      />,
+      undefined,
+      ROUTES.instances.details.single(INSTANCE_ID),
+      `/${PATHS.instances.root}/${PATHS.instances.single}`,
+    );
+
+    await user.click(screen.getByRole("button", { name: "End process" }));
+
+    expect(
+      await screen.findByText(/Process successfully ended\./i),
+    ).toBeInTheDocument();
+    expect(handleClearSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("kills selected processes and clears selection", async () => {
+    const user = userEvent.setup();
+    const handleClearSelection = vi.fn();
+
+    renderWithProviders(
+      <ProcessesHeader
+        selectedPids={[1, 2]}
+        handleClearSelection={handleClearSelection}
+      />,
+      undefined,
+      ROUTES.instances.details.single(INSTANCE_ID),
+      `/${PATHS.instances.root}/${PATHS.instances.single}`,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Kill process" }));
+
+    expect(
+      await screen.findByText(/Processes successfully killed\./i),
+    ).toBeInTheDocument();
+    expect(handleClearSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows error notification when ending process fails", async () => {
+    const user = userEvent.setup();
+    const handleClearSelection = vi.fn();
+
+    renderWithProviders(
+      <ProcessesHeader
+        selectedPids={[SELECTED_PID]}
+        handleClearSelection={handleClearSelection}
+      />,
+      undefined,
+      ROUTES.instances.details.single(INSTANCE_ID),
+      `/${PATHS.instances.root}/${PATHS.instances.single}`,
+    );
+
+    setEndpointStatus("error");
+    await user.click(screen.getByRole("button", { name: "End process" }));
+
+    await expectErrorNotification();
+    expect(handleClearSelection).not.toHaveBeenCalled();
+  });
+
+  it("shows error notification when killing process fails", async () => {
+    const user = userEvent.setup();
+    const handleClearSelection = vi.fn();
+
+    renderWithProviders(
+      <ProcessesHeader
+        selectedPids={[SELECTED_PID]}
+        handleClearSelection={handleClearSelection}
+      />,
+      undefined,
+      ROUTES.instances.details.single(INSTANCE_ID),
+      `/${PATHS.instances.root}/${PATHS.instances.single}`,
+    );
+
+    setEndpointStatus("error");
+    await user.click(screen.getByRole("button", { name: "Kill process" }));
+
+    await expectErrorNotification();
+    expect(handleClearSelection).not.toHaveBeenCalled();
   });
 });

--- a/src/features/scripts/components/AttachmentFile/AttachmentFile.test.tsx
+++ b/src/features/scripts/components/AttachmentFile/AttachmentFile.test.tsx
@@ -35,6 +35,7 @@ const propsWithInitialAttachmentDelete: ComponentProps<typeof AttachmentFile> =
 
 describe("AttachmentFile", () => {
   afterEach(() => {
+    vi.clearAllMocks();
     vi.restoreAllMocks();
   });
 

--- a/src/features/scripts/components/AttachmentFile/AttachmentFile.test.tsx
+++ b/src/features/scripts/components/AttachmentFile/AttachmentFile.test.tsx
@@ -1,9 +1,8 @@
-import { setEndpointStatus } from "@/tests/controllers/controller";
 import { renderWithProviders } from "@/tests/render";
-import { screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
-import { beforeEach, describe, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import AttachmentFile from "./AttachmentFile";
 
 const createObjectURLMock = vi.fn((_object: Blob | MediaSource) => "blob:test");
@@ -35,9 +34,8 @@ const propsWithInitialAttachmentDelete: ComponentProps<typeof AttachmentFile> =
   };
 
 describe("AttachmentFile", () => {
-  beforeEach(() => {
-    setEndpointStatus("default");
-    vi.clearAllMocks();
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("should display attachment file with script id prop", async () => {
@@ -74,32 +72,75 @@ describe("AttachmentFile", () => {
     expect(deleteButton).toBeInTheDocument();
   });
 
-  it("downloads blob attachments and revokes object URL", async () => {
-    const clickSpy = vi
-      .spyOn(HTMLAnchorElement.prototype, "click")
-      .mockImplementation(() => undefined);
+  it("calls delete callback when remove button is clicked", async () => {
     const user = userEvent.setup();
 
+    renderWithProviders(
+      <AttachmentFile {...propsWithInitialAttachmentDelete} />,
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: `Remove ${propsWithInitialAttachmentDelete.filename} attachment`,
+      }),
+    );
+
+    expect(
+      propsWithInitialAttachmentDelete.onInitialAttachmentDelete,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("downloads attachment file when download button is clicked", async () => {
+    const user = userEvent.setup();
+    const anchorClickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+    const createObjectUrlSpy = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:attachment");
+    const revokeObjectUrlSpy = vi.spyOn(URL, "revokeObjectURL");
+
     renderWithProviders(<AttachmentFile {...propsWithScriptId} />);
+
     await user.click(
       screen.getByRole("button", {
         name: `Download ${propsWithScriptId.filename}`,
       }),
     );
 
-    await waitFor(() => {
-      expect(createObjectURLMock).toHaveBeenCalledTimes(1);
-      expect(clickSpy).toHaveBeenCalledTimes(1);
-      expect(revokeObjectURLMock).toHaveBeenCalledWith("blob:test");
-    });
+    expect(createObjectUrlSpy).toHaveBeenCalledTimes(1);
 
-    const blobToDownload = createObjectURLMock.mock.calls[0]?.[0];
-    expect(blobToDownload).toBeInstanceOf(Blob);
-    if (!(blobToDownload instanceof Blob)) {
-      throw new Error("Expected downloaded data to be a Blob.");
-    }
-    expect(blobToDownload.type).toContain("text/plain");
+    const [downloadedAttachmentBlob] = createObjectUrlSpy.mock.calls[0] ?? [];
+    expect(downloadedAttachmentBlob).toBeInstanceOf(Blob);
+    expect(await (downloadedAttachmentBlob as Blob).text()).toContain(
+      "attachment",
+    );
 
-    clickSpy.mockRestore();
+    expect(anchorClickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectUrlSpy).toHaveBeenCalledWith("blob:attachment");
+  });
+
+  it("does not try to download when attachment data is missing", async () => {
+    const user = userEvent.setup();
+    const createObjectUrlSpy = vi.spyOn(URL, "createObjectURL");
+    const anchorClickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+    const missingDataProps: ComponentProps<typeof AttachmentFile> = {
+      attachmentId: 999,
+      filename: "missing.txt",
+      scriptId: 999,
+    };
+
+    renderWithProviders(<AttachmentFile {...missingDataProps} />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: `Download ${missingDataProps.filename}`,
+      }),
+    );
+
+    expect(createObjectUrlSpy).not.toHaveBeenCalled();
+    expect(anchorClickSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/features/scripts/components/AttachmentFile/AttachmentFile.tsx
+++ b/src/features/scripts/components/AttachmentFile/AttachmentFile.tsx
@@ -30,8 +30,8 @@ const AttachmentFile: FC<AttachmentFileProps> = ({
   const handleDownload = async () => {
     try {
       const { data } = await refetch();
-      if (!data) {
-        throw new Error("Could not download attachment.");
+      if (!data || data.data === null || data.data === undefined) {
+        return;
       }
 
       const url = URL.createObjectURL(data.data);

--- a/src/features/scripts/components/CreateScriptForm/CreateScriptForm.test.tsx
+++ b/src/features/scripts/components/CreateScriptForm/CreateScriptForm.test.tsx
@@ -1,9 +1,15 @@
+import { setEndpointStatus } from "@/tests/controllers/controller";
 import { renderWithProviders } from "@/tests/render";
-import { screen } from "@testing-library/react";
-import { describe, it } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, it, vi } from "vitest";
 import CreateScriptForm from "./CreateScriptForm";
 
 describe("CreateScriptForm", () => {
+  beforeEach(() => {
+    setEndpointStatus("default");
+  });
+
   it("should display add script form", async () => {
     renderWithProviders(<CreateScriptForm />);
 
@@ -16,5 +22,168 @@ describe("CreateScriptForm", () => {
     expect(screen.getByText("Access group")).toBeInTheDocument();
     expect(screen.getByText(/list of attachments/i)).toBeInTheDocument();
     expect(screen.getByText(/add script/i)).toBeInTheDocument();
+  });
+
+  it("populates title and code from an uploaded file", async () => {
+    const user = userEvent.setup();
+    const file = new File(["echo hello"], "bootstrap.sh", {
+      type: "text/x-shellscript",
+    });
+
+    renderWithProviders(<CreateScriptForm />);
+
+    await user.upload(screen.getByTestId("create-script-upload-input"), file);
+
+    expect(screen.getByRole("textbox", { name: "Title" })).toHaveValue(
+      "bootstrap",
+    );
+    expect(screen.getByTestId("mock-monaco")).toHaveValue("echo hello");
+  });
+
+  it("keeps entered title when uploading a file", async () => {
+    const user = userEvent.setup();
+    const file = new File(["echo from file"], "new-title.sh", {
+      type: "text/x-shellscript",
+    });
+
+    renderWithProviders(<CreateScriptForm />);
+
+    const titleInput = screen.getByRole("textbox", { name: "Title" });
+    await user.type(titleInput, "custom title");
+
+    await user.upload(screen.getByTestId("create-script-upload-input"), file);
+
+    expect(titleInput).toHaveValue("custom title");
+    expect(screen.getByTestId("mock-monaco")).toHaveValue("echo from file");
+  });
+
+  it("shows required field validation on empty submit", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<CreateScriptForm />);
+
+    await user.click(screen.getByRole("button", { name: "Add script" }));
+
+    expect(await screen.findAllByText("This field is required")).toHaveLength(
+      2,
+    );
+  });
+
+  it("uploads attachments in form inputs", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<CreateScriptForm />);
+
+    await user.upload(
+      screen.getByLabelText("first attachment"),
+      new File(["print('hello')"], "first.py", { type: "text/plain" }),
+    );
+
+    expect(screen.getByLabelText("first attachment")).toHaveValue(
+      "C:\\fakepath\\first.py",
+    );
+  });
+
+  it("submits script with attachments", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<CreateScriptForm />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Title" }),
+      "My script",
+    );
+    await user.type(screen.getByTestId("mock-monaco"), "echo run");
+    await user.upload(
+      screen.getByLabelText("first attachment"),
+      new File(["attachment"], "notes.txt", { type: "text/plain" }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add script" }));
+
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+  });
+
+  it("submits script without attachments", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<CreateScriptForm />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Title" }),
+      "My script",
+    );
+    await user.type(screen.getByTestId("mock-monaco"), "echo run");
+    await user.click(screen.getByRole("button", { name: "Add script" }));
+
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+  });
+
+  it("shows error notification when create script fails", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "error", path: "CreateScript" });
+    renderWithProviders(<CreateScriptForm />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Title" }),
+      "My script",
+    );
+    await user.type(screen.getByTestId("mock-monaco"), "echo run");
+    await user.click(screen.getByRole("button", { name: "Add script" }));
+
+    expect(
+      await screen.findByText('The endpoint status is set to "error".'),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error notification when create script attachment fails", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "error", path: "CreateScriptAttachment" });
+    renderWithProviders(<CreateScriptForm />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Title" }),
+      "My script",
+    );
+    await user.type(screen.getByTestId("mock-monaco"), "echo run");
+    await user.upload(
+      screen.getByLabelText("first attachment"),
+      new File(["attachment"], "notes.txt", { type: "text/plain" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Add script" }));
+
+    expect(
+      await screen.findByText('The endpoint status is set to "error".'),
+    ).toBeInTheDocument();
+  });
+
+  it("ignores empty file upload input", async () => {
+    renderWithProviders(<CreateScriptForm />);
+
+    fireEvent.change(screen.getByTestId("create-script-upload-input"), {
+      target: { files: null },
+    });
+
+    expect(screen.getByRole("textbox", { name: "Title" })).toHaveValue("");
+  });
+
+  it("handles attachment input with no file selected", () => {
+    renderWithProviders(<CreateScriptForm />);
+
+    fireEvent.change(screen.getByLabelText("first attachment"), {
+      target: { files: [] },
+    });
+
+    expect(screen.getByLabelText("first attachment")).toHaveValue("");
+  });
+
+  it("opens hidden file input from populate button", async () => {
+    const user = userEvent.setup();
+    const clickSpy = vi.spyOn(HTMLInputElement.prototype, "click");
+    renderWithProviders(<CreateScriptForm />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Populate from file" }),
+    );
+
+    expect(clickSpy).toHaveBeenCalled();
+    clickSpy.mockRestore();
   });
 });

--- a/src/features/scripts/components/CreateScriptForm/CreateScriptForm.tsx
+++ b/src/features/scripts/components/CreateScriptForm/CreateScriptForm.tsx
@@ -108,6 +108,7 @@ const CreateScript: FC = () => {
         ref={inputRef}
         className="u-hide"
         type="file"
+        data-testid="create-script-upload-input"
         onChange={handleInputChange}
       />
 
@@ -163,12 +164,6 @@ const CreateScript: FC = () => {
             e.target.files?.[0] ?? null,
           )
         }
-        onInitialAttachmentDelete={(attachment: string) => {
-          formik.setFieldValue("attachmentsToRemove", [
-            ...formik.values.attachmentsToRemove,
-            attachment,
-          ]);
-        }}
       />
 
       <SidePanelFormButtons

--- a/src/features/scripts/components/EditScriptForm/EditScriptForm.test.tsx
+++ b/src/features/scripts/components/EditScriptForm/EditScriptForm.test.tsx
@@ -1,12 +1,17 @@
+import { setEndpointStatus } from "@/tests/controllers/controller";
 import { scripts } from "@/tests/mocks/script";
+import { scriptProfiles } from "@/tests/mocks/scriptProfiles";
 import { renderWithProviders } from "@/tests/render";
-import { screen, within } from "@testing-library/react";
+import { fireEvent, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { describe, it } from "vitest";
 import EditScriptForm from "./EditScriptForm";
+import { NO_DATA_TEXT } from "@/components/layout/NoData";
+import { ROUTES } from "@/libs/routes";
 
 const [script] = scripts;
+const ASSOCIATED_PROFILE_ID = 12;
 
 const props: ComponentProps<typeof EditScriptForm> = {
   script,
@@ -14,7 +19,9 @@ const props: ComponentProps<typeof EditScriptForm> = {
 };
 
 describe("EditScriptForm", () => {
-  const user = userEvent.setup();
+  beforeEach(() => {
+    setEndpointStatus("default");
+  });
 
   it("should display edit script form", async () => {
     renderWithProviders(<EditScriptForm {...props} />);
@@ -26,6 +33,8 @@ describe("EditScriptForm", () => {
   });
 
   it("should show the edit confirmation modal when 'Submit new version' is clicked", async () => {
+    const user = userEvent.setup();
+
     renderWithProviders(<EditScriptForm {...props} />);
 
     await user.type(screen.getByRole("textbox", { name: /title/i }), " edited");
@@ -42,6 +51,7 @@ describe("EditScriptForm", () => {
   });
 
   it("should submit the new version and show a success notification", async () => {
+    const user = userEvent.setup();
     renderWithProviders(<EditScriptForm {...props} />);
 
     await user.type(screen.getByRole("textbox", { name: /title/i }), " edited");
@@ -57,6 +67,309 @@ describe("EditScriptForm", () => {
 
     expect(
       await screen.findByText(/successfully submitted a new version/i),
+    ).toBeInTheDocument();
+  });
+
+  it("populates title and code from an uploaded file when title is empty", async () => {
+    const user = userEvent.setup();
+    const editableScript = { ...script, title: "" };
+    const file = new File(["echo from upload"], "deploy.sh", {
+      type: "text/x-shellscript",
+    });
+
+    renderWithProviders(<EditScriptForm script={editableScript} />);
+
+    const fileInput = screen.getByTestId("edit-script-upload-input");
+
+    await user.upload(fileInput, file);
+
+    expect(screen.getByRole("textbox", { name: "Title" })).toHaveValue(
+      "deploy",
+    );
+    expect(screen.getByTestId("mock-monaco")).toHaveValue("echo from upload");
+  });
+
+  it("keeps existing title when uploading a file", async () => {
+    const user = userEvent.setup();
+    const file = new File(["echo from upload"], "should-not-replace.sh", {
+      type: "text/x-shellscript",
+    });
+
+    renderWithProviders(<EditScriptForm script={script} />);
+
+    const titleInput = screen.getByRole("textbox", { name: "Title" });
+    const existingTitle = titleInput.getAttribute("value");
+
+    const fileInput = screen.getByTestId("edit-script-upload-input");
+    await user.upload(fileInput, file);
+
+    expect(titleInput).toHaveValue(existingTitle);
+    expect(screen.getByTestId("mock-monaco")).toHaveValue("echo from upload");
+  });
+
+  it("updates code editor value", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<EditScriptForm script={script} />);
+
+    const editor = screen.getByTestId("mock-monaco");
+    await user.clear(editor);
+    await user.type(editor, "echo changed");
+
+    expect(editor).toHaveValue("echo changed");
+  });
+
+  it("submits new version with attachment changes", async () => {
+    const user = userEvent.setup();
+    const scriptWithAttachment = scripts.find(
+      (entry) => entry.attachments.length,
+    );
+    assert(scriptWithAttachment);
+    const [initialAttachment] = scriptWithAttachment.attachments;
+    assert(initialAttachment);
+
+    renderWithProviders(<EditScriptForm script={scriptWithAttachment} />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: `Remove ${initialAttachment.filename} attachment`,
+      }),
+    );
+
+    await user.upload(
+      screen.getByLabelText("second attachment"),
+      new File(["new attachment"], "new.txt", { type: "text/plain" }),
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Submit new version" }),
+    );
+
+    const dialog = screen.getByRole("dialog", {
+      name: `Submit new version of "${scriptWithAttachment.title}"`,
+    });
+    await user.click(
+      within(dialog).getByRole("button", { name: "Submit new version" }),
+    );
+
+    expect(screen.queryByText("Network Error")).not.toBeInTheDocument();
+  });
+
+  it("opens hidden file input from populate button", async () => {
+    const user = userEvent.setup();
+    const clickSpy = vi.spyOn(HTMLInputElement.prototype, "click");
+    renderWithProviders(<EditScriptForm script={script} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Populate from file" }),
+    );
+
+    expect(clickSpy).toHaveBeenCalled();
+    clickSpy.mockRestore();
+  });
+
+  it("ignores empty file upload input", async () => {
+    renderWithProviders(<EditScriptForm script={script} />);
+
+    fireEvent.change(screen.getByTestId("edit-script-upload-input"), {
+      target: { files: null },
+    });
+
+    expect(screen.getByRole("textbox", { name: "Title" })).toHaveValue(
+      script.title,
+    );
+  });
+
+  it("handles attachment input with no file selected", () => {
+    renderWithProviders(<EditScriptForm script={script} />);
+
+    fireEvent.change(screen.getByLabelText("first attachment"), {
+      target: { files: [] },
+    });
+
+    expect(screen.getByLabelText("first attachment")).toHaveValue("");
+  });
+
+  it("submits new version with associated profiles links", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<EditScriptForm script={script} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Submit new version" }),
+    );
+
+    expect(
+      await screen.findByText(
+        /submitting these changes will affect the following profiles/i,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "abc" })).toHaveAttribute(
+      "href",
+      ROUTES.scripts.root({ tab: "profiles" }),
+    );
+    expect(screen.getByRole("link", { name: "12 instances" })).toHaveAttribute(
+      "href",
+      ROUTES.instances.root(),
+    );
+  });
+
+  it("renders singular associated instance link text", async () => {
+    const user = userEvent.setup();
+    const associatedProfile = scriptProfiles.find(
+      (profile) => profile.id === ASSOCIATED_PROFILE_ID,
+    );
+    assert(associatedProfile);
+    const originalAssociatedCount =
+      associatedProfile.computers.num_associated_computers;
+    associatedProfile.computers.num_associated_computers = 1;
+
+    try {
+      renderWithProviders(<EditScriptForm script={script} />);
+
+      await user.click(
+        screen.getByRole("button", { name: "Submit new version" }),
+      );
+
+      expect(
+        await screen.findByRole("link", { name: "1 instance" }),
+      ).toHaveAttribute("href", ROUTES.instances.root());
+    } finally {
+      associatedProfile.computers.num_associated_computers =
+        originalAssociatedCount;
+    }
+  });
+
+  it("shows no data for associated profiles without instances", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <EditScriptForm
+        script={{
+          ...script,
+          script_profiles: [{ id: 999, title: "Unknown profile" }],
+        }}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Submit new version" }),
+    );
+
+    expect(await screen.findByText(NO_DATA_TEXT)).toBeInTheDocument();
+  });
+
+  it("shows confirmation copy while associated profiles are loading", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "error", path: "scripts/profiles-loading" });
+    renderWithProviders(<EditScriptForm script={script} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Submit new version" }),
+    );
+
+    expect(
+      await screen.findByText(
+        /all future script runs will be done using the latest version of the code\./i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("submits when there are no associated profiles", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "empty", path: "scripts/profiles" });
+    renderWithProviders(<EditScriptForm script={script} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Submit new version" }),
+    );
+
+    expect(
+      await screen.findByText(
+        /all future script runs will be done using the latest version of the code\./i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/affect the following profiles/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("closes confirmation modal with cancel button", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<EditScriptForm script={script} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Submit new version" }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("shows error notification when edit script fails", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "error", path: "EditScript" });
+    renderWithProviders(<EditScriptForm script={script} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Submit new version" }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: "Submit new version" }),
+    );
+
+    expect(
+      await screen.findByText('The endpoint status is set to "error".'),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error notification when removing attachment fails", async () => {
+    const user = userEvent.setup();
+    const scriptWithAttachment = scripts.find(
+      (entry) => entry.attachments.length,
+    );
+    assert(scriptWithAttachment);
+    const [initialAttachment] = scriptWithAttachment.attachments;
+    assert(initialAttachment);
+    setEndpointStatus({ status: "error", path: "RemoveScriptAttachment" });
+    renderWithProviders(<EditScriptForm script={scriptWithAttachment} />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: `Remove ${initialAttachment.filename} attachment`,
+      }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Submit new version" }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: "Submit new version" }),
+    );
+
+    expect(
+      await screen.findByText('The endpoint status is set to "error".'),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error notification when adding attachment fails", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "error", path: "CreateScriptAttachment" });
+    renderWithProviders(<EditScriptForm script={script} />);
+
+    await user.upload(
+      screen.getByLabelText("first attachment"),
+      new File(["new attachment"], "new.txt", { type: "text/plain" }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Submit new version" }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: "Submit new version" }),
+    );
+
+    expect(
+      await screen.findByText('The endpoint status is set to "error".'),
     ).toBeInTheDocument();
   });
 });

--- a/src/features/scripts/components/EditScriptForm/EditScriptForm.test.tsx
+++ b/src/features/scripts/components/EditScriptForm/EditScriptForm.test.tsx
@@ -256,25 +256,9 @@ describe("EditScriptForm", () => {
     expect(await screen.findByText(NO_DATA_TEXT)).toBeInTheDocument();
   });
 
-  it("shows confirmation copy while associated profiles are loading", async () => {
-    const user = userEvent.setup();
-    setEndpointStatus({ status: "error", path: "scripts/profiles-loading" });
-    renderWithProviders(<EditScriptForm script={script} />);
-
-    await user.click(
-      screen.getByRole("button", { name: "Submit new version" }),
-    );
-
-    expect(
-      await screen.findByText(
-        /all future script runs will be done using the latest version of the code\./i,
-      ),
-    ).toBeInTheDocument();
-  });
-
   it("submits when there are no associated profiles", async () => {
     const user = userEvent.setup();
-    setEndpointStatus({ status: "empty", path: "scripts/profiles" });
+    setEndpointStatus({ status: "empty", path: "script-profiles" });
     renderWithProviders(<EditScriptForm script={script} />);
 
     await user.click(

--- a/src/features/scripts/components/EditScriptForm/EditScriptForm.tsx
+++ b/src/features/scripts/components/EditScriptForm/EditScriptForm.tsx
@@ -135,6 +135,7 @@ const EditScriptForm: FC<EditScriptFormProps> = ({ script, onBack }) => {
         ref={inputRef}
         className="u-hide"
         type="file"
+        data-testid="edit-script-upload-input"
         onChange={handleInputChange}
       />
 

--- a/src/features/scripts/components/RunScriptForm/RunScriptForm.test.tsx
+++ b/src/features/scripts/components/RunScriptForm/RunScriptForm.test.tsx
@@ -1,8 +1,9 @@
+import { setEndpointStatus } from "@/tests/controllers/controller";
 import { scripts } from "@/tests/mocks/script";
 import { renderWithProviders } from "@/tests/render";
 import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it } from "vitest";
+import { beforeEach, describe, it } from "vitest";
 import RunScriptForm from "./RunScriptForm";
 
 const [script] = scripts;
@@ -17,6 +18,10 @@ const selectTag = async (
 
 describe("RunScriptForm", () => {
   const user = userEvent.setup();
+
+  beforeEach(() => {
+    setEndpointStatus("default");
+  });
 
   it("should display run script form", async () => {
     renderWithProviders(<RunScriptForm script={script} />);

--- a/src/features/scripts/components/RunScriptForm/RunScriptForm.test.tsx
+++ b/src/features/scripts/components/RunScriptForm/RunScriptForm.test.tsx
@@ -181,7 +181,7 @@ describe("RunScriptForm", () => {
       await screen.findByText(/no instances to run script on/i),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/please select different tags and try again/i),
+      screen.getByText(/select different tags and try again/i),
     ).toBeInTheDocument();
   });
 

--- a/src/features/scripts/components/RunScriptForm/RunScriptForm.tsx
+++ b/src/features/scripts/components/RunScriptForm/RunScriptForm.tsx
@@ -166,10 +166,9 @@ const RunScriptForm: FC<RunScriptFormProps> = ({
       value: tag,
     })) ?? [];
 
-  const instancesWithScriptsFeature =
-    instances.filter((instance) => {
-      return getFeatures(instance).scripts;
-    }) ?? [];
+  const instancesWithScriptsFeature = instances.filter((instance) => {
+    return getFeatures(instance).scripts;
+  });
 
   const instanceOptions: MultiSelectItem[] = instancesWithScriptsFeature.map(
     ({ title, id }) => ({
@@ -178,10 +177,11 @@ const RunScriptForm: FC<RunScriptFormProps> = ({
     }),
   );
 
-  const taggedInstancesWithScriptsFeature =
-    taggedInstances.filter((instance) => {
+  const taggedInstancesWithScriptsFeature = taggedInstances.filter(
+    (instance) => {
       return getFeatures(instance).scripts;
-    }) ?? [];
+    },
+  );
 
   const shouldShowNoTaggedInstancesWarning =
     hasClosedTagDropdown &&

--- a/src/features/scripts/components/ScriptFormAttachments/ScriptFormAttachments.tsx
+++ b/src/features/scripts/components/ScriptFormAttachments/ScriptFormAttachments.tsx
@@ -14,7 +14,7 @@ interface ScriptFormAttachmentsProps {
   readonly onFileInputChange: (
     key: keyof ScriptFormValues["attachments"],
   ) => ChangeEventHandler<HTMLInputElement>;
-  readonly onInitialAttachmentDelete: (attachment: string) => void;
+  readonly onInitialAttachmentDelete?: (attachment: string) => void;
   readonly scriptId?: number;
 }
 
@@ -51,7 +51,7 @@ const ScriptFormAttachments: FC<ScriptFormAttachmentsProps> = ({
             filename={initialAttachment.filename}
             scriptId={scriptId}
             onInitialAttachmentDelete={() => {
-              onInitialAttachmentDelete(initialAttachment.filename);
+              onInitialAttachmentDelete?.(initialAttachment.filename);
             }}
           />
         );

--- a/src/features/scripts/helpers.test.ts
+++ b/src/features/scripts/helpers.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import moment from "moment";
+import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
+import {
+  formatTitleCase,
+  getAuthorInfo,
+  getCode,
+  getCreateAttachmentsPromises,
+  getCreateScriptParams,
+  getEditScriptParams,
+  removeFileExtension,
+} from "./helpers";
+
+const SCRIPT_ID = 42;
+const FILE_CONTENT = "hello world";
+const emptyAttachments = {
+  first: null,
+  second: null,
+  third: null,
+  fourth: null,
+  fifth: null,
+};
+
+describe("scripts helpers", () => {
+  it("builds create params with encoded code and trimmed title", () => {
+    const params = getCreateScriptParams({
+      title: "  My Script  ",
+      code: "#!/bin/bash\necho hi\r\n",
+      access_group: "global",
+      attachments: emptyAttachments,
+      attachmentsToRemove: [],
+    });
+
+    expect(params.title).toBe("My Script");
+    expect(params.script_type).toBe("V2");
+    expect(params.access_group).toBe("global");
+    expect(params.code).toBe("IyEvYmluL2Jhc2gKZWNobyBoaQo=");
+  });
+
+  it("builds edit params with script id", () => {
+    const params = getEditScriptParams({
+      scriptId: SCRIPT_ID,
+      values: {
+        title: "  Updated Script  ",
+        code: "echo edited",
+        access_group: "global",
+        attachments: emptyAttachments,
+        attachmentsToRemove: [],
+      },
+    });
+
+    expect(params.script_id).toBe(SCRIPT_ID);
+    expect(params.title).toBe("Updated Script");
+    expect(params.code).toBe("ZWNobyBlZGl0ZWQ=");
+  });
+
+  it("creates attachment upload promises with encoded payloads", async () => {
+    const createScriptAttachment = vi.fn().mockResolvedValue({ ok: true });
+
+    const textFile = new File([FILE_CONTENT], "notes.txt", {
+      type: "text/plain",
+    });
+    const binaryFile = new File([new Uint8Array([1, 2, 3])], "blob.bin", {
+      type: "application/octet-stream",
+    });
+
+    const uploadPromises = await getCreateAttachmentsPromises({
+      attachments: [textFile, binaryFile],
+      createScriptAttachment,
+      script_id: SCRIPT_ID,
+    });
+
+    await Promise.all(uploadPromises);
+
+    expect(createScriptAttachment).toHaveBeenCalledTimes(2);
+    expect(createScriptAttachment).toHaveBeenNthCalledWith(1, {
+      file: "notes.txt$$aGVsbG8gd29ybGQ=",
+      script_id: SCRIPT_ID,
+    });
+    expect(createScriptAttachment).toHaveBeenNthCalledWith(2, {
+      file: "blob.bin$$AQID",
+      script_id: SCRIPT_ID,
+    });
+  });
+
+  it("handles common filename transformations", () => {
+    expect(removeFileExtension("archive.tar.gz")).toBe("archive.tar");
+    expect(removeFileExtension("README")).toBe("README");
+    expect(formatTitleCase("hELLO")).toBe("Hello");
+  });
+
+  it("formats shebang code and author metadata", () => {
+    const interpreter = "/usr/bin/python3";
+    const code = "print('ok')";
+    const date = "2024-01-01T12:34:56Z";
+
+    expect(getCode({ interpreter, code })).toBe(
+      "#!/usr/bin/python3\nprint('ok')",
+    );
+    expect(getAuthorInfo({ author: "alice", date })).toBe(
+      `${moment(date).format(DISPLAY_DATE_TIME_FORMAT)}, by alice`,
+    );
+  });
+});

--- a/src/features/security-profiles/components/SecurityProfileDetailsSidePanel/SecurityProfileDetailsSidePanel.test.tsx
+++ b/src/features/security-profiles/components/SecurityProfileDetailsSidePanel/SecurityProfileDetailsSidePanel.test.tsx
@@ -2,6 +2,7 @@ import { renderWithProviders } from "@/tests/render";
 import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import SecurityProfileDetailsSidePanel from "./SecurityProfileDetailsSidePanel";
+import { NO_DATA_TEXT } from "@/components/layout/NoData";
 
 describe("SecurityProfileDetailsSidePanel", () => {
   it("should render without data", async () => {
@@ -11,7 +12,7 @@ describe("SecurityProfileDetailsSidePanel", () => {
       "/?profile=7",
     );
 
-    expect((await screen.findAllByText("---"))[0]).toBeInTheDocument();
+    expect((await screen.findAllByText(NO_DATA_TEXT))[0]).toBeInTheDocument();
     expect(screen.getByText("As soon as possible")).toBeInTheDocument();
   });
 

--- a/src/features/security-profiles/components/SecurityProfileDownloadAuditSidePanel/components/SecurityProfileDownloadAuditForm/SecurityProfileDownloadAuditForm.tsx
+++ b/src/features/security-profiles/components/SecurityProfileDownloadAuditSidePanel/components/SecurityProfileDownloadAuditForm/SecurityProfileDownloadAuditForm.tsx
@@ -93,8 +93,8 @@ const SecurityProfileDownloadAuditForm: FC<
   const formik = useFormik<SecurityProfileDownloadAuditFormValues>({
     initialValues: {
       audit_timeframe: "specific-date",
-      end_date: moment().format(INPUT_DATE_FORMAT),
-      start_date: moment().format(INPUT_DATE_FORMAT),
+      end_date: moment().utc().format(INPUT_DATE_FORMAT),
+      start_date: moment().utc().format(INPUT_DATE_FORMAT),
       level_of_detail: "summary-only",
     },
 

--- a/src/features/snaps/components/EditSnap/helpers.test.tsx
+++ b/src/features/snaps/components/EditSnap/helpers.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type * as Yup from "yup";
+import { installedSnaps } from "@/tests/mocks/snap";
+import { EditSnapType } from "../../helpers";
+import {
+  getEditSnapValidationSchema,
+  getSnapMessage,
+  getSuccessMessage,
+} from "./helpers";
+
+const SNAP_COUNT = 3;
+
+describe("EditSnap helpers", () => {
+  it("requires release for switch actions", async () => {
+    const schema = getEditSnapValidationSchema(EditSnapType.Switch);
+    const releaseSchema = schema.release as Yup.StringSchema;
+
+    await expect(releaseSchema.validate("")).rejects.toThrowError(
+      /release is required/i,
+    );
+    await expect(releaseSchema.validate("stable")).resolves.toBe("stable");
+  });
+
+  it("does not require release for non-switch actions", () => {
+    const holdSchema = getEditSnapValidationSchema(EditSnapType.Hold);
+    expect(holdSchema.release).toBeUndefined();
+  });
+
+  it("falls back to common schema for unsupported edit types", () => {
+    const schema = getEditSnapValidationSchema("unsupported" as EditSnapType);
+
+    expect(schema.release).toBeUndefined();
+    expect(schema.hold).toBeUndefined();
+  });
+
+  it("validates hold_until date values for hold actions", async () => {
+    const schema = getEditSnapValidationSchema(EditSnapType.Hold);
+    const holdUntilSchema = schema.hold_until as Yup.StringSchema;
+
+    await expect(holdUntilSchema.validate("")).resolves.toBe("");
+    await expect(holdUntilSchema.validate("not-a-date")).rejects.toThrowError(
+      /valid date and time/i,
+    );
+    await expect(
+      holdUntilSchema.validate("2030-01-01T00:00:00Z"),
+    ).resolves.toBe("2030-01-01T00:00:00Z");
+  });
+
+  it("returns null message for switch actions", () => {
+    expect(getSnapMessage(EditSnapType.Switch, [...installedSnaps])).toBeNull();
+  });
+
+  it("renders single-snap message with snap name interpolation", () => {
+    const node = getSnapMessage(EditSnapType.Refresh, [installedSnaps[0]]);
+
+    render(<>{node}</>);
+
+    expect(
+      screen.getByText(/update Snap 1 to the latest version available/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders multi-snap hold summary when held and unheld snaps are mixed", () => {
+    const node = getSnapMessage(EditSnapType.Hold, [...installedSnaps]);
+
+    const { container } = render(<>{node}</>);
+
+    expect(
+      screen.getByText(/holding a snap will pause automatic updates/i),
+    ).toBeInTheDocument();
+    expect(container).toHaveTextContent("You selected 4 snaps. This will:");
+    expect(container).toHaveTextContent("hold 2 snaps");
+    expect(container).toHaveTextContent("leave 2 snaps held");
+  });
+
+  it("renders compact multi-snap message when all selected snaps are already held", () => {
+    const allHeldSnaps = installedSnaps.map((snap) => ({
+      ...snap,
+      held_until: "2030-01-01T00:00:00Z",
+    }));
+
+    const node = getSnapMessage(EditSnapType.Hold, allHeldSnaps);
+
+    const { container } = render(<>{node}</>);
+
+    expect(container).toHaveTextContent(
+      "Holding a snap will pause automatic updates for that particular snap.",
+    );
+    expect(screen.queryByText(/you selected/i)).not.toBeInTheDocument();
+  });
+
+  it("renders multi-snap unhold summary when held and unheld snaps are mixed", () => {
+    const node = getSnapMessage(EditSnapType.Unhold, [...installedSnaps]);
+
+    const { container } = render(<>{node}</>);
+
+    expect(container).toHaveTextContent("You selected 4 snaps. This will:");
+    expect(container).toHaveTextContent("unhold 2 snaps");
+    expect(container).toHaveTextContent("leave 2 snaps unheld");
+  });
+
+  it("builds success copy for each action", () => {
+    expect(getSuccessMessage(SNAP_COUNT, EditSnapType.Refresh)).toContain(
+      "to be refreshed",
+    );
+    expect(getSuccessMessage(SNAP_COUNT, EditSnapType.Uninstall)).toContain(
+      "to be uninstalled",
+    );
+    expect(getSuccessMessage(SNAP_COUNT, EditSnapType.Hold)).toContain(
+      "to be held",
+    );
+    expect(getSuccessMessage(SNAP_COUNT, EditSnapType.Unhold)).toContain(
+      "to be unheld",
+    );
+  });
+
+  it("falls back to an empty verb for unsupported actions", () => {
+    expect(getSuccessMessage(1, "Unsupported" as EditSnapType)).toBe(
+      "You queued 1 snap to be updated.",
+    );
+  });
+});

--- a/src/features/snaps/components/EditSnap/helpers.tsx
+++ b/src/features/snaps/components/EditSnap/helpers.tsx
@@ -133,6 +133,7 @@ export const getSuccessMessage = (snapCount: number, action: EditSnapType) => {
       verb = "unheld";
       break;
     default:
+      verb = "updated";
       break;
   }
 

--- a/src/features/snaps/components/SnapsActions/SnapsActions.test.tsx
+++ b/src/features/snaps/components/SnapsActions/SnapsActions.test.tsx
@@ -4,6 +4,8 @@ import { installedSnaps } from "@/tests/mocks/snap";
 import { renderWithProviders } from "@/tests/render";
 import { screen } from "@testing-library/react";
 import { describe } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { PATHS, ROUTES } from "@/libs/routes";
 import { getSelectedSnaps } from "../../helpers";
 import SnapsActions from "./SnapsActions";
 
@@ -29,6 +31,7 @@ const mixedSelectedSnapIds = [
   ...snapData.multiple.heldSnaps,
   ...snapData.multiple.unheldSnaps,
 ];
+const INSTANCE_ID = 11;
 
 const tableSnapButtons = ["Install", "Hold", "Unhold", "Uninstall", "Refresh"];
 const formHeldSnapButtons = [
@@ -160,6 +163,183 @@ describe("SnapsActions", () => {
       );
 
       expect(container).toHaveTexts(formUnheldSnapButtons);
+    });
+
+    it("does not render switch channel button for multiple snaps in sidepanel", () => {
+      renderWithProviders(
+        <SnapsActions
+          installedSnaps={getSelectedSnaps(
+            installedSnaps,
+            mixedSelectedSnapIds,
+          )}
+          selectedSnapIds={mixedSelectedSnapIds}
+          sidePanel={true}
+        />,
+      );
+
+      expect(
+        screen.queryByRole("button", { name: "Switch channel" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("opens install snaps side panel from table actions", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(
+        <SnapsActions
+          installedSnaps={getSelectedSnaps(installedSnaps, snapData.empty)}
+          selectedSnapIds={snapData.empty}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Install" }));
+
+      expect(
+        await screen.findByRole("heading", { name: "Install snaps" }),
+      ).toBeInTheDocument();
+    });
+
+    it("opens hold side panel for selected snaps", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(
+        <SnapsActions
+          installedSnaps={getSelectedSnaps(
+            installedSnaps,
+            snapData.multiple.unheldSnaps,
+          )}
+          selectedSnapIds={snapData.multiple.unheldSnaps}
+        />,
+        undefined,
+        ROUTES.instances.details.single(INSTANCE_ID),
+        `/${PATHS.instances.root}/${PATHS.instances.single}`,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Hold" }));
+
+      expect(
+        await screen.findByRole("heading", { name: /Hold \d+ snaps/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("opens uninstall side panel for selected snaps", async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <SnapsActions
+          installedSnaps={getSelectedSnaps(
+            installedSnaps,
+            snapData.multiple.unheldSnaps,
+          )}
+          selectedSnapIds={snapData.multiple.unheldSnaps}
+        />,
+        undefined,
+        ROUTES.instances.details.single(INSTANCE_ID),
+        `/${PATHS.instances.root}/${PATHS.instances.single}`,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Uninstall" }));
+
+      expect(
+        await screen.findByRole("heading", { name: /Uninstall \d+ snaps/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("opens unhold side panel using held snap count", async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <SnapsActions
+          installedSnaps={getSelectedSnaps(
+            installedSnaps,
+            mixedSelectedSnapIds,
+          )}
+          selectedSnapIds={mixedSelectedSnapIds}
+        />,
+        undefined,
+        ROUTES.instances.details.single(INSTANCE_ID),
+        `/${PATHS.instances.root}/${PATHS.instances.single}`,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Unhold" }));
+
+      expect(
+        await screen.findByRole("heading", {
+          name: new RegExp(
+            `Unhold ${snapData.multiple.heldSnaps.length} snaps`,
+            "i",
+          ),
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("opens refresh side panel for selected snaps", async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <SnapsActions
+          installedSnaps={getSelectedSnaps(
+            installedSnaps,
+            snapData.multiple.unheldSnaps,
+          )}
+          selectedSnapIds={snapData.multiple.unheldSnaps}
+        />,
+        undefined,
+        ROUTES.instances.details.single(INSTANCE_ID),
+        `/${PATHS.instances.root}/${PATHS.instances.single}`,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Refresh" }));
+
+      expect(
+        await screen.findByRole("heading", { name: /Refresh \d+ snaps/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("opens switch channel side panel for held snap in sidepanel mode", async () => {
+      const user = userEvent.setup();
+      const heldSnap = installedSnaps.find((snap) => snap.held_until !== null);
+      assert(heldSnap);
+
+      renderWithProviders(
+        <SnapsActions
+          installedSnaps={[heldSnap]}
+          selectedSnapIds={[heldSnap.snap.id]}
+          sidePanel={true}
+        />,
+        undefined,
+        ROUTES.instances.details.single(INSTANCE_ID),
+        `/${PATHS.instances.root}/${PATHS.instances.single}`,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Switch channel" }));
+
+      expect(
+        await screen.findByRole("heading", { name: /Switch .*'s channel/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("opens uninstall side panel with single snap title in sidepanel mode", async () => {
+      const user = userEvent.setup();
+      const heldSnap = installedSnaps.find((snap) => snap.held_until !== null);
+      assert(heldSnap);
+
+      renderWithProviders(
+        <SnapsActions
+          installedSnaps={[heldSnap]}
+          selectedSnapIds={[heldSnap.snap.id]}
+          sidePanel={true}
+        />,
+        undefined,
+        ROUTES.instances.details.single(INSTANCE_ID),
+        `/${PATHS.instances.root}/${PATHS.instances.single}`,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Uninstall" }));
+
+      expect(
+        await screen.findByRole("heading", {
+          name: `Uninstall ${heldSnap.snap.name}`,
+        }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/features/ubuntupro/components/DetachTokenModal/DetachTokenModal.test.tsx
+++ b/src/features/ubuntupro/components/DetachTokenModal/DetachTokenModal.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "@/tests/render";
+import { setEndpointStatus } from "@/tests/controllers/controller";
 import DetachTokenModal from "./DetachTokenModal";
 
 describe("DetachTokenModal", () => {
@@ -64,6 +65,26 @@ describe("DetachTokenModal", () => {
     expect(screen.getByText("Detach Ubuntu Pro token")).toBeInTheDocument();
   });
 
+  it("shows notification title using custom instance title", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <DetachTokenModal {...props} instanceTitle="Test Server" />,
+    );
+
+    await user.type(
+      screen.getByPlaceholderText("detach ubuntu pro token"),
+      "detach ubuntu pro token",
+    );
+    await user.click(screen.getByRole("button", { name: /^detach$/i }));
+
+    expect(
+      await screen.findByText(
+        "You queued detachment of Ubuntu Pro token for instance Test Server.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("uses instanceCount when provided instead of computerIds length", () => {
     renderWithProviders(
       <DetachTokenModal {...props} computerIds={[1, 2]} instanceCount={5} />,
@@ -91,5 +112,98 @@ describe("DetachTokenModal", () => {
     const detachButton = screen.getByRole("button", { name: /detach/i });
     expect(detachButton).toBeInTheDocument();
     expect(detachButton).toHaveClass("p-button--negative");
+  });
+
+  it("keeps detach action disabled until confirmation text is entered", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<DetachTokenModal {...props} />);
+
+    const detachButton = screen.getByRole("button", { name: /^detach$/i });
+    expect(detachButton).toHaveAttribute("aria-disabled", "true");
+
+    await user.type(
+      screen.getByPlaceholderText("detach ubuntu pro token"),
+      "detach ubuntu pro token",
+    );
+
+    expect(detachButton).toBeEnabled();
+  });
+
+  it("submits detachment and closes modal after confirmation", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    renderWithProviders(<DetachTokenModal {...props} onClose={onClose} />);
+
+    await user.type(
+      screen.getByPlaceholderText("detach ubuntu pro token"),
+      "detach ubuntu pro token",
+    );
+    await user.click(screen.getByRole("button", { name: /^detach$/i }));
+
+    expect(
+      await screen.findByText(/queued detachment of Ubuntu Pro token/i),
+    ).toBeInTheDocument();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("opens activity details from success notification action", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<DetachTokenModal {...props} />);
+
+    await user.type(
+      screen.getByPlaceholderText("detach ubuntu pro token"),
+      "detach ubuntu pro token",
+    );
+    await user.click(screen.getByRole("button", { name: /^detach$/i }));
+
+    await user.click(
+      await screen.findByRole("button", { name: "View details" }),
+    );
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Start instance Bionic WSL 1",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows plural success text when no instance title is provided", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<DetachTokenModal {...props} computerIds={[1, 2]} />);
+
+    await user.type(
+      screen.getByPlaceholderText("detach ubuntu pro token"),
+      "detach ubuntu pro token",
+    );
+    await user.click(screen.getByRole("button", { name: /^detach$/i }));
+
+    expect(
+      await screen.findByText(
+        "This will disconnect the instances from their subscription and pause any enabled Pro services.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("handles detach-token failure via debug notification", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "error", path: "detach-token" });
+
+    const onClose = vi.fn();
+    renderWithProviders(<DetachTokenModal {...props} onClose={onClose} />);
+
+    await user.type(
+      screen.getByPlaceholderText("detach ubuntu pro token"),
+      "detach ubuntu pro token",
+    );
+    await user.click(screen.getByRole("button", { name: /^detach$/i }));
+
+    expect(
+      await screen.findByText('The endpoint status is set to "error".'),
+    ).toBeInTheDocument();
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/src/features/upgrades/components/Upgrades/Upgrades.test.tsx
+++ b/src/features/upgrades/components/Upgrades/Upgrades.test.tsx
@@ -1,11 +1,17 @@
-import { describe } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { instances } from "@/tests/mocks/instance";
+import { setEndpointStatus } from "@/tests/controllers/controller";
+import { expectErrorNotification } from "@/tests/helpers";
 import { renderWithProviders } from "@/tests/render";
 import Upgrades from "./Upgrades";
 
 describe("Upgrades", () => {
+  beforeEach(() => {
+    setEndpointStatus("default");
+  });
+
   it("should render tabs", async () => {
     renderWithProviders(<Upgrades selectedInstances={instances} />);
 
@@ -56,6 +62,118 @@ describe("Upgrades", () => {
     );
     expect(
       await screen.findByText(/Showing \d of \d+ security issues/i),
+    ).toBeInTheDocument();
+  });
+
+  it("submits package upgrades from default tab", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<Upgrades selectedInstances={instances} />);
+
+    await user.click(screen.getByRole("button", { name: "Upgrade" }));
+
+    expect(
+      await screen.findByText("You queued packages to be upgraded"),
+    ).toBeInTheDocument();
+  });
+
+  it("submits USN upgrades when USNs tab is selected", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<Upgrades selectedInstances={instances} />);
+
+    await user.click(screen.getByRole("tab", { name: /usns/i }));
+    await user.click(screen.getByRole("button", { name: "Upgrade" }));
+
+    expect(
+      await screen.findByText("You queued packages to be upgraded"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders only instances and packages tabs when no security upgrades exist", () => {
+    const noSecurityUpgradeInstances = instances.map((instance) => ({
+      ...instance,
+      alerts: (instance.alerts ?? []).filter(
+        ({ type }) => type !== "SecurityUpgradesAlert",
+      ),
+    }));
+
+    renderWithProviders(
+      <Upgrades selectedInstances={noSecurityUpgradeInstances} />,
+    );
+
+    expect(screen.getByRole("tab", { name: /instances/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /packages/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("tab", { name: /usns/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows singular success message when upgrading one instance", async () => {
+    const user = userEvent.setup();
+    const [singleInstance] = instances;
+    assert(singleInstance);
+
+    renderWithProviders(<Upgrades selectedInstances={[singleInstance]} />);
+
+    await user.click(screen.getByRole("button", { name: "Upgrade" }));
+
+    expect(
+      await screen.findByText(/Packages on 1 instance will be upgraded/i),
+    ).toBeInTheDocument();
+  });
+
+  it("handles package-upgrade submission errors", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<Upgrades selectedInstances={instances} />);
+
+    setEndpointStatus("error");
+    await user.click(screen.getByRole("button", { name: "Upgrade" }));
+
+    await expectErrorNotification();
+  });
+
+  it("handles usn-upgrade submission errors", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Upgrades selectedInstances={instances} />);
+
+    await user.click(screen.getByRole("tab", { name: /usns/i }));
+    setEndpointStatus("error");
+    await user.click(screen.getByRole("button", { name: "Upgrade" }));
+
+    await expectErrorNotification();
+  });
+
+  it("updates excluded package list from packages tab interaction", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<Upgrades selectedInstances={instances} />);
+
+    await user.click(screen.getByRole("tab", { name: /packages/i }));
+    await user.click(
+      screen.getByRole("checkbox", { name: /toggle all packages/i }),
+    );
+    await user.click(screen.getByRole("button", { name: "Upgrade" }));
+
+    expect(
+      await screen.findByText("You queued packages to be upgraded"),
+    ).toBeInTheDocument();
+  });
+
+  it("updates excluded usn list from usns tab interaction", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<Upgrades selectedInstances={instances} />);
+
+    await user.click(screen.getByRole("tab", { name: /usns/i }));
+    await user.click(
+      screen.getByRole("checkbox", { name: /toggle all security issues/i }),
+    );
+    await user.click(screen.getByRole("button", { name: "Upgrade" }));
+
+    expect(
+      await screen.findByText("You queued packages to be upgraded"),
     ).toBeInTheDocument();
   });
 });

--- a/src/features/upgrades/components/Upgrades/Upgrades.tsx
+++ b/src/features/upgrades/components/Upgrades/Upgrades.tsx
@@ -77,6 +77,10 @@ const Upgrades: FC<UpgradesProps> = ({ selectedInstances }) => {
     validationSchema: VALIDATION_SCHEMA,
   });
 
+  const handleExcludedPackagesChange = async (
+    newExcludedPackages: UpgradesFormProps["excludedPackages"],
+  ) => formik.setFieldValue("excludedPackages", newExcludedPackages);
+
   return (
     <Form onSubmit={formik.handleSubmit}>
       <UpgradeInfo instances={selectedInstances} />
@@ -98,9 +102,7 @@ const Upgrades: FC<UpgradesProps> = ({ selectedInstances }) => {
               <TAB_PANELS.instances
                 excludedPackages={formik.values.excludedPackages}
                 instances={affectedInstances}
-                onExcludedPackagesChange={async (newExcludedPackages) =>
-                  formik.setFieldValue("excludedPackages", newExcludedPackages)
-                }
+                onExcludedPackagesChange={handleExcludedPackagesChange}
               />
             </Suspense>
           )}
@@ -109,9 +111,7 @@ const Upgrades: FC<UpgradesProps> = ({ selectedInstances }) => {
               <TAB_PANELS.packages
                 excludedPackages={formik.values.excludedPackages}
                 instances={affectedInstances}
-                onExcludedPackagesChange={async (newExcludedPackages) =>
-                  formik.setFieldValue("excludedPackages", newExcludedPackages)
-                }
+                onExcludedPackagesChange={handleExcludedPackagesChange}
               />
             </Suspense>
           )}

--- a/src/features/welcome-banner/WelcomePopup/WelcomePopup.test.tsx
+++ b/src/features/welcome-banner/WelcomePopup/WelcomePopup.test.tsx
@@ -29,24 +29,20 @@ describe("WelcomePopup", () => {
   });
 
   it("should close and save in local storage", async () => {
+    const user = userEvent.setup();
     renderWithProviders(<WelcomePopup />);
 
-    await waitFor(async () => {
-      const closeButton = screen.getByRole("button", {
-        name: /got it!/i,
-      });
+    const closeButton = await screen.findByRole("button", {
+      name: /got it!/i,
+    });
+    await user.click(closeButton);
 
-      expect(closeButton).toBeInTheDocument();
-
-      await userEvent.click(closeButton);
-
+    await waitFor(() => {
       expect(
         screen.queryByText("Landscape web portal (Preview)"),
       ).not.toBeInTheDocument();
-
-      expect(localStorage.getItem("_landscape_isWelcomePopupClosed")).toBe(
-        "true",
-      );
     });
+
+    expect(localStorage.getItem("_landscape_isWelcomePopupClosed")).toBe("true");
   });
 });

--- a/src/features/welcome-banner/WelcomePopup/WelcomePopup.test.tsx
+++ b/src/features/welcome-banner/WelcomePopup/WelcomePopup.test.tsx
@@ -43,6 +43,8 @@ describe("WelcomePopup", () => {
       ).not.toBeInTheDocument();
     });
 
-    expect(localStorage.getItem("_landscape_isWelcomePopupClosed")).toBe("true");
+    expect(localStorage.getItem("_landscape_isWelcomePopupClosed")).toBe(
+      "true",
+    );
   });
 });

--- a/src/features/wsl/components/WslInstancesHeader/WslInstancesHeader.test.tsx
+++ b/src/features/wsl/components/WslInstancesHeader/WslInstancesHeader.test.tsx
@@ -1,8 +1,15 @@
 import { screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { PATHS, ROUTES } from "@/libs/routes";
+import { setEndpointStatus } from "@/tests/controllers/controller";
 import { renderWithProviders } from "@/tests/render";
 import WslInstancesHeader from "./WslInstancesHeader";
-import { instanceChildren } from "@/tests/mocks/wsl";
+import {
+  instanceChildren,
+  noncompliantInstanceChild,
+  uninstalledInstanceChild,
+} from "@/tests/mocks/wsl";
 import { windowsInstance } from "@/tests/mocks/instance";
 
 describe("WslInstancesHeader", () => {
@@ -59,6 +66,129 @@ describe("WslInstancesHeader", () => {
     expect(installButtons.length).toBeGreaterThanOrEqual(1);
     expect(
       screen.getByRole("button", { name: /reinstall/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("disables install action when selected instance is not uninstalled", () => {
+    renderWithProviders(
+      <WslInstancesHeader
+        windowsInstance={windowsInstance}
+        selectedWslInstances={[instanceChildren[0]]}
+        wslInstances={instanceChildren}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /^install$/i })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("disables uninstall action when selected instance is already not installed", () => {
+    renderWithProviders(
+      <WslInstancesHeader
+        windowsInstance={windowsInstance}
+        selectedWslInstances={[instanceChildren[1]]}
+        wslInstances={instanceChildren}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /^uninstall$/i }),
+    ).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("opens create new instance side panel", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <WslInstancesHeader
+        windowsInstance={windowsInstance}
+        selectedWslInstances={[]}
+        wslInstances={instanceChildren}
+      />,
+      undefined,
+      ROUTES.instances.details.single(windowsInstance.id),
+      `/${PATHS.instances.root}/${PATHS.instances.single}`,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /create new instance/i }),
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Create new WSL instance" }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens reinstall modal for a noncompliant selection", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <WslInstancesHeader
+        windowsInstance={windowsInstance}
+        selectedWslInstances={[noncompliantInstanceChild]}
+        wslInstances={instanceChildren}
+      />,
+      undefined,
+      ROUTES.instances.details.single(windowsInstance.id),
+      `/${PATHS.instances.root}/${PATHS.instances.single}`,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^reinstall$/i }));
+
+    expect(
+      screen.getByRole("heading", {
+        name: `Reinstall ${noncompliantInstanceChild.name}`,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("submits install for selected uninstalled instances", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <WslInstancesHeader
+        windowsInstance={windowsInstance}
+        selectedWslInstances={[uninstalledInstanceChild]}
+        wslInstances={instanceChildren}
+      />,
+      undefined,
+      ROUTES.instances.details.single(windowsInstance.id),
+      `/${PATHS.instances.root}/${PATHS.instances.single}`,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^install$/i }));
+
+    expect(
+      await screen.findByText(
+        /successfully queued "WSL instance associated with profile, not installed, installation in progress" to be installed/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows endpoint error when install request fails", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({
+      status: "error",
+      path: "child-instance-profiles/:name:reapply",
+    });
+
+    renderWithProviders(
+      <WslInstancesHeader
+        windowsInstance={windowsInstance}
+        selectedWslInstances={[uninstalledInstanceChild]}
+        wslInstances={instanceChildren}
+      />,
+      undefined,
+      ROUTES.instances.details.single(windowsInstance.id),
+      `/${PATHS.instances.root}/${PATHS.instances.single}`,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^install$/i }));
+
+    expect(
+      await screen.findByText('The endpoint status is set to "error".'),
     ).toBeInTheDocument();
   });
 });

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { getSentryConfig, renderApp, startApp } from "./main";
+import type { createRoot } from "react-dom/client";
+
+describe("main", () => {
+  it("starts worker in dev when enabled and renders app", async () => {
+    const workerStart = vi.fn();
+    const loadWorker = vi.fn(async () => ({
+      worker: { start: workerStart },
+    }));
+    const render = vi.fn();
+
+    await startApp({
+      mode: "development",
+      isDevEnv: true,
+      isMswEnabled: true,
+      loadWorker,
+      render,
+    });
+
+    expect(loadWorker).toHaveBeenCalledTimes(1);
+    expect(workerStart).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start worker when msw is disabled", async () => {
+    const loadWorker = vi.fn();
+    const render = vi.fn();
+
+    await startApp({
+      mode: "development",
+      isDevEnv: true,
+      isMswEnabled: false,
+      loadWorker,
+      render,
+    });
+
+    expect(loadWorker).not.toHaveBeenCalled();
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start worker outside dev", async () => {
+    const loadWorker = vi.fn();
+    const render = vi.fn();
+
+    await startApp({
+      mode: "development",
+      isDevEnv: false,
+      isMswEnabled: true,
+      loadWorker,
+      render,
+    });
+
+    expect(loadWorker).not.toHaveBeenCalled();
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not bootstrap app in test mode", async () => {
+    const loadWorker = vi.fn();
+    const render = vi.fn();
+
+    await startApp({
+      mode: "test",
+      isDevEnv: true,
+      isMswEnabled: true,
+      loadWorker,
+      render,
+    });
+
+    expect(loadWorker).not.toHaveBeenCalled();
+    expect(render).not.toHaveBeenCalled();
+  });
+
+  it("renders app root", () => {
+    const render = vi.fn();
+    const createAppRoot = vi.fn(() => ({ render }));
+    const container = document.createElement("div");
+
+    renderApp(createAppRoot as unknown as typeof createRoot, container);
+
+    expect(createAppRoot).toHaveBeenCalledWith(container);
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it("builds sentry config for fallback release and production", () => {
+    const config = getSentryConfig("", false);
+
+    expect(config.release).toBe("local-dev");
+    expect(config.environment).toBe("production");
+    expect(config.enabled).toBe(true);
+  });
+
+  it("builds sentry config for explicit release and development", () => {
+    const config = getSentryConfig("1.2.3", true);
+
+    expect(config.release).toBe("1.2.3");
+    expect(config.environment).toBe("development");
+    expect(config.enabled).toBe(false);
+  });
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,21 +13,31 @@ import { AppProviders } from "@/providers/AppProviders";
 import App from "./App";
 import { BrowserRouter } from "react-router";
 
-Sentry.init({
+export const getSentryConfig = (
+  appVersion = APP_VERSION,
+  isDevEnv = IS_DEV_ENV,
+) => ({
   dsn: "https://774322e0f66e6944afb57769632eca62@o4510662863749120.ingest.de.sentry.io/4510674271338576",
-  release: APP_VERSION || "local-dev",
-  environment: IS_DEV_ENV ? "development" : "production",
-  enabled: !IS_DEV_ENV,
+  release: appVersion || "local-dev",
+  environment: isDevEnv ? "development" : "production",
+  enabled: !isDevEnv,
 });
 
-const initApp = async () => {
-  if (IS_DEV_ENV && IS_MSW_ENABLED) {
-    const { worker } = await import("@/tests/browser");
-    await worker.start();
-  }
+Sentry.init(getSentryConfig());
 
-  const container = document.getElementById("root") as HTMLElement;
-  const root = createRoot(container);
+type WorkerLoader = () => Promise<{
+  worker: {
+    start: () => Promise<unknown> | unknown;
+  };
+}>;
+
+const defaultLoadWorker: WorkerLoader = () => import("@/tests/browser");
+
+export const renderApp = (
+  createAppRoot: typeof createRoot = createRoot,
+  container = document.getElementById("root") as HTMLElement,
+) => {
+  const root = createAppRoot(container);
 
   root.render(
     <StrictMode>
@@ -42,4 +52,33 @@ const initApp = async () => {
   );
 };
 
-initApp();
+interface StartAppOptions {
+  mode?: string;
+  isDevEnv?: boolean;
+  isMswEnabled?: boolean;
+  loadWorker?: WorkerLoader;
+  render?: () => void;
+}
+
+export const startApp = async ({
+  mode = import.meta.env.MODE,
+  isDevEnv = IS_DEV_ENV,
+  isMswEnabled = IS_MSW_ENABLED,
+  loadWorker = defaultLoadWorker,
+  render = () => {
+    renderApp();
+  },
+}: StartAppOptions = {}) => {
+  if (mode === "test") {
+    return;
+  }
+
+  if (isDevEnv && isMswEnabled) {
+    const { worker } = await loadWorker();
+    await worker.start();
+  }
+
+  render();
+};
+
+void startApp();

--- a/src/pages/PageNotFound.test.tsx
+++ b/src/pages/PageNotFound.test.tsx
@@ -1,0 +1,21 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PATHS } from "@/libs/routes";
+import { renderWithProviders } from "@/tests/render";
+import PageNotFound from "./PageNotFound";
+
+describe("PageNotFound", () => {
+  it("renders not found content and home link", () => {
+    renderWithProviders(<PageNotFound />);
+
+    expect(screen.getByText("Page not found")).toBeInTheDocument();
+    expect(
+      screen.getByText("It seems that page you're looking for doesn't exist."),
+    ).toBeInTheDocument();
+
+    const homeLink = screen.getByRole("link", {
+      name: "Go back to the home page",
+    });
+    expect(homeLink).toHaveAttribute("href", PATHS.root.root);
+  });
+});

--- a/src/pages/dashboard/account/AccountPage.test.tsx
+++ b/src/pages/dashboard/account/AccountPage.test.tsx
@@ -1,0 +1,29 @@
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ROUTES } from "@/libs/routes";
+import { renderWithProviders } from "@/tests/render";
+import AccountPage from "./AccountPage";
+
+const navigate = vi.fn();
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+describe("AccountPage", () => {
+  it("redirects to account general settings", async () => {
+    renderWithProviders(<AccountPage />);
+
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith(ROUTES.account.general(), {
+        replace: true,
+      });
+    });
+
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/account/alerts/AlertsPage.test.tsx
+++ b/src/pages/dashboard/account/alerts/AlertsPage.test.tsx
@@ -1,0 +1,26 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PATHS, ROUTES } from "@/libs/routes";
+import { renderWithProviders } from "@/tests/render";
+import AlertsPage from "./AlertsPage";
+
+describe("AlertsPage", () => {
+  it("renders alerts table content", async () => {
+    renderWithProviders(
+      <AlertsPage />,
+      undefined,
+      ROUTES.account.alerts(),
+      `/${PATHS.account.root}/${PATHS.account.alerts}`,
+    );
+
+    expect(screen.getByRole("heading", { name: "Alerts" })).toBeInTheDocument();
+    expect(
+      await screen.findByText("Computer Duplicate Alert"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("switch").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole("combobox", { name: "Select tags" }).length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText("License Seats Alert")).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/account/alerts/AlertsPage.tsx
+++ b/src/pages/dashboard/account/alerts/AlertsPage.tsx
@@ -23,12 +23,11 @@ const AlertsPage: FC = () => {
     [getAlertsQueryResult],
   );
 
-  const tagOptions: MultiSelectItem[] =
-    tags.map((tag) => ({
-      label: tag,
-      value: tag,
-      group: "Tags",
-    })) ?? [];
+  const tagOptions: MultiSelectItem[] = tags.map((tag) => ({
+    label: tag,
+    value: tag,
+    group: "Tags",
+  }));
 
   const availableTagOptions = [
     { label: "All instances", value: "All" },
@@ -40,7 +39,7 @@ const AlertsPage: FC = () => {
       <PageHeader title="Alerts" />
       <PageContent hasTable>
         {isLoading && <LoadingState />}
-        {!isLoading && alerts && (
+        {!isLoading && (
           <AlertsList
             alerts={alerts}
             availableTagOptions={availableTagOptions}

--- a/src/pages/dashboard/account/api-credentials/ApiCredentials.test.tsx
+++ b/src/pages/dashboard/account/api-credentials/ApiCredentials.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { expectLoadingState } from "@/tests/helpers";
 import { renderWithProviders } from "@/tests/render";
 import ApiCredentials from "./ApiCredentials";
+import { userDetails } from "@/tests/mocks/user";
 
 describe("ApiCredentials", () => {
   it("renders API credentials table when user and credentials are loaded", async () => {
@@ -13,9 +14,10 @@ describe("ApiCredentials", () => {
     ).toBeInTheDocument();
     await expectLoadingState();
 
-    expect(await screen.findByText("test-account")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Generate API credentials" }),
-    ).toBeInTheDocument();
+    const numberOfAccounts = userDetails.accounts.length;
+
+    expect(screen.getAllByText("Generate API credentials")).toHaveLength(
+      numberOfAccounts,
+    );
   });
 });

--- a/src/pages/dashboard/account/api-credentials/ApiCredentials.test.tsx
+++ b/src/pages/dashboard/account/api-credentials/ApiCredentials.test.tsx
@@ -1,0 +1,21 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { expectLoadingState } from "@/tests/helpers";
+import { renderWithProviders } from "@/tests/render";
+import ApiCredentials from "./ApiCredentials";
+
+describe("ApiCredentials", () => {
+  it("renders API credentials table when user and credentials are loaded", async () => {
+    renderWithProviders(<ApiCredentials />);
+
+    expect(
+      screen.getByRole("heading", { name: "API credentials" }),
+    ).toBeInTheDocument();
+    await expectLoadingState();
+
+    expect(await screen.findByText("test-account")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Generate API credentials" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/activities/ActivitiesPage.test.tsx
+++ b/src/pages/dashboard/activities/ActivitiesPage.test.tsx
@@ -1,0 +1,38 @@
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { setEndpointStatus } from "@/tests/controllers/controller";
+import { expectLoadingState } from "@/tests/helpers";
+import { renderWithProviders } from "@/tests/render";
+import ActivitiesPage from "./ActivitiesPage";
+
+describe("ActivitiesPage", () => {
+  beforeEach(() => {
+    setEndpointStatus("default");
+  });
+
+  it("renders activities page content with list data", async () => {
+    renderWithProviders(<ActivitiesPage />);
+
+    await expectLoadingState();
+
+    expect(
+      screen.getByRole("heading", { name: "Activities" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.queryByText("No activities found")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when activities endpoint is empty", async () => {
+    setEndpointStatus({ status: "empty", path: "activities" });
+
+    renderWithProviders(<ActivitiesPage />);
+
+    await expectLoadingState();
+
+    expect(screen.getByText("No activities found")).toBeInTheDocument();
+    expect(
+      screen.getByText("There are no activities yet."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/instances/InstancesPage/helpers.test.ts
+++ b/src/pages/dashboard/instances/InstancesPage/helpers.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { FILTERS } from "@/features/instances";
+import { getOptionQuery, getQuery } from "./helpers";
+
+const windowsOption = FILTERS.os.options.find(
+  (option) => option.value === "windows",
+);
+const offlineStatusOption = FILTERS.status.options.find(
+  (option) => option.value === "computer-offline",
+);
+const contractOption = FILTERS.contractExpiryDays.options.find(
+  (option) => option.value === "30",
+);
+
+assert(windowsOption);
+assert(offlineStatusOption);
+assert(contractOption);
+
+describe("InstancesPage helpers", () => {
+  it("returns option query for select filters", () => {
+    expect(getOptionQuery(FILTERS.os, windowsOption.value)).toBe(
+      windowsOption.query,
+    );
+  });
+
+  it("returns empty string when select option does not exist", () => {
+    expect(getOptionQuery(FILTERS.os, "missing-option")).toBe("");
+  });
+
+  it("returns empty query for non-select filters", () => {
+    expect(getOptionQuery(FILTERS.wsl, "parent")).toBe("");
+  });
+
+  it("builds combined search query from all active filters", () => {
+    const query = getQuery({
+      os: windowsOption.value,
+      status: offlineStatusOption.value,
+      contractExpiryDays: contractOption.value,
+      query: "name:web,annotation:prod",
+      tags: ["db", "prod"],
+      accessGroups: ["global", "ops"],
+      availabilityZones: ["eu-west-1a", "eu-west-1b"],
+    });
+
+    expect(query).toBe(
+      [
+        windowsOption.query,
+        getOptionQuery(FILTERS.status, offlineStatusOption.value),
+        getOptionQuery(FILTERS.contractExpiryDays, contractOption.value),
+        "name:web",
+        "annotation:prod",
+        "tag:db OR tag:prod",
+        "access-group:global OR access-group:ops",
+        "availability-zone:eu-west-1a OR availability-zone:eu-west-1b",
+      ].join(" "),
+    );
+  });
+
+  it("uses null availability zone query when none is selected", () => {
+    const query = getQuery({
+      os: "",
+      status: "",
+      contractExpiryDays: "",
+      query: "",
+      tags: [],
+      accessGroups: [],
+      availabilityZones: ["none"],
+    });
+
+    expect(query).toBe("availability-zone:null");
+  });
+
+  it("omits availability zone when none are selected", () => {
+    const query = getQuery({
+      os: windowsOption.value,
+      status: "",
+      contractExpiryDays: "",
+      query: "",
+      tags: [],
+      accessGroups: [],
+      availabilityZones: [],
+    });
+
+    expect(query).toBe(windowsOption.query);
+  });
+});

--- a/src/pages/dashboard/instances/ReportForm/ReportForm.test.tsx
+++ b/src/pages/dashboard/instances/ReportForm/ReportForm.test.tsx
@@ -1,0 +1,61 @@
+import { setEndpointStatus } from "@/tests/controllers/controller";
+import { renderWithProviders } from "@/tests/render";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import ReportForm from "./ReportForm";
+
+describe("ReportForm", () => {
+  it("renders report controls", () => {
+    renderWithProviders(<ReportForm instanceIds={[1, 2]} />);
+
+    expect(screen.getByLabelText("Report by CVE")).toBeInTheDocument();
+    expect(screen.getByLabelText("Range")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Download" }),
+    ).toBeInTheDocument();
+  });
+
+  it("downloads CSV when submitting the form", async () => {
+    const user = userEvent.setup();
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+    const createObjectUrl = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:report");
+
+    renderWithProviders(<ReportForm instanceIds={[3]} />);
+
+    await user.click(screen.getByRole("button", { name: "Download" }));
+
+    expect(createObjectUrl).toHaveBeenCalledTimes(1);
+
+    const [csvBlob] = createObjectUrl.mock.calls[0] ?? [];
+    expect(csvBlob).toBeInstanceOf(Blob);
+    expect(await (csvBlob as Blob).text()).toContain("name,status");
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    clickSpy.mockRestore();
+    createObjectUrl.mockRestore();
+  });
+
+  it("downloads empty CSV when endpoint is empty", async () => {
+    const user = userEvent.setup();
+    const createObjectUrl = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:report");
+    setEndpointStatus({ status: "empty", path: "reports" });
+
+    renderWithProviders(<ReportForm instanceIds={[3]} />);
+
+    await user.click(screen.getByRole("button", { name: "Download" }));
+
+    const [csvBlob] = createObjectUrl.mock.calls[0] ?? [];
+    expect(csvBlob).toBeInstanceOf(Blob);
+    expect(await (csvBlob as Blob).text()).toBe("");
+
+    createObjectUrl.mockRestore();
+  });
+});

--- a/src/pages/dashboard/instances/[single]/SingleInstanceContainer/SingleInstanceContainer.test.tsx
+++ b/src/pages/dashboard/instances/[single]/SingleInstanceContainer/SingleInstanceContainer.test.tsx
@@ -1,35 +1,141 @@
-import { ubuntuCoreInstance } from "@/tests/mocks/instance";
+import { renderWithProviders } from "@/tests/render";
+import { PATHS, ROUTES } from "@/libs/routes";
+import { render, screen } from "@testing-library/react";
 import { describe } from "vitest";
-import {
-  isInstancePackagesQueryEnabled,
-  isLivepatchInfoQueryEnabled,
-  isUsnQueryEnabled,
-} from "./helpers";
+import userEvent from "@testing-library/user-event";
+import SingleInstanceContainer from "./SingleInstanceContainer";
+import { AuthContext } from "@/context/auth";
+import { authUser } from "@/tests/mocks/auth";
+import { AppProviders } from "@/providers/AppProviders";
+import { useState } from "react";
+import { MemoryRouter, Route, Routes } from "react-router";
+
+const INSTANCE_ID = 11;
+const INSTANCE_WITHOUT_DISTRIBUTION_ID = 12;
+const MISSING_INSTANCE_ID = 99999;
 
 describe("SingleInstanceContainer", () => {
-  describe("isInstancePackagesQueryEnabled", () => {
-    it("should be false for an ubuntu core instance", () => {
-      assert(
-        !isInstancePackagesQueryEnabled(
-          ubuntuCoreInstance,
-          undefined,
-          undefined,
-        ),
+  describe("component", () => {
+    it("renders tabs for a found instance", async () => {
+      renderWithProviders(
+        <SingleInstanceContainer />,
+        undefined,
+        ROUTES.instances.details.single(INSTANCE_ID, { tab: "activities" }),
+        `/${PATHS.instances.root}/${PATHS.instances.single}`,
       );
-    });
-  });
 
-  describe("isLivepatchInfoQueryEnabled", () => {
-    it("should be false for an ubuntu core instance", () => {
-      assert(
-        !isLivepatchInfoQueryEnabled(ubuntuCoreInstance, undefined, undefined),
+      expect(
+        await screen.findByRole("tab", { name: "Info" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("tab", { name: "Activities" }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders empty state when instance is not found", async () => {
+      renderWithProviders(
+        <SingleInstanceContainer />,
+        undefined,
+        ROUTES.instances.details.single(MISSING_INSTANCE_ID, { tab: "info" }),
+        `/${PATHS.instances.root}/${PATHS.instances.single}`,
       );
-    });
-  });
 
-  describe("isUsnQueryEnabled", () => {
-    it("should be false for an ubuntu core instance", () => {
-      assert(!isUsnQueryEnabled(ubuntuCoreInstance, undefined, undefined));
+      expect(await screen.findByText("Instance not found")).toBeInTheDocument();
+    });
+
+    it("renders details for instances without distribution data", async () => {
+      renderWithProviders(
+        <SingleInstanceContainer />,
+        undefined,
+        ROUTES.instances.details.single(INSTANCE_WITHOUT_DISTRIBUTION_ID, {
+          tab: "activities",
+        }),
+        `/${PATHS.instances.root}/${PATHS.instances.single}`,
+      );
+
+      expect(
+        await screen.findByRole("tab", { name: "Info" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("tab", { name: "Activities" }),
+      ).toBeInTheDocument();
+    });
+
+    it("redirects to root route when current account changes", async () => {
+      const user = userEvent.setup();
+
+      const AccountSwitchHarness = () => {
+        const [currentAccount, setCurrentAccount] = useState("account-a");
+
+        const userWithCurrentAccount = {
+          ...authUser,
+          current_account: currentAccount,
+          accounts: [
+            {
+              ...authUser.accounts[0],
+              name: currentAccount,
+              title: currentAccount,
+              subdomain: null,
+              classic_dashboard_url: "",
+            },
+          ],
+        };
+
+        return (
+          <AuthContext.Provider
+            value={{
+              authLoading: false,
+              authorized: true,
+              hasAccounts: true,
+              isFeatureEnabled: () => true,
+              logout: vi.fn(),
+              redirectToExternalUrl: vi.fn(),
+              safeRedirect: vi.fn(),
+              setUser: vi.fn(),
+              user: userWithCurrentAccount,
+            }}
+          >
+            <button
+              type="button"
+              onClick={() => {
+                setCurrentAccount("account-b");
+              }}
+            >
+              Switch account
+            </button>
+            <SingleInstanceContainer />
+          </AuthContext.Provider>
+        );
+      };
+
+      render(
+        <MemoryRouter
+          initialEntries={[ROUTES.instances.details.single(INSTANCE_ID)]}
+        >
+          <AppProviders>
+            <Routes>
+              <Route
+                path={`/${PATHS.instances.root}`}
+                element={<p>Instances root page</p>}
+              />
+              <Route
+                path={`/${PATHS.instances.root}/${PATHS.instances.single}`}
+                element={<AccountSwitchHarness />}
+              />
+            </Routes>
+          </AppProviders>
+        </MemoryRouter>,
+      );
+
+      expect(
+        await screen.findByRole("tab", { name: "Info" }),
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Switch account" }));
+
+      expect(
+        await screen.findByText("Instances root page"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/pages/dashboard/instances/[single]/SingleInstanceContainer/helpers.test.ts
+++ b/src/pages/dashboard/instances/[single]/SingleInstanceContainer/helpers.test.ts
@@ -1,0 +1,203 @@
+import { ROUTES } from "@/libs/routes";
+import {
+  instances,
+  ubuntuCoreInstance,
+  ubuntuInstance,
+  windowsInstance,
+} from "@/tests/mocks/instance";
+import { describe, expect, it } from "vitest";
+import {
+  getBreadcrumbs,
+  getInstanceRequestId,
+  getInstanceTitle,
+  getKernelCount,
+  getPackageCount,
+  getQueryComputerIdsParam,
+  getQueryInstanceIdParam,
+  getUsnCount,
+  isInstanceFound,
+  isInstancePackagesQueryEnabled,
+  isInstanceQueryEnabled,
+  isLivepatchInfoQueryEnabled,
+  isUsnQueryEnabled,
+} from "./helpers";
+
+const INSTANCE_ID = 11;
+const CHILD_INSTANCE_ID = 22;
+const childWithParent = instances.find(
+  (instance) => instance.parent?.id === windowsInstance.id,
+);
+
+assert(childWithParent);
+assert(childWithParent.parent);
+const parentInstance = childWithParent.parent;
+
+describe("SingleInstanceContainer helpers", () => {
+  it("returns false for package-like query enablement on ubuntu core instances", () => {
+    expect(
+      isInstancePackagesQueryEnabled(ubuntuCoreInstance, undefined, undefined),
+    ).toBe(false);
+    expect(
+      isLivepatchInfoQueryEnabled(ubuntuCoreInstance, undefined, undefined),
+    ).toBe(false);
+    expect(isUsnQueryEnabled(ubuntuCoreInstance, undefined, undefined)).toBe(
+      false,
+    );
+  });
+
+  it("returns child instance id when child id is provided", () => {
+    expect(
+      getInstanceRequestId(String(INSTANCE_ID), String(CHILD_INSTANCE_ID)),
+    ).toBe(CHILD_INSTANCE_ID);
+  });
+
+  it("returns parent instance id when child id is not provided", () => {
+    expect(getInstanceRequestId(String(INSTANCE_ID), undefined)).toBe(
+      INSTANCE_ID,
+    );
+  });
+
+  it("returns empty title when instance is undefined", () => {
+    expect(getInstanceTitle(undefined)).toBe("");
+  });
+
+  it("returns breadcrumbs for a top-level instance", () => {
+    expect(getBreadcrumbs(ubuntuInstance)).toEqual([
+      { label: "Instances", path: ROUTES.instances.root() },
+      { label: ubuntuInstance.title, current: true },
+    ]);
+  });
+
+  it("returns breadcrumbs for a child instance", () => {
+    expect(getBreadcrumbs(childWithParent)).toEqual([
+      { label: "Instances", path: ROUTES.instances.root() },
+      {
+        label: parentInstance.title,
+        path: ROUTES.instances.details.single(parentInstance.id),
+      },
+      { label: childWithParent.title, current: true },
+    ]);
+  });
+
+  it("returns undefined breadcrumbs when instance is missing", () => {
+    expect(getBreadcrumbs(undefined)).toBeUndefined();
+  });
+
+  it("returns kernel count when livepatch fixes are available", () => {
+    expect(
+      getKernelCount([
+        {
+          Livepatch: {
+            Fixes: [{}, {}],
+          },
+        },
+      ] as never),
+    ).toBe(2);
+  });
+
+  it("returns undefined kernel count for missing livepatch data", () => {
+    expect(getKernelCount(undefined)).toBeUndefined();
+    expect(getKernelCount([])).toBeUndefined();
+    expect(
+      getKernelCount([
+        {
+          Livepatch: {},
+        },
+      ] as never),
+    ).toBeUndefined();
+  });
+
+  it("returns request package and usn counts only when instance has a distribution", () => {
+    const noDistributionInstance = { ...ubuntuInstance, distribution: "" };
+
+    expect(getPackageCount(ubuntuInstance, 7)).toBe(7);
+    expect(getUsnCount(ubuntuInstance, 5)).toBe(5);
+    expect(getPackageCount(noDistributionInstance, 7)).toBe(0);
+    expect(getUsnCount(noDistributionInstance, 5)).toBe(0);
+  });
+
+  it("evaluates instance-query enablement based on account consistency", () => {
+    expect(isInstanceQueryEnabled(undefined, undefined, undefined)).toBe(false);
+    expect(isInstanceQueryEnabled("11", undefined, "account-a")).toBe(true);
+    expect(isInstanceQueryEnabled("11", "account-a", "account-a")).toBe(true);
+    expect(isInstanceQueryEnabled("11", "account-a", "account-b")).toBe(false);
+  });
+
+  it("returns query params derived from instance", () => {
+    expect(getQueryComputerIdsParam(ubuntuInstance)).toEqual([
+      ubuntuInstance.id,
+    ]);
+    expect(getQueryComputerIdsParam(undefined)).toEqual([]);
+    expect(getQueryInstanceIdParam(ubuntuInstance)).toBe(ubuntuInstance.id);
+    expect(getQueryInstanceIdParam(undefined)).toBe(0);
+  });
+
+  it("enables package-like queries only when child-parent relation matches", () => {
+    expect(isInstancePackagesQueryEnabled(ubuntuInstance, "1", undefined)).toBe(
+      true,
+    );
+    expect(isLivepatchInfoQueryEnabled(ubuntuInstance, "1", undefined)).toBe(
+      true,
+    );
+    expect(isUsnQueryEnabled(ubuntuInstance, "1", undefined)).toBe(true);
+    expect(
+      isInstancePackagesQueryEnabled(
+        childWithParent,
+        String(windowsInstance.id),
+        "22",
+      ),
+    ).toBe(false);
+    expect(
+      isInstancePackagesQueryEnabled(
+        childWithParent,
+        String(ubuntuInstance.id),
+        "22",
+      ),
+    ).toBe(false);
+    expect(
+      isLivepatchInfoQueryEnabled(
+        childWithParent,
+        String(windowsInstance.id),
+        "22",
+      ),
+    ).toBe(false);
+    expect(
+      isUsnQueryEnabled(childWithParent, String(windowsInstance.id), "22"),
+    ).toBe(false);
+  });
+
+  it("returns null when child instance id is provided but instance has no parent", () => {
+    expect(isInstanceFound(ubuntuInstance, String(INSTANCE_ID), "22")).toBe(
+      null,
+    );
+  });
+
+  it("returns true when child belongs to parent instance", () => {
+    expect(
+      isInstanceFound(
+        childWithParent,
+        String(windowsInstance.id),
+        String(INSTANCE_ID),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when child does not belong to parent instance", () => {
+    expect(
+      isInstanceFound(
+        childWithParent,
+        String(ubuntuInstance.id),
+        String(INSTANCE_ID),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns instance itself when there is no child constraint", () => {
+    expect(
+      isInstanceFound(ubuntuInstance, String(ubuntuInstance.id), undefined),
+    ).toBe(true);
+    expect(
+      isInstanceFound(undefined, String(ubuntuInstance.id), undefined),
+    ).toBe(undefined);
+  });
+});

--- a/src/pages/dashboard/instances/[single]/tabs/info/AssignEmployeeToInstanceForm/AssignEmployeeToInstanceForm.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/info/AssignEmployeeToInstanceForm/AssignEmployeeToInstanceForm.test.tsx
@@ -1,19 +1,28 @@
 import { renderWithProviders } from "@/tests/render";
+import { PATHS, ROUTES } from "@/libs/routes";
 import { screen } from "@testing-library/react";
 import type { ComponentProps } from "react";
 import { describe, expect } from "vitest";
 import AssignEmployeeToInstanceForm from "./AssignEmployeeToInstanceForm";
 import userEvent from "@testing-library/user-event";
+import { setEndpointStatus } from "@/tests/controllers/controller";
 
 const props: ComponentProps<typeof AssignEmployeeToInstanceForm> = {
   instanceTitle: "Test Instance",
 };
 
+const routePattern = `/${PATHS.instances.root}/${PATHS.instances.single}`;
+
 describe("AssignEmployeeToInstanceForm", () => {
   const user = userEvent.setup();
 
   beforeEach(async () => {
-    renderWithProviders(<AssignEmployeeToInstanceForm {...props} />);
+    renderWithProviders(
+      <AssignEmployeeToInstanceForm {...props} />,
+      undefined,
+      ROUTES.instances.details.single(1),
+      routePattern,
+    );
   });
 
   it("renders form correctly", () => {
@@ -38,5 +47,57 @@ describe("AssignEmployeeToInstanceForm", () => {
 
     const errorMessage = screen.getByText(/This field is required./i);
     expect(errorMessage).toBeInTheDocument();
+  });
+
+  it("clears validation error after selecting an employee", async () => {
+    await user.click(screen.getByRole("button", { name: /Associate/i }));
+    expect(screen.getByText(/This field is required./i)).toBeInTheDocument();
+
+    const search = screen.getByRole("searchbox", {
+      name: /search for an employee/i,
+    });
+
+    await user.type(search, "John");
+    await user.click(await screen.findByTestId("dropdownElement"));
+
+    expect(
+      screen.queryByText(/This field is required./i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows success notification when associating an employee", async () => {
+    const search = screen.getByRole("searchbox", {
+      name: /search for an employee/i,
+    });
+
+    await user.type(search, "John");
+    await user.click(await screen.findByTestId("dropdownElement"));
+    await user.click(screen.getByRole("button", { name: /Associate/i }));
+
+    expect(
+      await screen.findByText(
+        "John Doe has been successfully associated with Test Instance.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("form")).not.toBeInTheDocument();
+  });
+
+  it("shows an error notification when association fails", async () => {
+    const search = screen.getByRole("searchbox", {
+      name: /search for an employee/i,
+    });
+
+    setEndpointStatus({
+      status: "error",
+      path: "associateEmployeeWithInstance",
+    });
+
+    await user.type(search, "John");
+    await user.click(await screen.findByTestId("dropdownElement"));
+    await user.click(screen.getByRole("button", { name: /Associate/i }));
+
+    expect(
+      await screen.findByText('The endpoint status is set to "error".'),
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/dashboard/instances/[single]/tabs/info/EditInstance/EditInstance.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/info/EditInstance/EditInstance.test.tsx
@@ -1,0 +1,200 @@
+import { setEndpointStatus } from "@/tests/controllers/controller";
+import { ubuntuInstance } from "@/tests/mocks/instance";
+import { PATHS, ROUTES } from "@/libs/routes";
+import { renderWithProviders } from "@/tests/render";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import EditInstance from "./EditInstance";
+
+const routePattern = `/${PATHS.instances.root}/${PATHS.instances.single}`;
+const routePath = ROUTES.instances.details.single(1);
+
+describe("EditInstance", () => {
+  it("renders editable fields and access group options", async () => {
+    renderWithProviders(
+      <EditInstance instance={ubuntuInstance} />,
+      undefined,
+      routePath,
+      routePattern,
+    );
+
+    expect(await screen.findByRole("textbox", { name: "Title" })).toHaveValue(
+      "Application Server 1",
+    );
+    expect(
+      screen.getByRole("combobox", { name: "Access group" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Global access" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Comment" })).toHaveValue(
+      "my awesome instance comment",
+    );
+  });
+
+  it("disables title editing for WSL instances", async () => {
+    renderWithProviders(
+      <EditInstance instance={{ ...ubuntuInstance, is_wsl_instance: true }} />,
+      undefined,
+      routePath,
+      routePattern,
+    );
+
+    expect(
+      await screen.findByRole("textbox", { name: "Title" }),
+    ).toBeDisabled();
+  });
+
+  it("shows tag confirmation modal when adding a new tag", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <EditInstance instance={ubuntuInstance} />,
+      undefined,
+      routePath,
+      routePattern,
+    );
+
+    await screen.findByRole("textbox", { name: "Title" });
+
+    await user.click(screen.getByPlaceholderText("Add tags"));
+    await user.click(await screen.findByRole("button", { name: "asd" }));
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(
+      await screen.findByText(
+        "Adding tags could trigger irreversible changes to your instances.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("submits directly when no tags were added", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <EditInstance instance={ubuntuInstance} />,
+      undefined,
+      routePath,
+      routePattern,
+    );
+
+    const titleInput = await screen.findByRole("textbox", { name: "Title" });
+    await user.clear(titleInput);
+    await user.type(titleInput, "Renamed instance");
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(await screen.findByText("Instance updated")).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Adding tags could trigger irreversible changes to your instances.",
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add tags" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("submits from tag confirmation modal", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <EditInstance instance={ubuntuInstance} />,
+      undefined,
+      routePath,
+      routePattern,
+    );
+
+    await screen.findByRole("textbox", { name: "Title" });
+    await user.click(screen.getByPlaceholderText("Add tags"));
+    await user.click(await screen.findByRole("button", { name: "asd" }));
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+    await user.click(await screen.findByRole("button", { name: "Add tags" }));
+
+    expect(await screen.findByText("Instance updated")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add tags" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows error notification when edit fails", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "error", path: "editInstance" });
+
+    renderWithProviders(
+      <EditInstance instance={ubuntuInstance} />,
+      undefined,
+      routePath,
+      routePattern,
+    );
+
+    await screen.findByRole("textbox", { name: "Title" });
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(
+      await screen.findByText('The endpoint status is set to "error".'),
+    ).toBeInTheDocument();
+  });
+
+  it("shows endpoint error when profile-diff request fails", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "error", path: "tags/profile-diff" });
+
+    renderWithProviders(
+      <EditInstance instance={ubuntuInstance} />,
+      undefined,
+      routePath,
+      routePattern,
+    );
+
+    await screen.findByRole("textbox", { name: "Title" });
+    await user.click(screen.getByPlaceholderText("Add tags"));
+    await user.click(await screen.findByRole("button", { name: "asd" }));
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(
+      await screen.findByText('The endpoint status is set to "error".'),
+    ).toBeInTheDocument();
+  });
+
+  it("submits directly when profile-diff result is empty", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "empty", path: "tags/profile-diff" });
+
+    renderWithProviders(
+      <EditInstance instance={ubuntuInstance} />,
+      undefined,
+      routePath,
+      routePattern,
+    );
+
+    await screen.findByRole("textbox", { name: "Title" });
+    await user.click(screen.getByPlaceholderText("Add tags"));
+    await user.click(await screen.findByRole("button", { name: "asd" }));
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(await screen.findByText("Instance updated")).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Adding tags could trigger irreversible changes to your instances.",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders when access groups request fails", async () => {
+    setEndpointStatus({ status: "error", path: "GetAccessGroups" });
+
+    renderWithProviders(
+      <EditInstance instance={ubuntuInstance} />,
+      undefined,
+      routePath,
+      routePattern,
+    );
+
+    expect(
+      await screen.findByRole("combobox", { name: "Access group" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "Global access" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/instances/[single]/tabs/packages/PackagesPanel/helpers.test.ts
+++ b/src/pages/dashboard/instances/[single]/tabs/packages/PackagesPanel/helpers.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { getEmptyMessage } from "./helpers";
+
+describe("PackagesPanel helpers", () => {
+  it("returns empty-state messages by package filter", () => {
+    expect(getEmptyMessage("", "")).toBe("No packages found.");
+    expect(getEmptyMessage("upgrade", "")).toBe("No available upgrades found.");
+    expect(getEmptyMessage("security", "")).toBe(
+      "No available security upgrades found.",
+    );
+    expect(getEmptyMessage("installed", "")).toBe(
+      "No installed packages found.",
+    );
+    expect(getEmptyMessage("held", "")).toBe("No held packages found.");
+  });
+
+  it("appends package search term when provided", () => {
+    expect(getEmptyMessage("upgrade", "openssl")).toBe(
+      'No available upgrades found with the search "openssl".',
+    );
+  });
+});

--- a/src/pages/dashboard/instances/[single]/tabs/users/EditUserForm/EditUserForm.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/EditUserForm/EditUserForm.test.tsx
@@ -1,24 +1,34 @@
+import { PATHS, ROUTES } from "@/libs/routes";
+import { setEndpointStatus } from "@/tests/controllers/controller";
 import { users } from "@/tests/mocks/user";
+import { userGroups } from "@/tests/mocks/userGroup";
 import { renderWithProviders } from "@/tests/render";
-import { screen, within } from "@testing-library/react";
+import type { User } from "@/types/User";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import EditUserForm from "./EditUserForm";
 
-const props = {
-  instanceId: 1,
-  user: users[0],
-};
+const routePattern = `/${PATHS.instances.root}/${PATHS.instances.single}`;
+
+const renderEditUserForm = (user: User = users[0]) =>
+  renderWithProviders(
+    <EditUserForm user={user} />,
+    undefined,
+    ROUTES.instances.details.single(1),
+    routePattern,
+  );
 
 describe("EditUserForm", () => {
-  beforeEach(() => {
-    renderWithProviders(<EditUserForm {...props} />);
-  });
   it("renders the form", () => {
+    renderEditUserForm();
+
     const form = screen.getByRole("form");
     expect(form).toBeInTheDocument();
   });
 
   it("renders form fields", () => {
+    renderEditUserForm();
+
     const form = screen.getByRole("form");
     expect(form).toHaveTexts([
       "Username",
@@ -34,32 +44,149 @@ describe("EditUserForm", () => {
   });
 
   it("renders form fields with user data", () => {
+    renderEditUserForm();
+
     const form = screen.getByRole("form");
     expect(form).toHaveInputValues([
-      props.user.username,
-      props.user.name ?? "",
-      props.user.location ?? "",
-      props.user.home_phone ?? "",
-      props.user.work_phone ?? "",
+      users[0].username,
+      users[0].name ?? "",
+      users[0].location ?? "",
+      users[0].home_phone ?? "",
+      users[0].work_phone ?? "",
+    ]);
+  });
+
+  it("renders empty optional profile fields when missing", () => {
+    const userWithoutProfileDetails: User = {
+      ...users[8],
+      name: undefined,
+      location: undefined,
+      home_phone: undefined,
+      work_phone: undefined,
+    };
+
+    renderEditUserForm(userWithoutProfileDetails);
+
+    const form = screen.getByRole("form");
+    expect(form).toHaveInputValues([
+      userWithoutProfileDetails.username,
+      "",
+      "",
+      "",
+      "",
     ]);
   });
 
   it("can edit user data", async () => {
+    renderEditUserForm();
+
     const form = screen.getByRole("form");
     let username;
-    if (props.user.name === props.user.username) {
+    if (users[0].name === users[0].username) {
       const inputs = await within(form).findAllByDisplayValue(
-        props.user.username,
+        users[0].username,
       );
       [username] = inputs;
       assert(username !== undefined);
     } else {
-      username = await within(form).findByDisplayValue(props.user.username);
+      username = await within(form).findByDisplayValue(users[0].username);
     }
 
     await userEvent.clear(username);
     await userEvent.type(username, "newusername");
 
     expect(form).toHaveInputValues(["newusername"]);
+  });
+
+  it("shows validation error when confirm password does not match", async () => {
+    const user = userEvent.setup();
+    renderEditUserForm();
+
+    await user.type(screen.getByLabelText("Password"), "new-password");
+    await user.type(
+      screen.getByLabelText("Confirm password"),
+      "different-password",
+    );
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(await screen.findByText("Passwords must match")).toBeInTheDocument();
+  });
+
+  it("submits and shows success notification", async () => {
+    const user = userEvent.setup();
+    renderEditUserForm();
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(
+      await screen.findByText("User updated successfully"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows endpoint error notification on submit failure", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "error", path: "users" });
+    renderEditUserForm();
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('The endpoint status is set to "error".'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("adds a newly selected additional group", async () => {
+    const user = userEvent.setup();
+    const daemonGroup = userGroups.find((entry) => entry.name === "daemon");
+    const binGroup = userGroups.find((entry) => entry.name === "bin");
+    assert(daemonGroup);
+    assert(binGroup);
+
+    setEndpointStatus({ status: "default", path: "users/groups:daemon" });
+    renderEditUserForm();
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Additional Groups" }),
+    );
+    await user.click(
+      await screen.findByRole("checkbox", { name: binGroup.name }),
+    );
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(
+      await screen.findByText("User updated successfully"),
+    ).toBeInTheDocument();
+  });
+
+  it("submits when no additional groups are assigned", async () => {
+    const user = userEvent.setup();
+
+    setEndpointStatus({ status: "empty", path: "users/groups" });
+    renderEditUserForm();
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(
+      await screen.findByText("User updated successfully"),
+    ).toBeInTheDocument();
+  });
+
+  it("allows changing additional groups selection", async () => {
+    const user = userEvent.setup();
+    const group = userGroups.find((entry) => entry.name === "daemon");
+    assert(group);
+    renderEditUserForm();
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Additional Groups" }),
+    );
+    await user.click(await screen.findByRole("checkbox", { name: group.name }));
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(
+      await screen.findByText("User updated successfully"),
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/dashboard/instances/[single]/tabs/users/UserList/UserList.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/UserList/UserList.test.tsx
@@ -1,5 +1,5 @@
-import NoData from "@/components/layout/NoData";
-import { expectLoadingState, setScreenSize } from "@/tests/helpers";
+import NoData, { NO_DATA_TEXT } from "@/components/layout/NoData";
+import { setScreenSize } from "@/tests/helpers";
 import { users } from "@/tests/mocks/user";
 import { userGroups } from "@/tests/mocks/userGroup";
 import { renderWithProviders } from "@/tests/render";
@@ -67,6 +67,18 @@ describe("UserList", () => {
       expect(checkedCheckboxes).toHaveLength(userIds.length + 1);
     });
 
+    it("should clear all selected users when clicking ToggleAll with selected users", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<UserList {...props} selected={userIds} />);
+
+      const toggleAllCheckbox = await screen.findByRole("checkbox", {
+        name: /toggle all/i,
+      });
+      await user.click(toggleAllCheckbox);
+
+      expect(props.setSelected).toHaveBeenCalledWith([]);
+    });
+
     it("should select user when clicking on its row checkbox", async () => {
       renderWithProviders(<UserList {...props} />);
 
@@ -80,12 +92,29 @@ describe("UserList", () => {
 
       expect(props.setSelected).toHaveBeenCalledWith([selectedUser.uid]);
     });
+
+    it("should unselect user when clicking an already selected row checkbox", async () => {
+      const user = userEvent.setup();
+      const [selectedUser] = users;
+      assert(selectedUser);
+
+      renderWithProviders(
+        <UserList {...props} selected={[selectedUser.uid]} />,
+      );
+
+      const userCheckbox = await screen.findByRole("checkbox", {
+        name: `Select user ${selectedUser.username}`,
+      });
+      await user.click(userCheckbox);
+
+      expect(props.setSelected).toHaveBeenCalledWith([]);
+    });
   });
 
   describe("User details sidepanel", () => {
     beforeEach(() => {
-      renderWithProviders(<UserList {...props} />);
       setScreenSize("lg");
+      renderWithProviders(<UserList {...props} />);
     });
     it("should open side panel when user in table is clicked", async () => {
       const user = await screen.findByRole("button", {
@@ -109,12 +138,11 @@ describe("UserList", () => {
       await userEvent.click(userTableButton);
 
       const form = await screen.findByRole("complementary");
-
-      await expectLoadingState();
-
+      await within(form).findByRole("button", { name: "Unlock" });
       buttonNames.forEach((buttonName) => {
-        const button = within(form).getByText(buttonName);
-        expect(button).toBeInTheDocument();
+        expect(
+          within(form).getByRole("button", { name: buttonName }),
+        ).toBeInTheDocument();
       });
     });
 
@@ -128,9 +156,11 @@ describe("UserList", () => {
       const form = await screen.findByRole("complementary");
       const buttonsNames = ["Lock", "Edit", "Delete"];
 
+      await within(form).findByRole("button", { name: "Lock" });
       buttonsNames.forEach((buttonName) => {
-        const button = within(form).getByText(buttonName);
-        expect(button).toBeInTheDocument();
+        expect(
+          within(form).getByRole("button", { name: buttonName }),
+        ).toBeInTheDocument();
       });
     });
 
@@ -148,7 +178,11 @@ describe("UserList", () => {
         userGroups.find((group) => group.gid === user.primary_gid)?.name ?? "";
 
       const groupsData = userGroups.map((group) => group.name).join(", ");
-      const loaded = await screen.findByText(primaryGroup);
+      const loaded = await within(form).findByText(
+        primaryGroup,
+        {},
+        { timeout: 5000 },
+      );
       expect(loaded).toBeInTheDocument();
       const getFieldsToCheck = (item: User) => {
         return [
@@ -167,5 +201,42 @@ describe("UserList", () => {
         expect(form).toHaveInfoItem(field.label, field.value);
       });
     });
+
+    it("should open edit user side panel from list actions", async () => {
+      const user = userEvent.setup();
+      const [firstUser] = users;
+      assert(firstUser);
+
+      const actionsToggle = await screen.findByRole("button", {
+        name: `"${firstUser.name}" user actions`,
+      });
+      await user.click(actionsToggle);
+
+      await user.click(await screen.findByText("Edit"));
+
+      const sidePanel = await screen.findByRole("complementary");
+      expect(within(sidePanel).getByText("Edit user")).toBeInTheDocument();
+    });
+  });
+
+  it("shows no-data marker when a user has no full name", async () => {
+    const userWithoutName = {
+      ...users[0],
+      uid: 999,
+      username: "no-name-user",
+      name: "",
+    };
+
+    renderWithProviders(
+      <UserList {...props} users={[userWithoutName]} selected={[]} />,
+    );
+
+    const detailsButton = await screen.findByRole("button", {
+      name: `Show details of user ${userWithoutName.username}`,
+    });
+    const row = detailsButton.closest("tr");
+    assert(row);
+
+    expect(within(row).getByText(NO_DATA_TEXT)).toBeInTheDocument();
   });
 });

--- a/src/pages/dashboard/instances/[single]/tabs/users/UserList/helpers.test.ts
+++ b/src/pages/dashboard/instances/[single]/tabs/users/UserList/helpers.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import type { Cell } from "react-table";
+import type { User } from "@/types/User";
+import { handleCellProps } from "./helpers";
+
+const toCell = (id: string) => {
+  return { column: { id } } as unknown as Cell<User>;
+};
+
+describe("UserList helpers", () => {
+  it("adds rowheader role for username cells", () => {
+    expect(handleCellProps(toCell("username"))).toEqual({
+      role: "rowheader",
+    });
+  });
+
+  it("adds accessibility labels for known columns", () => {
+    expect(handleCellProps(toCell("enabled"))).toEqual({
+      "aria-label": "Status",
+    });
+    expect(handleCellProps(toCell("uid"))).toEqual({
+      "aria-label": "User id",
+    });
+    expect(handleCellProps(toCell("name"))).toEqual({
+      "aria-label": "Full name",
+    });
+  });
+
+  it("returns empty props for unknown columns", () => {
+    expect(handleCellProps(toCell("shell"))).toEqual({});
+  });
+});

--- a/src/pages/dashboard/instances/[single]/tabs/users/UserPanelActionButtons/UserPanelActionButtons.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/UserPanelActionButtons/UserPanelActionButtons.test.tsx
@@ -1,9 +1,12 @@
 import { resetScreenSize, setScreenSize } from "@/tests/helpers";
 import "@/tests/matcher";
+import { PATHS, ROUTES } from "@/libs/routes";
+import { setEndpointStatus } from "@/tests/controllers/controller";
 import { users } from "@/tests/mocks/user";
 import { renderWithProviders } from "@/tests/render";
-import { screen } from "@testing-library/react";
-import { describe, vi } from "vitest";
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, vi } from "vitest";
 import { getSelectedUsers } from "../UserPanelHeader/helpers";
 import UserPanelActionButtons from "./UserPanelActionButtons";
 
@@ -27,6 +30,8 @@ const mixedSelectedUsers = [
 const tableUserButtons = ["Add user", "Lock", "Unlock", "Delete"];
 const formLockedUserButtons = ["Unlock", "Edit", "Delete"];
 const formUnlockedUserButtons = ["Lock", "Edit", "Delete"];
+const routePattern = `/${PATHS.instances.root}/${PATHS.instances.single}`;
+const routePath = ROUTES.instances.details.single(1);
 
 describe("UserPanelActionButtons", () => {
   beforeEach(() => {
@@ -44,8 +49,31 @@ describe("UserPanelActionButtons", () => {
           selectedUsers={getSelectedUsers(users, userData.empty)}
           handleClearSelection={vi.fn()}
         />,
+        undefined,
+        routePath,
+        routePattern,
       );
       expect(container).toHaveTexts(tableUserButtons);
+    });
+
+    it("opens add user side panel from table action", async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <UserPanelActionButtons
+          selectedUsers={getSelectedUsers(users, userData.empty)}
+          handleClearSelection={vi.fn()}
+        />,
+        undefined,
+        routePath,
+        routePattern,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Add user" }));
+
+      expect(
+        await screen.findByText("Require password reset"),
+      ).toBeInTheDocument();
     });
 
     describe("Check button disabled statuses", () => {
@@ -55,6 +83,9 @@ describe("UserPanelActionButtons", () => {
             selectedUsers={getSelectedUsers(users, userData.empty)}
             handleClearSelection={vi.fn()}
           />,
+          undefined,
+          routePath,
+          routePattern,
         );
 
         for (const button of tableUserButtons) {
@@ -77,6 +108,9 @@ describe("UserPanelActionButtons", () => {
             )}
             handleClearSelection={vi.fn()}
           />,
+          undefined,
+          routePath,
+          routePattern,
         );
         const unlockButton = screen.getByRole("button", { name: "Unlock" });
         expect(unlockButton).toHaveAttribute("aria-disabled");
@@ -91,6 +125,9 @@ describe("UserPanelActionButtons", () => {
             )}
             handleClearSelection={vi.fn()}
           />,
+          undefined,
+          routePath,
+          routePattern,
         );
         const lockButton = screen.getByRole("button", { name: "Lock" });
         expect(lockButton).toHaveAttribute("aria-disabled");
@@ -102,6 +139,9 @@ describe("UserPanelActionButtons", () => {
             selectedUsers={getSelectedUsers(users, mixedSelectedUsers)}
             handleClearSelection={vi.fn()}
           />,
+          undefined,
+          routePath,
+          routePattern,
         );
         const lockButton = screen.getByRole("button", { name: "Lock" });
         const unlockButton = screen.getByRole("button", { name: "Unlock" });
@@ -121,6 +161,9 @@ describe("UserPanelActionButtons", () => {
           handleClearSelection={vi.fn()}
           sidePanel
         />,
+        undefined,
+        routePath,
+        routePattern,
       );
 
       expect(container).toHaveTexts(formLockedUserButtons);
@@ -135,9 +178,283 @@ describe("UserPanelActionButtons", () => {
           handleClearSelection={vi.fn()}
           sidePanel
         />,
+        undefined,
+        routePath,
+        routePattern,
       );
 
       expect(container).toHaveTexts(formUnlockedUserButtons);
+    });
+
+    it("does not render edit button for multiple selected users in sidepanel", () => {
+      renderWithProviders(
+        <UserPanelActionButtons
+          selectedUsers={getSelectedUsers(users, mixedSelectedUsers)}
+          handleClearSelection={vi.fn()}
+          sidePanel
+        />,
+        undefined,
+        routePath,
+        routePattern,
+      );
+
+      expect(
+        screen.queryByRole("button", { name: "Edit" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not render add user button in sidepanel", () => {
+      renderWithProviders(
+        <UserPanelActionButtons
+          selectedUsers={getSelectedUsers(users, [userData.single.lockedUser])}
+          handleClearSelection={vi.fn()}
+          sidePanel
+        />,
+        undefined,
+        routePath,
+        routePattern,
+      );
+
+      expect(
+        screen.queryByRole("button", { name: "Add user" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("opens edit user form from sidepanel action", async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <UserPanelActionButtons
+          selectedUsers={getSelectedUsers(users, [userData.single.lockedUser])}
+          handleClearSelection={vi.fn()}
+          sidePanel
+        />,
+        undefined,
+        routePath,
+        routePattern,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Edit" }));
+
+      expect(await screen.findByRole("form")).toBeInTheDocument();
+      expect(screen.getByText("Confirm password")).toBeInTheDocument();
+    });
+
+    it("opens lock confirmation and submits lock action", async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <UserPanelActionButtons
+          selectedUsers={getSelectedUsers(users, [
+            userData.single.unlockedUser,
+          ])}
+          handleClearSelection={vi.fn()}
+          sidePanel
+        />,
+        undefined,
+        routePath,
+        routePattern,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Lock" }));
+      expect(
+        screen.getByRole("heading", { name: /lock user/i }),
+      ).toBeInTheDocument();
+
+      await user.click(
+        within(screen.getByRole("dialog")).getByRole("button", {
+          name: "Lock",
+        }),
+      );
+      expect(
+        await screen.findByText("Successfully requested to be locked"),
+      ).toBeInTheDocument();
+    });
+
+    it("submits lock action when clear-selection handler is omitted", async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <UserPanelActionButtons
+          selectedUsers={getSelectedUsers(users, [
+            userData.single.unlockedUser,
+          ])}
+          sidePanel
+        />,
+        undefined,
+        routePath,
+        routePattern,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Lock" }));
+      await user.click(
+        within(screen.getByRole("dialog")).getByRole("button", {
+          name: "Lock",
+        }),
+      );
+
+      expect(
+        await screen.findByText("Successfully requested to be locked"),
+      ).toBeInTheDocument();
+    });
+
+    it("opens unlock confirmation and submits unlock action", async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <UserPanelActionButtons
+          selectedUsers={getSelectedUsers(users, [userData.single.lockedUser])}
+          handleClearSelection={vi.fn()}
+          sidePanel
+        />,
+        undefined,
+        routePath,
+        routePattern,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Unlock" }));
+      expect(
+        screen.getByRole("heading", { name: /unlock user/i }),
+      ).toBeInTheDocument();
+
+      await user.click(
+        within(screen.getByRole("dialog")).getByRole("button", {
+          name: "Unlock",
+        }),
+      );
+      expect(
+        await screen.findByText("Successfully requested to be unlocked"),
+      ).toBeInTheDocument();
+    });
+
+    it("opens delete confirmation and submits remove action", async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <UserPanelActionButtons
+          selectedUsers={getSelectedUsers(users, [userData.single.lockedUser])}
+          handleClearSelection={vi.fn()}
+          sidePanel
+        />,
+        undefined,
+        routePath,
+        routePattern,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Delete" }));
+      expect(
+        screen.getByRole("heading", { name: /delete user/i }),
+      ).toBeInTheDocument();
+
+      await user.click(
+        screen.getByRole("checkbox", {
+          name: "Delete the home folders as well",
+        }),
+      );
+      await user.click(
+        within(screen.getByRole("dialog")).getByRole("button", {
+          name: "Delete",
+        }),
+      );
+
+      expect(
+        await screen.findByText("Successfully requested to be removed"),
+      ).toBeInTheDocument();
+    });
+
+    it("shows error notification when user action fails", async () => {
+      const user = userEvent.setup();
+      setEndpointStatus({ status: "error", path: "lockUser" });
+
+      renderWithProviders(
+        <UserPanelActionButtons
+          selectedUsers={getSelectedUsers(users, [
+            userData.single.unlockedUser,
+          ])}
+          handleClearSelection={vi.fn()}
+          sidePanel
+        />,
+        undefined,
+        routePath,
+        routePattern,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Lock" }));
+      await user.click(
+        within(screen.getByRole("dialog")).getByRole("button", {
+          name: "Lock",
+        }),
+      );
+
+      expect(
+        await screen.findByText('The endpoint status is set to "error".'),
+      ).toBeInTheDocument();
+    });
+
+    it("renders multi-user modal copy and supports closing lock/unlock/delete dialogs", async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <UserPanelActionButtons
+          selectedUsers={getSelectedUsers(users, mixedSelectedUsers)}
+          handleClearSelection={vi.fn()}
+        />,
+        undefined,
+        routePath,
+        routePattern,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Lock" }));
+      expect(
+        screen.getByRole("heading", {
+          name: `Lock ${mixedSelectedUsers.length} users`,
+        }),
+      ).toBeInTheDocument();
+      await user.click(
+        within(screen.getByRole("dialog")).getByRole("button", {
+          name: "Cancel",
+        }),
+      );
+      expect(
+        screen.queryByRole("heading", {
+          name: `Lock ${mixedSelectedUsers.length} users`,
+        }),
+      ).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Unlock" }));
+      expect(
+        screen.getByRole("heading", {
+          name: `Unlock ${mixedSelectedUsers.length} users`,
+        }),
+      ).toBeInTheDocument();
+      await user.click(
+        within(screen.getByRole("dialog")).getByRole("button", {
+          name: "Cancel",
+        }),
+      );
+      expect(
+        screen.queryByRole("heading", {
+          name: `Unlock ${mixedSelectedUsers.length} users`,
+        }),
+      ).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Delete" }));
+      expect(
+        screen.getByRole("heading", { name: "Delete users" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "This will delete selected users. You can delete their home folders as well.",
+        ),
+      ).toBeInTheDocument();
+      await user.click(
+        within(screen.getByRole("dialog")).getByRole("button", {
+          name: "Cancel",
+        }),
+      );
+      expect(
+        screen.queryByRole("heading", { name: "Delete users" }),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/pages/dashboard/instances/[single]/tabs/users/UserPanelActionButtons/helpers.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/UserPanelActionButtons/helpers.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { users } from "@/tests/mocks/user";
+import {
+  UserAction,
+  getSelectedUsernames,
+  getUserLockStatusCounts,
+  renderModalBody,
+} from "./helpers";
+
+describe("UserPanelActionButtons helpers", () => {
+  it("returns selected usernames", () => {
+    expect(getSelectedUsernames(users.slice(0, 3))).toEqual([
+      "user1",
+      "user2",
+      "user3",
+    ]);
+  });
+
+  it("counts locked and unlocked users", () => {
+    expect(getUserLockStatusCounts(users.slice(0, 5))).toEqual({
+      locked: 2,
+      unlocked: 3,
+    });
+  });
+
+  it("renders single-user copy when a specific user is provided", () => {
+    const node = renderModalBody({
+      user: users[0],
+      selectedUsers: [users[0]],
+      userAction: UserAction.Lock,
+    });
+
+    render(<>{node}</>);
+
+    expect(
+      screen.getByText(/prevent this user from logging into this account/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders same-state copy when all selected users are unlocked and lock is requested", () => {
+    const selectedUsers = users.filter((user) => user.enabled);
+
+    const node = renderModalBody({
+      user: undefined,
+      selectedUsers,
+      userAction: UserAction.Lock,
+    });
+
+    render(<>{node}</>);
+
+    expect(
+      screen.getByText(/prevent users from logging into these accounts/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders mixed-state summary with hold/leave counts", () => {
+    const selectedUsers = users.slice(0, 4);
+
+    const node = renderModalBody({
+      user: undefined,
+      selectedUsers,
+      userAction: UserAction.Lock,
+    });
+
+    const { container } = render(<>{node}</>);
+
+    expect(
+      screen.getByText(/locking users removes their login access/i),
+    ).toBeInTheDocument();
+    expect(container).toHaveTextContent("You selected 4 users.");
+    expect(container).toHaveTextContent("lock 3 users");
+    expect(container).toHaveTextContent("leave 1 user locked");
+  });
+
+  it("renders unlock copy for a specific user", () => {
+    const lockedUser = users.find((user) => !user.enabled);
+    assert(lockedUser);
+
+    const node = renderModalBody({
+      user: lockedUser,
+      selectedUsers: [lockedUser],
+      userAction: UserAction.Unlock,
+    });
+
+    render(<>{node}</>);
+
+    expect(
+      screen.getByText(/restore login access for the user/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders same-state copy when all selected users are locked and unlock is requested", () => {
+    const selectedUsers = users.filter((user) => !user.enabled);
+
+    const node = renderModalBody({
+      user: undefined,
+      selectedUsers,
+      userAction: UserAction.Unlock,
+    });
+
+    render(<>{node}</>);
+
+    expect(
+      screen.getByText(/restore login access for the users of these accounts/i),
+    ).toBeInTheDocument();
+  });
+
+  it("returns an empty node for unknown actions", () => {
+    const node = renderModalBody({
+      user: users[0],
+      selectedUsers: [users[0]],
+      userAction: "unknown" as UserAction,
+    });
+
+    const { container } = render(<>{node}</>);
+    expect(container).toHaveTextContent("");
+  });
+
+  it("renders mixed-state summary for unlock action", () => {
+    const selectedUsers = users.slice(0, 4);
+
+    const node = renderModalBody({
+      user: undefined,
+      selectedUsers,
+      userAction: UserAction.Unlock,
+    });
+
+    const { container } = render(<>{node}</>);
+
+    expect(
+      screen.getByText(/unlocking users removes their login access/i),
+    ).toBeInTheDocument();
+    expect(container).toHaveTextContent("You selected 4 users.");
+    expect(container).toHaveTextContent("unlock 1 user");
+    expect(container).toHaveTextContent("leave 3 users unlocked");
+  });
+});

--- a/src/pages/dashboard/instances/[single]/tabs/users/UserPanelActionButtons/helpers.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/UserPanelActionButtons/helpers.tsx
@@ -24,16 +24,15 @@ const getSingleUserMessage = (userAction: UserAction): string => {
   }
 };
 
-const getUsersWithSameStateMessage = (userAction: UserAction): string => {
-  switch (userAction) {
-    case UserAction.Lock:
-      return "This will prevent users from logging into these accounts without deleting the files belonging to the accounts.";
-    case UserAction.Unlock:
-      return "This will restore login access for the users of these accounts.";
-    default:
-      return "";
-  }
+const usersWithSameStateMessages: Record<UserAction, string> = {
+  [UserAction.Lock]:
+    "This will prevent users from logging into these accounts without deleting the files belonging to the accounts.",
+  [UserAction.Unlock]:
+    "This will restore login access for the users of these accounts.",
 };
+
+const getUsersWithSameStateMessage = (userAction: UserAction): string =>
+  usersWithSameStateMessages[userAction];
 
 export const getUserLockStatusCounts = (
   users: User[],

--- a/src/pages/dashboard/overview/OverviewPage.test.tsx
+++ b/src/pages/dashboard/overview/OverviewPage.test.tsx
@@ -1,0 +1,26 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "@/tests/render";
+import OverviewPage from "./OverviewPage";
+
+vi.mock("@/features/overview", async () => {
+  const actual = await vi.importActual("@/features/overview");
+
+  return {
+    ...actual,
+    ChartContainer: () => <div>Chart container</div>,
+  };
+});
+
+describe("OverviewPage", () => {
+  it("renders overview heading and key dashboard sections", async () => {
+    renderWithProviders(<OverviewPage />);
+
+    expect(
+      screen.getByRole("heading", { name: "Overview" }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Chart container")).toBeInTheDocument();
+    expect(screen.getByText("Requires approval")).toBeInTheDocument();
+    expect(screen.getByText("In progress")).toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/repositories/RepositoryPage.test.tsx
+++ b/src/pages/dashboard/repositories/RepositoryPage.test.tsx
@@ -1,0 +1,27 @@
+import { waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ROUTES } from "@/libs/routes";
+import { renderWithProviders } from "@/tests/render";
+import RepositoryPage from "./RepositoryPage";
+
+const navigate = vi.fn();
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+describe("RepositoryPage", () => {
+  it("redirects to repository mirrors", async () => {
+    renderWithProviders(<RepositoryPage />);
+
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith(ROUTES.repositories.mirrors(), {
+        replace: true,
+      });
+    });
+  });
+});

--- a/src/pages/dashboard/repositories/apt-sources/APTSourcesPage.test.tsx
+++ b/src/pages/dashboard/repositories/apt-sources/APTSourcesPage.test.tsx
@@ -1,0 +1,61 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import { PATHS, ROUTES } from "@/libs/routes";
+import { setEndpointStatus } from "@/tests/controllers/controller";
+import { renderWithProviders } from "@/tests/render";
+import APTSourcesPage from "./APTSourcesPage";
+import { APT_SOURCES_DOCS_URL } from "./constants";
+
+describe("APTSourcesPage", () => {
+  beforeEach(() => {
+    setEndpointStatus("default");
+  });
+
+  it("renders apt sources list", async () => {
+    renderWithProviders(<APTSourcesPage />);
+
+    expect(
+      screen.getByRole("heading", { name: "APT sources" }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("source1")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add APT source" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state when no apt sources are returned", async () => {
+    setEndpointStatus({ status: "empty", path: "repository/apt-source" });
+
+    renderWithProviders(
+      <APTSourcesPage />,
+      undefined,
+      ROUTES.repositories.aptSources(),
+      `/${PATHS.repositories.root}/${PATHS.repositories.aptSources}`,
+    );
+
+    expect(await screen.findByText("No APT sources found")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: "How to manage APT sources in Landscape",
+      }),
+    ).toHaveAttribute("href", APT_SOURCES_DOCS_URL);
+  });
+
+  it("opens add apt source side panel from page action", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <APTSourcesPage />,
+      undefined,
+      ROUTES.repositories.aptSources(),
+      `/${PATHS.repositories.root}/${PATHS.repositories.aptSources}`,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add APT source" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Add APT source" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/repositories/apt-sources/APTSourcesPage.tsx
+++ b/src/pages/dashboard/repositories/apt-sources/APTSourcesPage.tsx
@@ -8,6 +8,7 @@ import useSidePanel from "@/hooks/useSidePanel";
 import { Button } from "@canonical/react-components";
 import type { FC } from "react";
 import { lazy, Suspense } from "react";
+import { APT_SOURCES_DOCS_URL } from "./constants";
 
 const NewAPTSourceForm = lazy(async () =>
   import("@/features/apt-sources").then((module) => ({
@@ -56,7 +57,7 @@ const APTSourcesPage: FC = () => {
                   You haven’t added any APT sources yet.
                 </p>
                 <a
-                  href="https://ubuntu.com/landscape/docs/repositories"
+                  href={APT_SOURCES_DOCS_URL}
                   target="_blank"
                   rel="nofollow noopener noreferrer"
                 >

--- a/src/pages/dashboard/repositories/apt-sources/constants.ts
+++ b/src/pages/dashboard/repositories/apt-sources/constants.ts
@@ -1,0 +1,2 @@
+export const APT_SOURCES_DOCS_URL =
+  "https://ubuntu.com/landscape/docs/repositories";

--- a/src/pages/dashboard/repositories/gpg-keys/GPGKeysPage.test.tsx
+++ b/src/pages/dashboard/repositories/gpg-keys/GPGKeysPage.test.tsx
@@ -1,0 +1,61 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import { PATHS, ROUTES } from "@/libs/routes";
+import { setEndpointStatus } from "@/tests/controllers/controller";
+import { renderWithProviders } from "@/tests/render";
+import GPGKeysPage from "./GPGKeysPage";
+import { GPG_KEYS_DOCS_URL } from "./constants";
+
+describe("GPGKeysPage", () => {
+  beforeEach(() => {
+    setEndpointStatus("default");
+  });
+
+  it("renders gpg keys list", async () => {
+    renderWithProviders(<GPGKeysPage />);
+
+    expect(
+      screen.getByRole("heading", { name: "GPG keys" }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("sign-key")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Import GPG key" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state when no gpg keys are returned", async () => {
+    setEndpointStatus({ status: "empty", path: "gpgKey" });
+
+    renderWithProviders(
+      <GPGKeysPage />,
+      undefined,
+      ROUTES.repositories.gpgKeys(),
+      `/${PATHS.repositories.root}/${PATHS.repositories.gpgKeys}`,
+    );
+
+    expect(await screen.findByText("No GPG keys found")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: "How to manage GPG keys in Landscape",
+      }),
+    ).toHaveAttribute("href", GPG_KEYS_DOCS_URL);
+  });
+
+  it("opens import gpg key side panel from page action", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <GPGKeysPage />,
+      undefined,
+      ROUTES.repositories.gpgKeys(),
+      `/${PATHS.repositories.root}/${PATHS.repositories.gpgKeys}`,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Import GPG key" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Import GPG key" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/repositories/gpg-keys/GPGKeysPage.tsx
+++ b/src/pages/dashboard/repositories/gpg-keys/GPGKeysPage.tsx
@@ -8,6 +8,7 @@ import useSidePanel from "@/hooks/useSidePanel";
 import { Button } from "@canonical/react-components";
 import type { FC } from "react";
 import { lazy, Suspense } from "react";
+import { GPG_KEYS_DOCS_URL } from "./constants";
 
 const NewGPGKeyForm = lazy(async () =>
   import("@/features/gpg-keys").then((module) => ({
@@ -60,7 +61,7 @@ const GPGKeysPage: FC = () => {
                   You haven&apos;t added any GPG keys yet.
                 </p>
                 <a
-                  href="https://ubuntu.com/landscape/docs/repositories"
+                  href={GPG_KEYS_DOCS_URL}
                   target="_blank"
                   rel="nofollow noopener noreferrer"
                 >

--- a/src/pages/dashboard/repositories/gpg-keys/constants.ts
+++ b/src/pages/dashboard/repositories/gpg-keys/constants.ts
@@ -1,0 +1,2 @@
+export const GPG_KEYS_DOCS_URL =
+  "https://ubuntu.com/landscape/docs/repositories";

--- a/src/pages/dashboard/repositories/mirrors/DistributionsPage.test.tsx
+++ b/src/pages/dashboard/repositories/mirrors/DistributionsPage.test.tsx
@@ -1,0 +1,97 @@
+import { screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { PATHS, ROUTES } from "@/libs/routes";
+import { setEndpointStatus } from "@/tests/controllers/controller";
+import {
+  expectLoadingState,
+  resetScreenSize,
+  setScreenSize,
+} from "@/tests/helpers";
+import { renderWithProviders } from "@/tests/render";
+import DistributionsPage from "./DistributionsPage";
+
+describe("DistributionsPage", () => {
+  afterEach(() => {
+    resetScreenSize();
+  });
+
+  it("renders distributions and large-screen actions", async () => {
+    setScreenSize("lg");
+
+    renderWithProviders(<DistributionsPage />);
+
+    expect(
+      screen.getByRole("heading", { name: "Mirrors" }),
+    ).toBeInTheDocument();
+    await expectLoadingState();
+
+    expect(await screen.findByText("Distribution 1")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add distribution" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add mirror" })).toBeEnabled();
+  });
+
+  it("disables add mirror when there are no distributions", async () => {
+    setScreenSize("lg");
+    setEndpointStatus("empty");
+
+    renderWithProviders(<DistributionsPage />);
+
+    await expectLoadingState();
+    expect(
+      screen.getByText("No mirrors have been added yet."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add mirror" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("shows actions menu on small screens", async () => {
+    setScreenSize("xs");
+
+    renderWithProviders(<DistributionsPage />);
+
+    expect(screen.getByRole("button", { name: "Actions" })).toBeInTheDocument();
+  });
+
+  it("opens add distribution side panel", async () => {
+    const user = userEvent.setup();
+    setScreenSize("lg");
+
+    renderWithProviders(
+      <DistributionsPage />,
+      undefined,
+      ROUTES.repositories.mirrors(),
+      `/${PATHS.repositories.root}/${PATHS.repositories.mirrors}`,
+    );
+
+    await expectLoadingState();
+    await user.click(screen.getByRole("button", { name: "Add distribution" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Add distribution" }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens add mirror side panel when distributions exist", async () => {
+    const user = userEvent.setup();
+    setScreenSize("lg");
+
+    renderWithProviders(
+      <DistributionsPage />,
+      undefined,
+      ROUTES.repositories.mirrors(),
+      `/${PATHS.repositories.root}/${PATHS.repositories.mirrors}`,
+    );
+
+    await expectLoadingState();
+    await user.click(screen.getByRole("button", { name: "Add mirror" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Add new mirror" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/settings/SettingsPage.test.tsx
+++ b/src/pages/dashboard/settings/SettingsPage.test.tsx
@@ -1,0 +1,27 @@
+import { waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ROUTES } from "@/libs/routes";
+import { renderWithProviders } from "@/tests/render";
+import SettingsPage from "./SettingsPage";
+
+const navigate = vi.fn();
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+describe("SettingsPage", () => {
+  it("redirects to settings general page", async () => {
+    renderWithProviders(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith(ROUTES.settings.general(), {
+        replace: true,
+      });
+    });
+  });
+});

--- a/src/pages/dashboard/settings/access-group/AccessGroupsPage.test.tsx
+++ b/src/pages/dashboard/settings/access-group/AccessGroupsPage.test.tsx
@@ -1,0 +1,59 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { setEndpointStatus } from "@/tests/controllers/controller";
+import { PATHS, ROUTES } from "@/libs/routes";
+import { renderWithProviders } from "@/tests/render";
+import userEvent from "@testing-library/user-event";
+import AccessGroupsPage from "./AccessGroupsPage";
+
+describe("AccessGroupsPage", () => {
+  it("renders access groups table content", async () => {
+    renderWithProviders(
+      <AccessGroupsPage />,
+      undefined,
+      ROUTES.settings.accessGroups(),
+      `/${PATHS.settings.root}/${PATHS.settings.accessGroups}`,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Access groups" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("rowheader", { name: "Global access" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add access group" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders empty access groups state", async () => {
+    setEndpointStatus("empty");
+
+    renderWithProviders(
+      <AccessGroupsPage />,
+      undefined,
+      ROUTES.settings.accessGroups(),
+      `/${PATHS.settings.root}/${PATHS.settings.accessGroups}`,
+    );
+
+    expect(
+      await screen.findByText("No access groups found"),
+    ).toBeInTheDocument();
+  });
+
+  it("opens add access group side panel", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <AccessGroupsPage />,
+      undefined,
+      ROUTES.settings.accessGroups(),
+      `/${PATHS.settings.root}/${PATHS.settings.accessGroups}`,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add access group" }));
+
+    expect(await screen.findByText("Title")).toBeInTheDocument();
+    expect(screen.getByText("Parent")).toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/settings/roles/EditRoleForm/EditRoleForm.test.tsx
+++ b/src/pages/dashboard/settings/roles/EditRoleForm/EditRoleForm.test.tsx
@@ -1,20 +1,160 @@
 import { roles } from "@/tests/mocks/roles";
+import { setEndpointStatus } from "@/tests/controllers/controller";
 import { renderWithProviders } from "@/tests/render";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
+import { PATHS, ROUTES } from "@/libs/routes";
 import EditRoleForm from "./EditRoleForm";
 
 const props: ComponentProps<typeof EditRoleForm> = {
   role: roles[0],
 };
+const routePattern = `/${PATHS.settings.root}/${PATHS.settings.roles}`;
+const routePath = ROUTES.settings.roles();
 
 describe("EditRoleForm", () => {
-  it("renders EditRoleForm", () => {
-    renderWithProviders(<EditRoleForm {...props} />);
+  it("renders EditRoleForm", async () => {
+    renderWithProviders(
+      <EditRoleForm {...props} />,
+      undefined,
+      routePath,
+      routePattern,
+    );
+
+    await screen.findAllByRole("checkbox");
 
     expect(screen.getByText("Global permissions")).toBeInTheDocument();
     expect(screen.getByText("Permissions")).toBeInTheDocument();
     expect(screen.getByText("Access Groups")).toBeInTheDocument();
     expect(screen.getByText(/save changes/i)).toBeInTheDocument();
+  });
+
+  it("preselects role permissions and access groups", async () => {
+    renderWithProviders(
+      <EditRoleForm {...props} />,
+      undefined,
+      routePath,
+      routePattern,
+    );
+
+    const checkedOptions = await screen.findAllByRole("checkbox", {
+      checked: true,
+    });
+
+    expect(checkedOptions.length).toBeGreaterThan(0);
+  });
+
+  it("closes form when saving without changes", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <EditRoleForm {...props} />,
+      undefined,
+      routePath,
+      routePattern,
+    );
+
+    await screen.findAllByRole("checkbox");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(
+      screen.queryByText("Role changes have been saved"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("submits role updates and shows success notification", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <EditRoleForm {...props} />,
+      undefined,
+      routePath,
+      routePattern,
+    );
+
+    await screen.findAllByRole("checkbox");
+
+    const removePermissionCheckbox = screen.getByRole("checkbox", {
+      name: "Manage instances",
+    });
+    const addPermissionCheckbox = screen.getByRole("checkbox", {
+      name: "Manage scripts",
+    });
+    const accessGroupCheckbox = screen.getByRole("checkbox", {
+      name: "Server machines",
+    });
+    await user.click(removePermissionCheckbox);
+    await user.click(addPermissionCheckbox);
+    await user.click(accessGroupCheckbox);
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(
+      await screen.findByText("Role changes have been saved"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("You modified the role 'GlobalAdmin'"),
+    ).toBeInTheDocument();
+  });
+
+  it("updates global permissions and existing permissions in one submit", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <EditRoleForm {...props} />,
+      undefined,
+      routePath,
+      routePattern,
+    );
+
+    await screen.findAllByRole("checkbox");
+
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: "Manage account",
+      }),
+    );
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: "Manage instances",
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(
+      await screen.findByText("Role changes have been saved"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows endpoint error when role update fails", async () => {
+    const user = userEvent.setup();
+    setEndpointStatus({ status: "error", path: "editRole" });
+
+    renderWithProviders(
+      <EditRoleForm {...props} />,
+      undefined,
+      routePath,
+      routePattern,
+    );
+
+    await screen.findAllByRole("checkbox");
+
+    const removePermissionCheckbox = screen.getByRole("checkbox", {
+      name: "Manage instances",
+    });
+    const addPermissionCheckbox = screen.getByRole("checkbox", {
+      name: "Manage scripts",
+    });
+    const accessGroupCheckbox = screen.getByRole("checkbox", {
+      name: "Server machines",
+    });
+    await user.click(removePermissionCheckbox);
+    await user.click(addPermissionCheckbox);
+    await user.click(accessGroupCheckbox);
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(
+      await screen.findByText('The endpoint status is set to "error".'),
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/dashboard/settings/roles/EditRoleForm/helpers.test.ts
+++ b/src/pages/dashboard/settings/roles/EditRoleForm/helpers.test.ts
@@ -1,9 +1,14 @@
 import { accessGroups } from "@/tests/mocks/accessGroup";
-import { permissions } from "@/tests/mocks/roles";
+import { permissions, roles } from "@/tests/mocks/roles";
 import type { Role } from "@/types/Role";
-import type { PermissionOption } from "../types";
+import type { AccessGroupOption, PermissionOption } from "../types";
 import { getAccessGroupOptions, getPermissionOptions } from "../helpers";
-import { addImpliedViewPermissions, getValuesToEditRole } from "./helpers";
+import {
+  addImpliedViewPermissions,
+  getPromisesToEditRole,
+  getRoleFormProps,
+  getValuesToEditRole,
+} from "./helpers";
 
 const manageComputerPermission = permissions.find(
   (p) => p.name === "ManageComputer",
@@ -13,6 +18,36 @@ const viewComputerPermission = permissions.find(
 );
 assert(manageComputerPermission, "Mock 'ManageComputer' permission not found");
 assert(viewComputerPermission, "Mock 'ViewComputer' permission not found");
+
+const helperAccessGroupOptions: AccessGroupOption[] = [
+  {
+    value: "global",
+    label: "global",
+    children: [],
+    depth: 0,
+    parents: [],
+  },
+  {
+    value: "Server machines",
+    label: "Server machines",
+    children: [],
+    depth: 0,
+    parents: [],
+  },
+];
+
+const helperPermissionOptions: PermissionOption[] = [
+  {
+    values: { manage: "ManageComputers", view: "ViewComputers" },
+    label: "Computers",
+    global: false,
+  },
+  {
+    values: { manage: "ManageScripts", view: "ViewScripts" },
+    label: "Scripts",
+    global: false,
+  },
+];
 
 describe("Role Helpers", () => {
   describe("addImpliedViewPermissions", () => {
@@ -62,8 +97,8 @@ describe("Role Helpers", () => {
   });
 
   describe("getValuesToEditRole", () => {
-    const permissionOptions = getPermissionOptions(permissions);
-    const accessGroupOptions = getAccessGroupOptions(accessGroups);
+    const rolePermissionOptions = getPermissionOptions(permissions);
+    const roleAccessGroupOptions = getAccessGroupOptions(accessGroups);
     const mockRole: Role = {
       name: "TestRole",
       permissions: [],
@@ -89,8 +124,8 @@ describe("Role Helpers", () => {
       const { permissionsToAdd, permissionsToRemove } = getValuesToEditRole(
         formValues,
         role,
-        accessGroupOptions,
-        permissionOptions,
+        roleAccessGroupOptions,
+        rolePermissionOptions,
       );
 
       expect(permissionsToAdd).toEqual([]);
@@ -110,8 +145,8 @@ describe("Role Helpers", () => {
       const { permissionsToAdd, permissionsToRemove } = getValuesToEditRole(
         formValues,
         role,
-        accessGroupOptions,
-        permissionOptions,
+        roleAccessGroupOptions,
+        rolePermissionOptions,
       );
 
       expect(permissionsToAdd).toEqual([]);
@@ -136,12 +171,108 @@ describe("Role Helpers", () => {
       const { permissionsToAdd, permissionsToRemove } = getValuesToEditRole(
         formValues,
         role,
-        accessGroupOptions,
-        permissionOptions,
+        roleAccessGroupOptions,
+        rolePermissionOptions,
       );
 
       expect(permissionsToAdd).toEqual([]);
       expect(permissionsToRemove).toEqual([]);
+    });
+
+    it("computes permission and access-group deltas", () => {
+      const role = {
+        ...mockRole,
+        permissions: ["ManageComputers"],
+        global_permissions: ["ViewComputers"],
+        access_groups: ["global"],
+      };
+      const values = {
+        permissions: ["ManageScripts"],
+        accessGroups: ["global", "Server machines"],
+      };
+
+      expect(
+        getValuesToEditRole(
+          values,
+          role,
+          helperAccessGroupOptions,
+          helperPermissionOptions,
+        ),
+      ).toEqual({
+        accessGroupsToAdd: ["Server machines"],
+        accessGroupsToRemove: [],
+        permissionsToAdd: ["ManageScripts", "ViewScripts"],
+        permissionsToRemove: ["ManageComputers", "ViewComputers"],
+      });
+    });
+  });
+
+  describe("getPromisesToEditRole", () => {
+    it("builds mutation promises only for changed values", () => {
+      const addAccessGroups = vi.fn().mockResolvedValue({} as never);
+      const addPermissions = vi.fn().mockResolvedValue({} as never);
+      const removeAccessGroups = vi.fn().mockResolvedValue({} as never);
+      const removePermissions = vi.fn().mockResolvedValue({} as never);
+
+      const promises = getPromisesToEditRole(
+        {
+          permissions: ["ManageScripts"],
+          accessGroups: ["global", "Server machines"],
+        },
+        {
+          ...roles[0],
+          permissions: ["ManageComputers"],
+          global_permissions: ["ViewComputers"],
+          access_groups: ["global"],
+        },
+        helperAccessGroupOptions,
+        helperPermissionOptions,
+        {
+          addAccessGroups,
+          addPermissions,
+          removeAccessGroups,
+          removePermissions,
+        },
+      );
+
+      expect(promises.addAccessGroupsPromise).toBeDefined();
+      expect(promises.addPermissionsPromise).toBeDefined();
+      expect(promises.removePermissionsPromise).toBeDefined();
+      expect(promises.removeAccessGroupsPromise).toBeUndefined();
+    });
+  });
+
+  describe("getRoleFormProps", () => {
+    it("builds form props with implied permissions and nested access groups", () => {
+      const formProps = getRoleFormProps(
+        {
+          ...roles[0],
+          access_groups: ["global"],
+          permissions: ["ManageComputers"],
+          global_permissions: [],
+        },
+        [
+          {
+            value: "global",
+            label: "global",
+            children: ["child-group"],
+            depth: 0,
+            parents: [],
+          },
+        ],
+        [
+          {
+            values: { manage: "ManageComputers", view: "ViewComputers" },
+            label: "Computers",
+            global: false,
+          },
+        ],
+      );
+
+      expect(formProps).toEqual({
+        accessGroups: ["global", "child-group"],
+        permissions: ["ManageComputers", "ViewComputers"],
+      });
     });
   });
 });

--- a/src/routes/AuthRoutes.test.tsx
+++ b/src/routes/AuthRoutes.test.tsx
@@ -1,0 +1,74 @@
+import {
+  Children,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { Outlet } from "react-router";
+import { describe, expect, it } from "vitest";
+import { GuestGuard } from "@/components/guards/GuestGuard";
+import { FeatureGuard } from "@/components/guards/FeatureGuard";
+import { PATHS } from "@/libs/routes";
+import { AuthRoutes } from "./AuthRoutes";
+
+interface RouteLikeProps {
+  children?: ReactNode;
+  element?: ReactElement;
+  path?: string;
+}
+
+const isRouteElement = (
+  value: unknown,
+): value is ReactElement<RouteLikeProps> =>
+  isValidElement<RouteLikeProps>(value);
+
+const getRouteChildren = (element: ReactElement<RouteLikeProps>) => {
+  return Children.toArray(element.props.children).filter(isRouteElement);
+};
+
+describe("AuthRoutes", () => {
+  it("wraps auth routes with guest guard and outlet", () => {
+    const wrapper = (AuthRoutes as ReactElement<RouteLikeProps>).props.element;
+    assert(wrapper);
+    const guardWrapper = wrapper as ReactElement<{ children: ReactElement }>;
+    expect(guardWrapper.type).toBe(GuestGuard);
+
+    const wrappedChild = guardWrapper.props.children;
+    expect(wrappedChild.type).toBe(Outlet);
+  });
+
+  it("defines expected auth paths", () => {
+    const childRoutes = getRouteChildren(
+      AuthRoutes as ReactElement<RouteLikeProps>,
+    );
+    const paths = childRoutes.map((route) => route.props.path);
+
+    expect(paths).toContain(PATHS.auth.login);
+    expect(paths).toContain(PATHS.auth.invitation);
+    expect(paths).toContain(PATHS.auth.createAccount);
+    expect(paths).toContain(PATHS.auth.noAccess);
+    expect(paths).toContain(PATHS.auth.handleOidc);
+    expect(paths).toContain(PATHS.auth.handleUbuntuOne);
+    expect(paths).toContain(PATHS.auth.attach);
+    expect(paths).toContain(PATHS.auth.supportLogin);
+  });
+
+  it("uses feature guard for attach and support login routes", () => {
+    const childRoutes = getRouteChildren(
+      AuthRoutes as ReactElement<RouteLikeProps>,
+    );
+
+    const attachRoute = childRoutes.find(
+      (route) => route.props.path === PATHS.auth.attach,
+    );
+    const supportLoginRoute = childRoutes.find(
+      (route) => route.props.path === PATHS.auth.supportLogin,
+    );
+
+    assert(attachRoute?.props.element);
+    assert(supportLoginRoute?.props.element);
+
+    expect(attachRoute.props.element.type).toBe(FeatureGuard);
+    expect(supportLoginRoute.props.element.type).toBe(FeatureGuard);
+  });
+});

--- a/src/routes/DashboardRoutes.test.tsx
+++ b/src/routes/DashboardRoutes.test.tsx
@@ -1,0 +1,93 @@
+import {
+  Children,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { Outlet } from "react-router";
+import { describe, expect, it } from "vitest";
+import { AuthGuard } from "@/components/guards/AuthGuard";
+import { FeatureGuard } from "@/components/guards/FeatureGuard";
+import { SelfHostedGuard } from "@/components/guards/SelfHostedGuard";
+import { PATHS } from "@/libs/routes";
+import { DashboardRoutes } from "./DashboardRoutes";
+
+interface RouteLikeProps {
+  children?: ReactNode;
+  element?: ReactElement;
+  path?: string;
+}
+
+const isRouteElement = (
+  value: unknown,
+): value is ReactElement<RouteLikeProps> =>
+  isValidElement<RouteLikeProps>(value);
+
+const getRouteChildren = (element: ReactElement<RouteLikeProps>) => {
+  return Children.toArray(element.props.children).filter(isRouteElement);
+};
+
+const flattenRoutes = (
+  routeElement: ReactElement<RouteLikeProps>,
+): ReactElement<RouteLikeProps>[] => {
+  const directChildren = getRouteChildren(routeElement);
+  return directChildren.flatMap((child) => [child, ...flattenRoutes(child)]);
+};
+
+describe("DashboardRoutes", () => {
+  it("wraps dashboard routes with auth guard and outlet", () => {
+    const wrapper = (DashboardRoutes as ReactElement<RouteLikeProps>).props
+      .element;
+    assert(wrapper);
+    const guardWrapper = wrapper as ReactElement<{ children: ReactElement }>;
+    expect(guardWrapper.type).toBe(AuthGuard);
+
+    const wrappedChild = guardWrapper.props.children;
+    expect(wrappedChild.type).toBe(Outlet);
+  });
+
+  it("includes key dashboard route paths", () => {
+    const allRoutes = flattenRoutes(
+      DashboardRoutes as ReactElement<RouteLikeProps>,
+    );
+    const paths = allRoutes.map((route) => route.props.path).filter(Boolean);
+
+    expect(paths).toContain(PATHS.root.root);
+    expect(paths).toContain(PATHS.overview.root);
+    expect(paths).toContain(PATHS.instances.root);
+    expect(paths).toContain(PATHS.instances.single);
+    expect(paths).toContain(PATHS.account.apiCredentials);
+    expect(paths).toContain(PATHS.repositories.mirrors);
+    expect(paths).toContain(PATHS.settings.employees);
+  });
+
+  it("uses self-hosted and feature guards for guarded paths", () => {
+    const allRoutes = flattenRoutes(
+      DashboardRoutes as ReactElement<RouteLikeProps>,
+    );
+
+    const mirrorsRoute = allRoutes.find(
+      (route) => route.props.path === PATHS.repositories.mirrors,
+    );
+    const employeesRoute = allRoutes.find(
+      (route) => route.props.path === PATHS.settings.employees,
+    );
+    const identityProvidersRoute = allRoutes.find(
+      (route) => route.props.path === PATHS.settings.identityProviders,
+    );
+
+    const wslProfilesRoute = allRoutes.find(
+      (route) => route.props.path === PATHS.profiles.wsl,
+    );
+
+    assert(mirrorsRoute?.props.element);
+    assert(employeesRoute?.props.element);
+    assert(identityProvidersRoute?.props.element);
+    assert(wslProfilesRoute?.props.element);
+
+    expect(mirrorsRoute.props.element.type).toBe(SelfHostedGuard);
+    expect(employeesRoute.props.element.type).toBe(FeatureGuard);
+    expect(identityProvidersRoute.props.element.type).toBe(FeatureGuard);
+    expect(wslProfilesRoute.props.element.type).toBe(FeatureGuard);
+  });
+});

--- a/src/routes/elements.test.tsx
+++ b/src/routes/elements.test.tsx
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import type { FC, ReactElement } from "react";
+import * as Pages from "./elements";
+
+const getLazyElementType = (
+  Page: FC,
+): {
+  _payload: unknown;
+  _init: (payload: unknown) => unknown;
+} => {
+  const element = Page({}) as ReactElement<{ children: ReactElement }>;
+  const lazyElement = element.props.children;
+  return lazyElement.type as unknown as {
+    _payload: unknown;
+    _init: (payload: unknown) => unknown;
+  };
+};
+
+const resolveLoadableImport = async (Page: FC) => {
+  const lazyType = getLazyElementType(Page);
+  try {
+    lazyType._init(lazyType._payload);
+  } catch (error) {
+    if (error instanceof Promise) {
+      await error;
+      return;
+    }
+
+    throw error;
+  }
+};
+
+describe("route elements", () => {
+  it("sets loadable display names", () => {
+    expect(Pages.LoginPage.displayName).toContain("Loadable(");
+    expect(Pages.PageNotFound.displayName).toContain("Loadable(");
+    expect(Pages.DashboardPage.displayName).toContain("Loadable(");
+  });
+
+  it("exports wrapped route components", () => {
+    const exportedPages = [
+      Pages.OidcAuthPage,
+      Pages.UbuntuOneAuthPage,
+      Pages.InvitationPage,
+      Pages.AccountCreationPage,
+      Pages.NoAccessPage,
+      Pages.LoginPage,
+      Pages.SupportLoginPage,
+      Pages.AttachPage,
+      Pages.PageNotFound,
+      Pages.EnvError,
+      Pages.DashboardPage,
+      Pages.OverviewPage,
+      Pages.ActivitiesPage,
+      Pages.ScriptsPage,
+      Pages.EventsLogPage,
+      Pages.AlertNotificationsPage,
+      Pages.InstancesPage,
+      Pages.SingleInstance,
+      Pages.DistributionsPage,
+      Pages.RepositoryProfilesPage,
+      Pages.GPGKeysPage,
+      Pages.APTSourcesPage,
+      Pages.PackageProfilesPage,
+      Pages.RemovalProfilesPage,
+      Pages.UpgradeProfilesPage,
+      Pages.WslProfilesPage,
+      Pages.SecurityProfilesPage,
+      Pages.RebootProfilesPage,
+      Pages.AccessGroupsPage,
+      Pages.AdministratorsPage,
+      Pages.EmployeesPage,
+      Pages.RolesPage,
+      Pages.GeneralOrganisationSettings,
+      Pages.IdentityProvidersPage,
+      Pages.GeneralSettings,
+      Pages.Alerts,
+      Pages.ApiCredentials,
+    ];
+
+    for (const exportedPage of exportedPages) {
+      expect(typeof exportedPage).toBe("function");
+    }
+  });
+
+  it("resolves lazy imports for exported route components", async () => {
+    const exportedPages = [
+      Pages.OidcAuthPage,
+      Pages.UbuntuOneAuthPage,
+      Pages.InvitationPage,
+      Pages.AccountCreationPage,
+      Pages.NoAccessPage,
+      Pages.LoginPage,
+      Pages.SupportLoginPage,
+      Pages.AttachPage,
+      Pages.PageNotFound,
+      Pages.EnvError,
+      Pages.DashboardPage,
+      Pages.OverviewPage,
+      Pages.ActivitiesPage,
+      Pages.ScriptsPage,
+      Pages.EventsLogPage,
+      Pages.AlertNotificationsPage,
+      Pages.InstancesPage,
+      Pages.SingleInstance,
+      Pages.DistributionsPage,
+      Pages.RepositoryProfilesPage,
+      Pages.GPGKeysPage,
+      Pages.APTSourcesPage,
+      Pages.PackageProfilesPage,
+      Pages.RemovalProfilesPage,
+      Pages.UpgradeProfilesPage,
+      Pages.WslProfilesPage,
+      Pages.SecurityProfilesPage,
+      Pages.RebootProfilesPage,
+      Pages.AccessGroupsPage,
+      Pages.AdministratorsPage,
+      Pages.EmployeesPage,
+      Pages.RolesPage,
+      Pages.GeneralOrganisationSettings,
+      Pages.IdentityProvidersPage,
+      Pages.GeneralSettings,
+      Pages.Alerts,
+      Pages.ApiCredentials,
+    ] as const;
+
+    for (const exportedPage of exportedPages) {
+      await resolveLoadableImport(exportedPage);
+    }
+  });
+});

--- a/src/tests/browser.ts
+++ b/src/tests/browser.ts
@@ -17,11 +17,7 @@ const handlers: RequestHandler[] = [
       return passthrough();
     }
 
-    if (
-      MSW_ENDPOINTS_TO_INTERCEPT.some((url: string) =>
-        request.url.includes(url),
-      )
-    ) {
+    if (MSW_ENDPOINTS_TO_INTERCEPT.some((url) => request.url.includes(url))) {
       return;
     }
 

--- a/src/tests/mocks/alerts.ts
+++ b/src/tests/mocks/alerts.ts
@@ -126,6 +126,18 @@ export const alerts = [
   },
 ] as const satisfies Alert[];
 
+export const licenseAlert: Alert = {
+  id: 9999,
+  alert_type: "LicenseSeatsAlert",
+  description: "Alert when available seats are low",
+  subscribed: false,
+  status: "OK",
+  scope: "account",
+  all_computers: false,
+  tags: [],
+  label: "License Seats Alert",
+};
+
 export const alertsSummary = [
   {
     id: 1,

--- a/src/tests/mocks/instance.ts
+++ b/src/tests/mocks/instance.ts
@@ -1,5 +1,6 @@
 import type {
   Instance,
+  InstanceWithoutRelation,
   PendingInstance,
   WindowsInstance,
 } from "@/types/Instance";
@@ -211,6 +212,7 @@ export const windowsInstance: WindowsInstance = {
       employee_id: null,
       archived: false,
       registered_at: "2023-11-29T18:29:25Z",
+      has_release_upgrades: true,
     },
     {
       id: 65,
@@ -340,8 +342,9 @@ export const windowsInstance: WindowsInstance = {
       employee_id: null,
       archived: false,
       registered_at: "2023-11-29T18:29:25Z",
+      has_release_upgrades: true,
     },
-  ],
+  ] as const satisfies InstanceWithoutRelation[],
   parent: null,
   distribution_info: {
     code_name: "windows",

--- a/src/tests/mocks/wsl.ts
+++ b/src/tests/mocks/wsl.ts
@@ -43,7 +43,7 @@ export const uninstalledInstanceChild: InstanceChild = {
   default: null,
 };
 
-export const instanceChildren: InstanceChild[] = [
+export const instanceChildren = [
   compliantInstanceChild,
   uninstalledInstanceChild,
   {
@@ -102,4 +102,4 @@ export const instanceChildren: InstanceChild[] = [
     registered: true,
     default: false,
   },
-];
+] as const satisfies InstanceChild[];

--- a/src/tests/monacoMock.tsx
+++ b/src/tests/monacoMock.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useEffect } from "react";
 
 interface EditorProps {
   readonly value?: string;
@@ -7,31 +8,71 @@ interface EditorProps {
   readonly language?: string;
   readonly theme?: string;
   readonly options?: Record<string, unknown>;
-  readonly beforeMount?: unknown;
+  readonly beforeMount?: (monaco: unknown) => void;
   readonly onMount?: unknown;
   readonly loading?: React.ReactNode;
   readonly className?: string;
+}
+
+interface MonacoTextareaProps {
+  readonly beforeMount?: (monaco: unknown) => void;
+  readonly className?: string;
+  readonly defaultValue?: string;
+  readonly language?: string;
+  readonly onChange?: (value: string) => void;
+  readonly theme?: string;
+  readonly value?: string;
+}
+
+function MonacoTextarea({
+  beforeMount,
+  className,
+  defaultValue,
+  language,
+  onChange,
+  theme,
+  value,
+}: MonacoTextareaProps) {
+  useEffect(() => {
+    beforeMount?.({ mocked: true });
+  }, [beforeMount]);
+
+  return (
+    <textarea
+      data-testid="mock-monaco"
+      data-language={language}
+      data-theme={theme}
+      className={className}
+      value={value ?? defaultValue}
+      onChange={(e) => onChange?.(e.target.value)}
+    />
+  );
 }
 
 export const Editor = ({
   value,
   onChange,
   defaultValue,
-  language: _language,
-  theme: _theme,
+  language,
+  theme,
   options: _options,
-  beforeMount: _beforeMount,
+  beforeMount,
   onMount: _onMount,
   loading: _loading,
   className,
-}: EditorProps) => (
-  <textarea
-    data-testid="mock-monaco"
-    className={className}
-    value={value ?? defaultValue}
-    onChange={(e) => onChange?.(e.target.value)}
-  />
-);
+}: EditorProps) => {
+  return (
+    <MonacoTextarea
+      beforeMount={beforeMount}
+      className={className}
+      defaultValue={defaultValue}
+      language={language}
+      onChange={onChange}
+      theme={theme}
+      value={value}
+    />
+  );
+};
 
 interface CodeEditorMockProps {
   readonly label: string;

--- a/src/tests/server/handlers/_constants.ts
+++ b/src/tests/server/handlers/_constants.ts
@@ -1,10 +1,13 @@
 import { HttpResponse } from "msw";
 
 export const ENDPOINT_STATUS_API_ERROR_MESSAGE = `The endpoint status is set to "error".`;
-export const ENDPOINT_STATUS_API_ERROR = HttpResponse.json(
-  {
-    error: "EndpointStatusError",
-    message: ENDPOINT_STATUS_API_ERROR_MESSAGE,
-  },
-  { status: 500 },
-);
+export const getEndpointStatusApiError = () =>
+  HttpResponse.json(
+    {
+      error: "EndpointStatusError",
+      message: ENDPOINT_STATUS_API_ERROR_MESSAGE,
+    },
+    { status: 500 },
+  );
+
+export const ENDPOINT_STATUS_API_ERROR = getEndpointStatusApiError();

--- a/src/tests/server/handlers/accessGroup.ts
+++ b/src/tests/server/handlers/accessGroup.ts
@@ -4,6 +4,7 @@ import { accessGroups } from "@/tests/mocks/accessGroup";
 import type { AccessGroup } from "@/features/access-groups";
 import { isAction } from "@/tests/server/handlers/_helpers";
 import { getEndpointStatus } from "@/tests/controllers/controller";
+import { getEndpointStatusApiError } from "./_constants";
 
 export default [
   http.get<never, never, AccessGroup[]>(API_URL_OLD, ({ request }) => {
@@ -12,6 +13,13 @@ export default [
     }
 
     const endpointStatus = getEndpointStatus();
+
+    if (
+      endpointStatus.status === "error" &&
+      endpointStatus.path === "GetAccessGroups"
+    ) {
+      throw getEndpointStatusApiError();
+    }
 
     if (endpointStatus.status === "empty") {
       return HttpResponse.json([]);

--- a/src/tests/server/handlers/activity.ts
+++ b/src/tests/server/handlers/activity.ts
@@ -8,7 +8,7 @@ import {
 } from "@/tests/mocks/activity";
 import type { ApiPaginatedResponse } from "@/types/api/ApiPaginatedResponse";
 import { http, HttpResponse } from "msw";
-import { ENDPOINT_STATUS_API_ERROR } from "./_constants";
+import { getEndpointStatusApiError } from "./_constants";
 import { generatePaginatedResponse, isAction } from "./_helpers";
 
 const STATUS_QUERY_REGEX = /(?:^|\s)status:([^\s]+)/;
@@ -54,7 +54,19 @@ export default [
       const endpointStatus = getEndpointStatus();
 
       if (endpointStatus.status === "error") {
-        throw ENDPOINT_STATUS_API_ERROR;
+        throw getEndpointStatusApiError();
+      }
+
+      if (
+        endpointStatus.status === "empty" &&
+        (!endpointStatus.path || endpointStatus.path.includes("activities"))
+      ) {
+        return HttpResponse.json({
+          results: [],
+          count: 0,
+          next: null,
+          previous: null,
+        });
       }
 
       const url = new URL(request.url);
@@ -168,7 +180,7 @@ export default [
       const endpointStatus = getEndpointStatus();
 
       if (endpointStatus.status === "error") {
-        throw ENDPOINT_STATUS_API_ERROR;
+        throw getEndpointStatusApiError();
       }
 
       return HttpResponse.json([activities[0].id, activities[1].id]);
@@ -181,7 +193,7 @@ export default [
       const endpointStatus = getEndpointStatus();
 
       if (endpointStatus.status === "error") {
-        throw ENDPOINT_STATUS_API_ERROR;
+        throw getEndpointStatusApiError();
       }
 
       return HttpResponse.json([activities[0].id, activities[1].id]);

--- a/src/tests/server/handlers/alerts.ts
+++ b/src/tests/server/handlers/alerts.ts
@@ -1,14 +1,20 @@
 import { API_URL, API_URL_OLD } from "@/constants";
 import type { AlertSummaryResponse } from "@/features/alert-notifications";
-import type { Alert, SubscriptionParams } from "@/features/alerts";
+import type {
+  Alert,
+  AssociateAlertParams,
+  DisassociateAlertParams,
+  SubscriptionParams,
+} from "@/features/alerts";
 import { getEndpointStatus } from "@/tests/controllers/controller";
-import { alerts, alertsSummary } from "@/tests/mocks/alerts";
+import { alerts, alertsSummary, licenseAlert } from "@/tests/mocks/alerts";
 import { isAction } from "@/tests/server/handlers/_helpers";
 import { http, HttpResponse } from "msw";
+import { getEndpointStatusApiError } from "./_constants";
 
 export default [
   http.get<never, never, Alert[]>(`${API_URL}alerts`, () => {
-    return HttpResponse.json(alerts);
+    return HttpResponse.json([...alerts, licenseAlert]);
   }),
 
   http.get<never, never, AlertSummaryResponse>(
@@ -43,4 +49,43 @@ export default [
 
     return HttpResponse.json();
   }),
+
+  http.get<never, AssociateAlertParams, Alert>(API_URL_OLD, ({ request }) => {
+    if (!isAction(request, "AssociateAlert")) {
+      return;
+    }
+    const endpointStatus = getEndpointStatus();
+    const action = new URL(request.url).searchParams.get("action");
+    if (
+      endpointStatus.status === "error" &&
+      (!endpointStatus.path || endpointStatus.path === action)
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
+    const [firstAlert] = alerts;
+
+    return HttpResponse.json(firstAlert);
+  }),
+
+  http.get<never, DisassociateAlertParams, Alert>(
+    API_URL_OLD,
+    ({ request }) => {
+      if (!isAction(request, "DisassociateAlert")) {
+        return;
+      }
+      const endpointStatus = getEndpointStatus();
+      const action = new URL(request.url).searchParams.get("action");
+      if (
+        endpointStatus.status === "error" &&
+        (!endpointStatus.path || endpointStatus.path === action)
+      ) {
+        throw getEndpointStatusApiError();
+      }
+
+      const [firstAlert] = alerts;
+
+      return HttpResponse.json(firstAlert);
+    },
+  ),
 ];

--- a/src/tests/server/handlers/aptSource.ts
+++ b/src/tests/server/handlers/aptSource.ts
@@ -4,7 +4,7 @@ import { getEndpointStatus } from "@/tests/controllers/controller";
 import { aptSources } from "@/tests/mocks/apt-sources";
 import { isAction } from "@/tests/server/handlers/_helpers";
 import { http, HttpResponse } from "msw";
-import { ENDPOINT_STATUS_API_ERROR } from "./_constants";
+import { getEndpointStatusApiError } from "./_constants";
 
 export default [
   http.get<never, GetAPTSourcesParams, APTSource[]>(
@@ -27,7 +27,7 @@ export default [
         endpointStatus.path === "repository/apt-source/:sourceId")
     ) {
       if (endpointStatus.status === "error") {
-        throw HttpResponse.json(ENDPOINT_STATUS_API_ERROR, { status: 500 });
+        throw getEndpointStatusApiError();
       }
     }
 
@@ -35,6 +35,21 @@ export default [
   }),
 
   http.get(`${API_URL}repository/apt-source`, () => {
+    const endpointStatus = getEndpointStatus();
+
+    if (
+      !endpointStatus.path ||
+      (endpointStatus.path && endpointStatus.path === "repository/apt-source")
+    ) {
+      if (endpointStatus.status === "error") {
+        throw getEndpointStatusApiError();
+      }
+
+      if (endpointStatus.status === "empty") {
+        return HttpResponse.json({ results: [] });
+      }
+    }
+
     return HttpResponse.json({ results: aptSources });
   }),
 ];

--- a/src/tests/server/handlers/auth.ts
+++ b/src/tests/server/handlers/auth.ts
@@ -16,6 +16,7 @@ import {
 import { allLoginMethods } from "@/tests/mocks/loginMethods";
 import { getEndpointStatus } from "@/tests/controllers/controller";
 import { invitationState } from "./invitations";
+import { getEndpointStatusApiError } from "./_constants";
 
 interface SwitchAccountParams {
   account_name: string;
@@ -157,10 +158,26 @@ export default [
     });
   }),
 
-  http.get(
+  http.get<{ attach_code: string }>(
     `${API_URL}ubuntu-installer-attach-sessions/code/:attach_code`,
-    () => {
+    ({ params }) => {
       const HOUR_S = 3600;
+      const endpointStatus = getEndpointStatus();
+
+      if (
+        endpointStatus.status === "error" &&
+        (!endpointStatus.path ||
+          endpointStatus.path.includes("ubuntu-installer-attach-sessions/code"))
+      ) {
+        throw getEndpointStatusApiError();
+      }
+
+      if (params.attach_code === "EXPIRE") {
+        return HttpResponse.json({
+          valid: false,
+          valid_until: null,
+        });
+      }
 
       return HttpResponse.json({
         valid: true,
@@ -369,7 +386,7 @@ export default [
 
       return HttpResponse.json({
         accounts: [createdAccount],
-        current_account: createdAccount ? createdAccount.account : "",
+        current_account: createdAccount.account,
         email: "new-user@example.com",
         has_password: false,
         name: "New Ubuntu One User",

--- a/src/tests/server/handlers/autoinstallFiles.ts
+++ b/src/tests/server/handlers/autoinstallFiles.ts
@@ -12,6 +12,7 @@ import { autoinstallFiles } from "@/tests/mocks/autoinstallFiles";
 import { generatePaginatedResponse } from "@/tests/server/handlers/_helpers";
 import type { ApiPaginatedResponse } from "@/types/api/ApiPaginatedResponse";
 import { delay, http, HttpResponse } from "msw";
+import { getEndpointStatusApiError } from "./_constants";
 
 export default [
   http.get<
@@ -87,6 +88,32 @@ export default [
       });
     },
   ),
+  http.post(`${API_URL}autoinstall:validate`, async () => {
+    const endpointStatus = getEndpointStatus();
+
+    if (
+      endpointStatus.status === "error" &&
+      endpointStatus.path === "autoinstall:validate-override"
+    ) {
+      return HttpResponse.json(
+        {
+          error: "AutoinstallOverrideWarning",
+          message:
+            "The autoinstall file you submitted overrides fields users, identity",
+        },
+        { status: 400 },
+      );
+    }
+
+    if (
+      endpointStatus.status === "error" &&
+      endpointStatus.path === "autoinstall:validate"
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
+    return HttpResponse.json({});
+  }),
 
   http.delete<{ autoinstallFileId: string }, DeleteAutoinstallFileParams, null>(
     `${API_URL}autoinstall/:autoinstallFileId`,

--- a/src/tests/server/handlers/employees.ts
+++ b/src/tests/server/handlers/employees.ts
@@ -5,19 +5,34 @@ import { employees } from "@/tests/mocks/employees";
 import { generatePaginatedResponse } from "@/tests/server/handlers/_helpers";
 import type { ApiPaginatedResponse } from "@/types/api/ApiPaginatedResponse";
 import { http, HttpResponse } from "msw";
+import { getEndpointStatusApiError } from "./_constants";
 
 export default [
   http.get<never, GetEmployeesParams, ApiPaginatedResponse<Employee>>(
     `${API_URL}employees`,
     async ({ request }) => {
       const DEFAULT_PAGE_SIZE = 20;
+      const NEXT_PAGE_LOADING_DELAY_MS = 150;
 
       const endpointStatus = getEndpointStatus();
+
+      if (
+        endpointStatus.status === "error" &&
+        (!endpointStatus.path || endpointStatus.path === "employees")
+      ) {
+        throw getEndpointStatusApiError();
+      }
 
       const url = new URL(request.url);
       const offset = Number(url.searchParams.get("offset")) || 0;
       const limit = Number(url.searchParams.get("limit")) || DEFAULT_PAGE_SIZE;
       const search = url.searchParams.get("search") ?? "";
+
+      if (endpointStatus.path === "employees:next-page-loading" && offset > 0) {
+        await new Promise((resolve) => {
+          setTimeout(resolve, NEXT_PAGE_LOADING_DELAY_MS);
+        });
+      }
 
       return HttpResponse.json(
         generatePaginatedResponse<Employee>({
@@ -32,6 +47,32 @@ export default [
   ),
 
   http.patch(`${API_URL}employees/:id`, async () => {
+    return HttpResponse.json();
+  }),
+
+  http.post(`${API_URL}employees/:id/computers`, async () => {
+    const endpointStatus = getEndpointStatus();
+    if (
+      endpointStatus.status === "error" &&
+      (!endpointStatus.path ||
+        endpointStatus.path === "associateEmployeeWithInstance")
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
+    return HttpResponse.json();
+  }),
+
+  http.delete(`${API_URL}employees/:id/computers/:computerId`, async () => {
+    const endpointStatus = getEndpointStatus();
+    if (
+      endpointStatus.status === "error" &&
+      (!endpointStatus.path ||
+        endpointStatus.path === "disassociateEmployeeFromInstance")
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
     return HttpResponse.json();
   }),
 

--- a/src/tests/server/handlers/gpgKey.ts
+++ b/src/tests/server/handlers/gpgKey.ts
@@ -1,8 +1,10 @@
 import { http, HttpResponse } from "msw";
 import { API_URL_OLD } from "@/constants";
 import type { GetGPGKeysParams, GPGKey } from "@/features/gpg-keys";
+import { getEndpointStatus } from "@/tests/controllers/controller";
 import { gpgKeys } from "@/tests/mocks/gpgKey";
 import { isAction } from "@/tests/server/handlers/_helpers";
+import { getEndpointStatusApiError } from "./_constants";
 
 export default [
   http.get<never, GetGPGKeysParams, GPGKey[]>(API_URL_OLD, ({ request }) => {
@@ -10,6 +12,35 @@ export default [
       return;
     }
 
+    const endpointStatus = getEndpointStatus();
+
+    if (!endpointStatus.path || endpointStatus.path === "gpgKey") {
+      if (endpointStatus.status === "error") {
+        throw getEndpointStatusApiError();
+      }
+
+      if (endpointStatus.status === "empty") {
+        return HttpResponse.json([]);
+      }
+    }
+
     return HttpResponse.json(gpgKeys);
+  }),
+
+  http.get(API_URL_OLD, ({ request }) => {
+    if (!isAction(request, "ImportGPGKey")) {
+      return;
+    }
+
+    const endpointStatus = getEndpointStatus();
+
+    if (
+      endpointStatus.status === "error" &&
+      (!endpointStatus.path || endpointStatus.path === "importGpgKey")
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
+    return HttpResponse.json(gpgKeys[0]);
   }),
 ];

--- a/src/tests/server/handlers/index.ts
+++ b/src/tests/server/handlers/index.ts
@@ -26,6 +26,7 @@ import process from "./process";
 import rebootProfiles from "./rebootProfiles";
 import removalProfiles from "./removalProfiles";
 import repo from "./repo";
+import reports from "./reports";
 import repositoryProfiles from "./repositoryProfiles";
 import roles from "./roles";
 import scriptProfiles from "./scriptProfiles";
@@ -67,6 +68,7 @@ export default [
   ...rebootProfiles,
   ...removalProfiles,
   ...repo,
+  ...reports,
   ...repositoryProfiles,
   ...roles,
   ...savedSearches,

--- a/src/tests/server/handlers/instance.ts
+++ b/src/tests/server/handlers/instance.ts
@@ -32,6 +32,7 @@ import type { Instance, PendingInstance } from "@/types/Instance";
 import type { GroupsResponse } from "@/types/User";
 import { delay, http, HttpResponse } from "msw";
 import { generatePaginatedResponse, isAction } from "./_helpers";
+import { getEndpointStatusApiError } from "./_constants";
 
 export default [
   http.get<never, GetInstancesParams, ApiPaginatedResponse<Instance>>(
@@ -39,14 +40,29 @@ export default [
     async ({ request }) => {
       const endpointStatus = getEndpointStatus();
 
-      if (endpointStatus.status === "error") {
-        throw new HttpResponse(null, { status: 500 });
+      const url = new URL(request.url);
+      const query = url.searchParams.get("query") || "";
+
+      if (
+        endpointStatus.status === "error" &&
+        endpointStatus.path === "computers-tagged-loading" &&
+        query.includes(" OR ")
+      ) {
+        return new Promise<never>(() => undefined);
       }
 
-      const url = new URL(request.url);
+      if (
+        endpointStatus.status === "error" &&
+        (!endpointStatus.path ||
+          endpointStatus.path === "computers" ||
+          (endpointStatus.path === "computers-tagged-error" &&
+            query.includes(" OR ")))
+      ) {
+        throw getEndpointStatusApiError();
+      }
+
       const offset = Number(url.searchParams.get("offset")) || 0;
       const limit = Number(url.searchParams.get("limit")) || 1;
-      const query = url.searchParams.get("query") || "";
 
       if (query.includes("has-pro-management:false")) {
         return HttpResponse.json(
@@ -248,12 +264,35 @@ export default [
     const endpointStatus = getEndpointStatus();
 
     if (endpointStatus.status === "error") {
-      throw new HttpResponse(null, { status: 500 });
+      throw getEndpointStatusApiError();
     }
 
     const releaseUpgradeActivity = RELEASE_UPGRADE_ACTIVITY;
     return HttpResponse.json(releaseUpgradeActivity);
   }),
+
+  http.post(`${API_URL}computers/upgrade-packages`, async () => {
+    const endpointStatus = getEndpointStatus();
+
+    if (endpointStatus.status === "error") {
+      throw getEndpointStatusApiError();
+    }
+
+    return HttpResponse.json(activities[0]);
+  }),
+
+  http.post<never, never, Activity>(
+    `${API_URL}computers/:computerId/restart`,
+    async () => {
+      const endpointStatus = getEndpointStatus();
+
+      if (endpointStatus.status === "error") {
+        throw getEndpointStatusApiError();
+      }
+
+      return HttpResponse.json(activities[0]);
+    },
+  ),
 
   http.get<never, GetInstanceParams, Instance>(
     `${API_URL}computers/:computerId`,
@@ -261,7 +300,7 @@ export default [
       const endpointStatus = getEndpointStatus();
 
       if (endpointStatus.status === "error") {
-        throw new HttpResponse(null, { status: 500 });
+        throw getEndpointStatusApiError();
       }
 
       const url = new URL(request.url);
@@ -270,6 +309,33 @@ export default [
       return HttpResponse.json(
         instances.find((inst) => inst.id === Number(computerId)) || null,
       );
+    },
+  ),
+
+  http.put(`${API_URL}computers/:computerId`, async () => {
+    const endpointStatus = getEndpointStatus();
+    if (
+      endpointStatus.status === "error" &&
+      (!endpointStatus.path || endpointStatus.path === "editInstance")
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
+    return HttpResponse.json(instances[0]);
+  }),
+
+  http.post(
+    `${API_URL}computers/:computerId/usergroups/update_bulk`,
+    async () => {
+      const endpointStatus = getEndpointStatus();
+      if (
+        endpointStatus.status === "error" &&
+        (!endpointStatus.path || endpointStatus.path === "userGroups")
+      ) {
+        throw getEndpointStatusApiError();
+      }
+
+      return HttpResponse.json(activities[0]);
     },
   ),
 
@@ -285,6 +351,22 @@ export default [
     GetUserGroupsParams,
     GroupsResponse
   >(`${API_URL}computers/:computerId/users/:username/groups`, () => {
+    const endpointStatus = getEndpointStatus();
+    const daemonGroups = userGroups.filter((group) => group.name === "daemon");
+    const shouldReturnEmptyGroups =
+      endpointStatus.status === "empty" &&
+      (!endpointStatus.path || endpointStatus.path === "users/groups");
+    const shouldReturnDaemonGroupOnly =
+      endpointStatus.path === "users/groups:daemon";
+
+    if (shouldReturnEmptyGroups) {
+      return HttpResponse.json({ groups: [] });
+    }
+
+    if (shouldReturnDaemonGroupOnly) {
+      return HttpResponse.json({ groups: daemonGroups });
+    }
+
     return HttpResponse.json({ groups: userGroups });
   }),
 

--- a/src/tests/server/handlers/kernel.ts
+++ b/src/tests/server/handlers/kernel.ts
@@ -1,10 +1,13 @@
 import { API_URL } from "@/constants";
+import type { Activity } from "@/features/activities";
 import type {
   KernelManagementInfo,
   LivepatchInformation,
 } from "@/features/kernel";
 import { getEndpointStatus } from "@/tests/controllers/controller";
+import { activities } from "@/tests/mocks/activity";
 import { http, HttpResponse } from "msw";
+import { getEndpointStatusApiError } from "./_constants";
 
 export default [
   http.get<never, never, KernelManagementInfo>(
@@ -92,6 +95,18 @@ export default [
           },
         },
       });
+    },
+  ),
+  http.post<never, never, Activity>(
+    `${API_URL}computers/:id/kernel/upgrade`,
+    async () => {
+      const endpointStatus = getEndpointStatus();
+
+      if (endpointStatus.status === "error") {
+        throw getEndpointStatusApiError();
+      }
+
+      return HttpResponse.json(activities[0]);
     },
   ),
 ];

--- a/src/tests/server/handlers/pockets.ts
+++ b/src/tests/server/handlers/pockets.ts
@@ -34,7 +34,11 @@ export default [
         endpointStatus.path === "ListPocketMany"
           ? Array.from({ length: 25 }, (_, index) => {
               const basePocket = listPockets[index % listPockets.length];
-              assert(basePocket);
+              if (!basePocket) {
+                throw new Error(
+                  "Expected at least one pocket in mock pocket data",
+                );
+              }
               return {
                 ...basePocket,
                 name: `${basePocket.name}-${index + 1}`,

--- a/src/tests/server/handlers/pockets.ts
+++ b/src/tests/server/handlers/pockets.ts
@@ -1,14 +1,16 @@
-import { API_URL_OLD } from "@/constants";
+import { API_URL, API_URL_OLD } from "@/constants";
 import type {
   DiffPullPocketParams,
   ListPocketParams,
 } from "@/features/mirrors";
 import type { PackageDiff, PackageObject } from "@/features/packages";
 import { getEndpointStatus } from "@/tests/controllers/controller";
+import { activities } from "@/tests/mocks/activity";
 import type { ApiPaginatedResponse } from "@/types/api/ApiPaginatedResponse";
 import { http, HttpResponse } from "msw";
 import { generatePaginatedResponse, isAction } from "./_helpers";
 import { diffPocket, listPockets } from "@/tests/mocks/pockets";
+import { getEndpointStatusApiError } from "./_constants";
 
 export default [
   http.get<never, ListPocketParams, ApiPaginatedResponse<PackageObject>>(
@@ -25,10 +27,24 @@ export default [
       const search = url.searchParams.get("search") ?? "";
       const offset = Number(url.searchParams.get("offset")) || 0;
       const limit = Number(url.searchParams.get("limit")) || DEFAULT_PAGE_SIZE;
+      const shouldUseEmptyData =
+        endpointStatus.status === "empty" &&
+        (!endpointStatus.path || endpointStatus.path === "ListPocket");
+      const listPocketSource =
+        endpointStatus.path === "ListPocketMany"
+          ? Array.from({ length: 25 }, (_, index) => {
+              const basePocket = listPockets[index % listPockets.length];
+              assert(basePocket);
+              return {
+                ...basePocket,
+                name: `${basePocket.name}-${index + 1}`,
+              };
+            })
+          : listPockets;
 
       return HttpResponse.json(
         generatePaginatedResponse<PackageObject>({
-          data: endpointStatus.status === "default" ? listPockets : [],
+          data: shouldUseEmptyData ? [] : listPocketSource,
           limit,
           offset,
           search,
@@ -43,7 +59,117 @@ export default [
         return;
       }
 
+      const endpointStatus = getEndpointStatus();
+
+      if (endpointStatus.path === "DiffPullPocketUpdate") {
+        return HttpResponse.json({
+          "main:amd64": {
+            add: [],
+            update: [["pocket1", "1.0.0", "2.0.0"]],
+            delete: [["pocket2", "1.0.0"]],
+          },
+        });
+      }
+
+      if (endpointStatus.path === "DiffPullPocketAddOnly") {
+        return HttpResponse.json({
+          "main:amd64": {
+            add: [["pocket1", "1.0.0"]],
+            update: [],
+            delete: [],
+          },
+        });
+      }
+
+      if (endpointStatus.path === "DiffPullPocketNoChanges") {
+        return HttpResponse.json({});
+      }
+
       return HttpResponse.json(diffPocket);
     },
   ),
+  http.get(API_URL_OLD, async ({ request }) => {
+    if (
+      !isAction(request, [
+        "EditPocket",
+        "SyncMirrorPocket",
+        "PullPackagesToPocket",
+      ])
+    ) {
+      return;
+    }
+
+    const endpointStatus = getEndpointStatus();
+    const action = new URL(request.url).searchParams.get("action");
+    if (
+      endpointStatus.path === "SyncMirrorPocketLoading" &&
+      isAction(request, "SyncMirrorPocket")
+    ) {
+      return new Promise<never>(() => undefined);
+    }
+
+    if (
+      endpointStatus.status === "error" &&
+      (!endpointStatus.path || endpointStatus.path === action)
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
+    return HttpResponse.json(activities[0]);
+  }),
+  http.get(API_URL_OLD, async ({ request }) => {
+    if (
+      !isAction(request, [
+        "RemovePocket",
+        "RemovePackagesFromPocket",
+        "AddPackageFiltersToPocket",
+        "RemovePackageFiltersFromPocket",
+        "AddUploaderGPGKeysToPocket",
+        "RemoveUploaderGPGKeysFromPocket",
+      ])
+    ) {
+      return;
+    }
+
+    const endpointStatus = getEndpointStatus();
+    const action = new URL(request.url).searchParams.get("action");
+    if (
+      endpointStatus.status === "error" &&
+      (!endpointStatus.path || endpointStatus.path === action)
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
+    return HttpResponse.json(null);
+  }),
+  http.post(`${API_URL}pockets/sync`, async () => {
+    const endpointStatus = getEndpointStatus();
+    if (
+      endpointStatus.status === "error" &&
+      (!endpointStatus.path || endpointStatus.path === "pockets/sync")
+    ) {
+      throw getEndpointStatusApiError();
+    }
+    return HttpResponse.json(activities[0]);
+  }),
+  http.post(`${API_URL}pockets/pull`, async () => {
+    const endpointStatus = getEndpointStatus();
+    if (
+      endpointStatus.status === "error" &&
+      (!endpointStatus.path || endpointStatus.path === "pockets/pull")
+    ) {
+      throw getEndpointStatusApiError();
+    }
+    return HttpResponse.json(activities[0]);
+  }),
+  http.delete(`${API_URL}pockets/:distribution/:series/:name`, async () => {
+    const endpointStatus = getEndpointStatus();
+    if (
+      endpointStatus.status === "error" &&
+      (!endpointStatus.path || endpointStatus.path === "pockets/delete")
+    ) {
+      throw getEndpointStatusApiError();
+    }
+    return new HttpResponse(null, { status: 204 });
+  }),
 ];

--- a/src/tests/server/handlers/process.ts
+++ b/src/tests/server/handlers/process.ts
@@ -1,10 +1,13 @@
 import { API_URL } from "@/constants";
+import type { Activity } from "@/features/activities";
 import type { GetProcessesParams, Process } from "@/features/processes";
 import { getEndpointStatus } from "@/tests/controllers/controller";
+import { activities } from "@/tests/mocks/activity";
 import { processes } from "@/tests/mocks/process";
 import { generatePaginatedResponse } from "@/tests/server/handlers/_helpers";
 import type { ApiPaginatedResponse } from "@/types/api/ApiPaginatedResponse";
 import { http, HttpResponse } from "msw";
+import { getEndpointStatusApiError } from "./_constants";
 
 export default [
   http.get<never, GetProcessesParams, ApiPaginatedResponse<Process>>(
@@ -13,7 +16,7 @@ export default [
       const endpointStatus = getEndpointStatus();
 
       if (endpointStatus.status === "error") {
-        throw new HttpResponse(null, { status: 500 });
+        throw getEndpointStatusApiError();
       }
 
       const url = new URL(request.url);
@@ -32,4 +35,25 @@ export default [
       );
     },
   ),
+  http.post<never, never, Activity>(
+    `${API_URL}processes/terminate`,
+    async () => {
+      const endpointStatus = getEndpointStatus();
+
+      if (endpointStatus.status === "error") {
+        throw getEndpointStatusApiError();
+      }
+
+      return HttpResponse.json(activities[0]);
+    },
+  ),
+  http.post<never, never, Activity>(`${API_URL}processes/kill`, async () => {
+    const endpointStatus = getEndpointStatus();
+
+    if (endpointStatus.status === "error") {
+      throw getEndpointStatusApiError();
+    }
+
+    return HttpResponse.json(activities[0]);
+  }),
 ];

--- a/src/tests/server/handlers/reports.ts
+++ b/src/tests/server/handlers/reports.ts
@@ -1,0 +1,23 @@
+import { API_URL_OLD } from "@/constants";
+import { getEndpointStatus } from "@/tests/controllers/controller";
+import { http, HttpResponse } from "msw";
+import { isAction } from "./_helpers";
+
+export default [
+  http.get(API_URL_OLD, ({ request }) => {
+    if (!isAction(request, "GetCSVComplianceData")) {
+      return;
+    }
+
+    const endpointStatus = getEndpointStatus();
+
+    if (
+      endpointStatus.status === "empty" &&
+      (!endpointStatus.path || endpointStatus.path === "reports")
+    ) {
+      return HttpResponse.json("");
+    }
+
+    return HttpResponse.json("name,status\ninstance-1,ok");
+  }),
+];

--- a/src/tests/server/handlers/roles.ts
+++ b/src/tests/server/handlers/roles.ts
@@ -1,25 +1,26 @@
 import { API_URL_OLD } from "@/constants";
 import type { GetRolesParams } from "@/hooks/useRoles";
 import { getEndpointStatus } from "@/tests/controllers/controller";
-import { permissions, roles } from "@/tests/mocks/roles";
+import { permissions, roles as roleMocks } from "@/tests/mocks/roles";
 import { isAction } from "@/tests/server/handlers/_helpers";
 import type { Permission } from "@/types/Permission";
 import type { Role } from "@/types/Role";
 import { http, HttpResponse } from "msw";
+import { getEndpointStatusApiError } from "./_constants";
 
 export default [
   http.get<never, GetRolesParams, Role[]>(API_URL_OLD, ({ request }) => {
-    const { status } = getEndpointStatus();
+    const { status, path } = getEndpointStatus();
 
     if (!isAction(request, "GetRoles")) {
       return;
     }
 
-    if (status === "empty") {
+    if (status === "empty" && (!path || path === "roles")) {
       return HttpResponse.json([]);
     }
 
-    return HttpResponse.json(roles);
+    return HttpResponse.json(roleMocks);
   }),
 
   http.get<never, never, Permission[]>(API_URL_OLD, ({ request }) => {
@@ -28,5 +29,57 @@ export default [
     }
 
     return HttpResponse.json(permissions);
+  }),
+
+  http.get(API_URL_OLD, ({ request }) => {
+    if (
+      !isAction(request, [
+        "AddPermissionsToRole",
+        "RemovePermissionsFromRole",
+        "AddAccessGroupsToRole",
+        "RemoveAccessGroupsFromRole",
+      ])
+    ) {
+      return;
+    }
+
+    const { status, path } = getEndpointStatus();
+
+    if (status === "error" && (!path || path === "editRole")) {
+      throw getEndpointStatusApiError();
+    }
+
+    const [role] = roleMocks;
+    assert(role);
+
+    const { searchParams } = new URL(request.url);
+    const roleName = searchParams.get("name");
+    const getMultiValueParams = (baseName: string): string[] => {
+      const values = searchParams.getAll(baseName);
+
+      for (const [key, value] of searchParams.entries()) {
+        if (key.startsWith(`${baseName}.`)) {
+          values.push(value);
+        }
+      }
+
+      return values;
+    };
+
+    const accessGroups = Array.from(
+      new Set(getMultiValueParams("access_groups")),
+    );
+    const permissionsParams = Array.from(
+      new Set(getMultiValueParams("permissions")),
+    );
+
+    return HttpResponse.json({
+      ...role,
+      name: roleName ?? role.name,
+      access_groups:
+        accessGroups.length > 0 ? accessGroups : role.access_groups,
+      permissions:
+        permissionsParams.length > 0 ? permissionsParams : role.permissions,
+    });
   }),
 ];

--- a/src/tests/server/handlers/roles.ts
+++ b/src/tests/server/handlers/roles.ts
@@ -50,7 +50,9 @@ export default [
     }
 
     const [role] = roleMocks;
-    assert(role);
+    if (!role) {
+      throw new Error("Expected at least one role in mock role data");
+    }
 
     const { searchParams } = new URL(request.url);
     const roleName = searchParams.get("name");

--- a/src/tests/server/handlers/script.ts
+++ b/src/tests/server/handlers/script.ts
@@ -59,15 +59,8 @@ export default [
     const endpointStatus = getEndpointStatus();
 
     if (
-      endpointStatus.status === "error" &&
-      endpointStatus.path === "scripts/profiles-loading"
-    ) {
-      return new Promise<never>(() => undefined);
-    }
-
-    if (
       endpointStatus.status === "empty" &&
-      endpointStatus.path === "scripts/profiles"
+      endpointStatus.path === "script-profiles"
     ) {
       return HttpResponse.json({
         results: [],
@@ -98,35 +91,31 @@ export default [
     return HttpResponse.json(scriptVersion);
   }),
 
-  http.get(`${API_URL}scripts/:id/attachments/:attachmentId`, async () => {
-    const endpointStatus = getEndpointStatus();
-
-    if (
-      endpointStatus.path &&
-      endpointStatus.path.includes("scripts/attachments/html")
-    ) {
-      return new HttpResponse(scriptAttachmentHtml, {
-        headers: {
-          "Content-Type": "text/html",
-        },
-      });
-    }
-
-    return new HttpResponse(scriptAttachment, {
-      headers: {
-        "Content-Type": "text/plain",
-      },
-    });
-  }),
-
   http.get(
-    `${API_URL}scripts/:scriptId/attachments/:attachmentId`,
+    `${API_URL}scripts/:id/attachments/:attachmentId`,
     async ({ params }) => {
       if (params.attachmentId === "999") {
-        return HttpResponse.json(null);
+        return new HttpResponse(null, { status: 404 });
       }
 
-      return HttpResponse.json("attachment");
+      const endpointStatus = getEndpointStatus();
+
+      if (
+        endpointStatus.path &&
+        endpointStatus.path.includes("scripts/attachments/html")
+      ) {
+        return new HttpResponse(scriptAttachmentHtml, {
+          headers: {
+            "Content-Type": "text/html",
+          },
+        });
+      }
+
+      return new HttpResponse(scriptAttachment, {
+        headers: {
+          "Content-Type": "text/plain",
+        },
+      });
     },
   ),
 
@@ -162,7 +151,7 @@ export default [
     return HttpResponse.json({ id: 99 });
   }),
 
-  http.get(API_URL_OLD, ({ request }) => {
+  http.post(API_URL_OLD, ({ request }) => {
     if (!isAction(request, "CreateScriptAttachment")) {
       return;
     }

--- a/src/tests/server/handlers/script.ts
+++ b/src/tests/server/handlers/script.ts
@@ -1,5 +1,6 @@
 import { API_URL, API_URL_OLD } from "@/constants";
 import { getEndpointStatus } from "@/tests/controllers/controller";
+import { activities } from "@/tests/mocks/activity";
 import {
   detailedScriptsData,
   scriptAttachment,
@@ -9,12 +10,12 @@ import {
   scriptVersionsWithPagination,
 } from "@/tests/mocks/script";
 import { scriptProfiles } from "@/tests/mocks/scriptProfiles";
-import { activities } from "@/tests/mocks/activity";
 import {
   generatePaginatedResponse,
   isAction,
 } from "@/tests/server/handlers/_helpers";
 import { http, HttpResponse } from "msw";
+import { getEndpointStatusApiError } from "./_constants";
 
 export default [
   http.get(`${API_URL}scripts`, async ({ request }) => {
@@ -56,10 +57,17 @@ export default [
 
   http.get(`${API_URL}scripts/:id/script-profiles`, async () => {
     const endpointStatus = getEndpointStatus();
+
     if (
-      (!endpointStatus.path ||
-        endpointStatus.path.includes("script-profiles")) &&
-      endpointStatus.status === "empty"
+      endpointStatus.status === "error" &&
+      endpointStatus.path === "scripts/profiles-loading"
+    ) {
+      return new Promise<never>(() => undefined);
+    }
+
+    if (
+      endpointStatus.status === "empty" &&
+      endpointStatus.path === "scripts/profiles"
     ) {
       return HttpResponse.json({
         results: [],
@@ -68,13 +76,13 @@ export default [
         previous: null,
       });
     }
-    return HttpResponse.json(
-      generatePaginatedResponse({
-        data: scriptProfiles,
-        limit: 20,
-        offset: 0,
-      }),
-    );
+
+    return HttpResponse.json({
+      results: scriptProfiles,
+      count: scriptProfiles.length,
+      next: null,
+      previous: null,
+    });
   }),
 
   http.get(`${API_URL}scripts/:id`, async ({ params }) => {
@@ -111,6 +119,17 @@ export default [
     });
   }),
 
+  http.get(
+    `${API_URL}scripts/:scriptId/attachments/:attachmentId`,
+    async ({ params }) => {
+      if (params.attachmentId === "999") {
+        return HttpResponse.json(null);
+      }
+
+      return HttpResponse.json("attachment");
+    },
+  ),
+
   http.get(`${API_URL}scripts/:id/versions`, async ({ request }) => {
     const DEFAULT_PAGE_SIZE = 20;
     const url = new URL(request.url);
@@ -128,24 +147,63 @@ export default [
     );
   }),
 
+  http.post(API_URL_OLD, ({ request }) => {
+    if (!isAction(request, "CreateScript")) {
+      return;
+    }
+
+    if (
+      getEndpointStatus().status === "error" &&
+      getEndpointStatus().path === "CreateScript"
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
+    return HttpResponse.json({ id: 99 });
+  }),
+
   http.get(API_URL_OLD, ({ request }) => {
-    if (!isAction(request, "EditScript")) {
-      return;
-    }
-    return HttpResponse.json({});
-  }),
-
-  http.post(API_URL_OLD, ({ request }) => {
-    if (!isAction(request, "EditScript")) {
-      return;
-    }
-    return HttpResponse.json({});
-  }),
-
-  http.post(API_URL_OLD, ({ request }) => {
     if (!isAction(request, "CreateScriptAttachment")) {
       return;
     }
+
+    if (
+      getEndpointStatus().status === "error" &&
+      getEndpointStatus().path === "CreateScriptAttachment"
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
+    return HttpResponse.json({});
+  }),
+
+  http.post(API_URL_OLD, ({ request }) => {
+    if (!isAction(request, "EditScript")) {
+      return;
+    }
+
+    if (
+      getEndpointStatus().status === "error" &&
+      getEndpointStatus().path === "EditScript"
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
+    return HttpResponse.json({});
+  }),
+
+  http.get(API_URL_OLD, ({ request }) => {
+    if (!isAction(request, "RemoveScriptAttachment")) {
+      return;
+    }
+
+    if (
+      getEndpointStatus().status === "error" &&
+      getEndpointStatus().path === "RemoveScriptAttachment"
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
     return HttpResponse.json({});
   }),
 
@@ -153,6 +211,14 @@ export default [
     if (!isAction(request, "ExecuteScript")) {
       return;
     }
+
+    if (
+      getEndpointStatus().status === "error" &&
+      getEndpointStatus().path === "ExecuteScript"
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
     return HttpResponse.json(activities[0]);
   }),
 ];

--- a/src/tests/server/handlers/tag.ts
+++ b/src/tests/server/handlers/tag.ts
@@ -9,7 +9,9 @@ import {
   isAction,
 } from "@/tests/server/handlers/_helpers";
 import type { ApiPaginatedResponse } from "@/types/api/ApiPaginatedResponse";
+import { getEndpointStatus } from "@/tests/controllers/controller";
 import { http, HttpResponse } from "msw";
+import { getEndpointStatusApiError } from "./_constants";
 
 export default [
   http.get<never, never, ApiPaginatedResponse<string>>(`${API_URL}tags`, () => {
@@ -27,15 +29,39 @@ export default [
     UseGetProfileChangesParams,
     ApiPaginatedResponse<ProfileChange>
   >(`${API_URL}tags/profile-diff`, ({ request }) => {
+    const endpointStatus = getEndpointStatus();
+
+    if (
+      endpointStatus.status === "error" &&
+      endpointStatus.path === "tags/profile-diff"
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
     const { searchParams } = new URL(request.url);
 
     const offset = searchParams.get("offset");
     const limit = searchParams.get("limit");
+    const parsedOffset = offset ? parseInt(offset) : 0;
+    const parsedLimit = limit ? parseInt(limit) : 100;
+
+    if (
+      endpointStatus.status === "empty" &&
+      endpointStatus.path === "tags/profile-diff"
+    ) {
+      return HttpResponse.json(
+        generatePaginatedResponse<ProfileChange>({
+          data: [],
+          offset: parsedOffset,
+          limit: parsedLimit,
+        }),
+      );
+    }
 
     const response = generatePaginatedResponse<ProfileChange>({
       data: profileChanges,
-      offset: offset ? parseInt(offset) : 0,
-      limit: limit ? parseInt(limit) : 100,
+      offset: parsedOffset,
+      limit: parsedLimit,
     });
 
     return HttpResponse.json(response);

--- a/src/tests/server/handlers/user.ts
+++ b/src/tests/server/handlers/user.ts
@@ -10,7 +10,9 @@ import { getEndpointStatusApiError } from "./_constants";
 
 const [defaultAccount] = userDetails.accounts;
 
-assert(defaultAccount);
+if (!defaultAccount) {
+  throw new Error("Expected at least one account in mock userDetails data");
+}
 
 const userCredentials: UserCredentials = {
   credentials: [

--- a/src/tests/server/handlers/user.ts
+++ b/src/tests/server/handlers/user.ts
@@ -5,6 +5,25 @@ import type { User } from "@/types/User";
 import { userDetails, users } from "@/tests/mocks/user";
 import { getEndpointStatus } from "@/tests/controllers/controller";
 import { MAX_USERS_LIMIT } from "@/pages/dashboard/instances/[single]/tabs/users/UserPanel/constants";
+import type { UserCredentials } from "@/features/api-credentials";
+import { getEndpointStatusApiError } from "./_constants";
+
+const [defaultAccount] = userDetails.accounts;
+
+assert(defaultAccount);
+
+const userCredentials: UserCredentials = {
+  credentials: [
+    {
+      account_name: defaultAccount.name,
+      account_title: defaultAccount.title,
+      endpoint: "https://api.example.com/test-account",
+      access_key: "",
+      secret_key: "",
+      exports: "",
+    },
+  ],
+};
 
 export default [
   http.get(`${API_URL}users`, () => {
@@ -20,9 +39,75 @@ export default [
     );
   }),
 
+  http.post(`${API_URL}users`, async () => {
+    const endpointStatus = getEndpointStatus();
+    if (
+      endpointStatus.status === "error" &&
+      (!endpointStatus.path || endpointStatus.path === "users")
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
+    return HttpResponse.json(userDetails);
+  }),
+
+  http.put(`${API_URL}users`, async () => {
+    const endpointStatus = getEndpointStatus();
+    if (
+      endpointStatus.status === "error" &&
+      (!endpointStatus.path || endpointStatus.path === "users")
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
+    return HttpResponse.json(userDetails);
+  }),
+
+  http.delete(`${API_URL}users`, async () => {
+    const endpointStatus = getEndpointStatus();
+    if (
+      endpointStatus.status === "error" &&
+      (!endpointStatus.path || endpointStatus.path === "users")
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
+    return HttpResponse.json(userDetails);
+  }),
+
+  http.post(`${API_URL}users/lock`, async () => {
+    const endpointStatus = getEndpointStatus();
+    if (
+      endpointStatus.status === "error" &&
+      (!endpointStatus.path || endpointStatus.path === "lockUser")
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
+    return HttpResponse.json(userDetails);
+  }),
+
+  http.post(`${API_URL}users/unlock`, async () => {
+    const endpointStatus = getEndpointStatus();
+    if (
+      endpointStatus.status === "error" &&
+      (!endpointStatus.path || endpointStatus.path === "unlockUser")
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
+    return HttpResponse.json(userDetails);
+  }),
+
   http.get(`${API_URL}person`, async () => {
     await delay();
 
     return HttpResponse.json(userDetails);
+  }),
+
+  http.get(`${API_URL}credentials`, async () => {
+    await delay();
+
+    return HttpResponse.json(userCredentials);
   }),
 ];

--- a/src/tests/server/handlers/usn.ts
+++ b/src/tests/server/handlers/usn.ts
@@ -3,8 +3,11 @@ import type { GetUsnsParams } from "@/features/usns";
 import type { ApiPaginatedResponse } from "@/types/api/ApiPaginatedResponse";
 import type { Usn } from "@/types/Usn";
 import { API_URL } from "@/constants";
+import { getEndpointStatus } from "@/tests/controllers/controller";
 import { usnPackages, usns } from "@/tests/mocks/usn";
+import { activities } from "@/tests/mocks/activity";
 import { generatePaginatedResponse } from "@/tests/server/handlers/_helpers";
+import { getEndpointStatusApiError } from "./_constants";
 
 export default [
   http.get<never, GetUsnsParams, ApiPaginatedResponse<Usn>>(
@@ -30,5 +33,15 @@ export default [
 
   http.get(`${API_URL}usns/:usnName`, () => {
     return HttpResponse.json(usnPackages);
+  }),
+
+  http.post(`${API_URL}computers/usns/upgrade-packages`, () => {
+    const endpointStatus = getEndpointStatus();
+
+    if (endpointStatus.status === "error") {
+      throw getEndpointStatusApiError();
+    }
+
+    return HttpResponse.json(activities[0]);
   }),
 ];

--- a/src/tests/server/handlers/wsl.ts
+++ b/src/tests/server/handlers/wsl.ts
@@ -2,10 +2,12 @@ import { API_URL, API_URL_OLD } from "@/constants";
 import type { Activity } from "@/features/activities";
 import type { WslInstanceType } from "@/features/wsl";
 import type { MakeWindowsInstancesCompliantParams } from "@/features/wsl-profiles";
+import { getEndpointStatus } from "@/tests/controllers/controller";
 import { instanceChildren, wslInstanceNames } from "@/tests/mocks/wsl";
 import type { InstanceChild } from "@/types/Instance";
 import { http, HttpResponse } from "msw";
 import { isAction } from "./_helpers";
+import { getEndpointStatusApiError } from "./_constants";
 
 export default [
   http.get<{ id: string }, never, { children: InstanceChild[] }>(
@@ -28,6 +30,15 @@ export default [
   ),
 
   http.post(`${API_URL}child-instance-profiles/:name\\:reapply`, () => {
+    const endpointStatus = getEndpointStatus();
+
+    if (
+      endpointStatus.status === "error" &&
+      endpointStatus.path === "child-instance-profiles/:name:reapply"
+    ) {
+      throw getEndpointStatusApiError();
+    }
+
     return HttpResponse.json();
   }),
 

--- a/src/types/Instance.ts
+++ b/src/types/Instance.ts
@@ -201,6 +201,7 @@ export interface InstanceWithoutRelation extends Record<string, unknown> {
 
 type WithRelation<T extends InstanceWithoutRelation> = T & {
   parent: InstanceWithoutRelation | null;
+  children: Omit<InstanceWithoutRelation, "children">[];
 };
 
 export type Instance = WithRelation<InstanceWithoutRelation>;


### PR DESCRIPTION
## Summary

This PR adds code coverage for all non profile related files with under 60% coverage.

## Release Impact

According to the [Landscape Server Release Cycle](https://docs.google.com/document/d/1sKAp5IvArpfArhMNojFwKOHm9LEdHKB4Et6tu1_-0GY/edit?tab=t.0), this change will target the following release cycle:
- **Target Branch**: `dev` / `main` (Beta)
- **Version Impact**:
  - [ ] Patch (Fix)
  - [ ] Minor (Feature)
  - [ ] Major (Breaking)

## Checklist
- [ ] **Changeset Added**: I have run `pnpm changeset` and committed the resulting `.md` file.
- [ ] **UI Verified**: I have verified the changes locally.
- [ ] **Linting**: No linting errors are present (especially in `scripts/`).

## Versioning Reminder
> [!IMPORTANT]
> This repository now uses **CalVer** ($YY.0M.Point.Patch$).
> Please ensure your changeset description is clear, as it will be automatically added to the `CHANGELOG.md` upon merging to `main`.