### PR TITLE
fix: adjust z-index values for side panel and dropdown elements

### DIFF
--- a/.changeset/soft-lemons-train.md
+++ b/.changeset/soft-lemons-train.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Fix bug causing saved searches dropdown to appear above wide sidepanels and modals

--- a/src/components/layout/SidePanel/SidePanel.module.scss
+++ b/src/components/layout/SidePanel/SidePanel.module.scss
@@ -10,6 +10,7 @@
   flex-direction: column;
   overflow: visible;
   padding-bottom: 0;
+  z-index: var(--z-sidepanel);
 }
 
 .medium {

--- a/src/features/saved-searches/components/SearchBoxWithSavedSearches/SearchBoxWithSavedSearches.module.scss
+++ b/src/features/saved-searches/components/SearchBoxWithSavedSearches/SearchBoxWithSavedSearches.module.scss
@@ -8,6 +8,7 @@
 
   & + :global(.p-search-and-filter__panel) {
     background-color: $colors--theme--background-default;
+    z-index: var(--z-page-dropdown);
   }
 }
 

--- a/src/styles/partials/elevation.scss
+++ b/src/styles/partials/elevation.scss
@@ -6,6 +6,7 @@
   --z-table-corner: 250;
   --z-sticky: 300;
   --z-application: 350;
+  --z-page-dropdown: 375;
   --z-sidepanel: 400;
   --z-navigation: 450;
   --z-dropdown: 500;

--- a/src/styles/partials/layout.scss
+++ b/src/styles/partials/layout.scss
@@ -19,7 +19,7 @@
   }
 
   .l-application & {
-    z-index: var(--z-application);
+    z-index: var(--z-sidepanel);
   }
 }
 


### PR DESCRIPTION
## Summary

This PR is related to [this Jira ticket](https://warthogs.atlassian.net/browse/LNDENG-4050)

Additionally it fixes this UI bug that is not shown in that ticket:

<img width="2078" height="935" alt="image" src="https://github.com/user-attachments/assets/c0582c8b-1ea6-419f-9620-17562cfbea81" />

## Release Impact

According to the [Landscape Server Release Cycle](https://docs.google.com/document/d/1sKAp5IvArpfArhMNojFwKOHm9LEdHKB4Et6tu1_-0GY/edit?tab=t.0), this change will target the following release cycle:
- **Target Branch**: `dev` / `main` (Beta)
- **Version Impact**:
  - [x] Patch (Fix)
  - [ ] Minor (Feature)
  - [ ] Major (Breaking)

## Checklist
- [x] **Changeset Added**: I have run `pnpm changeset` and committed the resulting `.md` file.
- [x] **UI Verified**: I have verified the changes locally.
- [x] **Linting**: No linting errors are present (especially in `scripts/`).

## Versioning Reminder
> [!IMPORTANT]
> This repository now uses **CalVer** ($YY.0M.Point.Patch$).
> Please ensure your changeset description is clear, as it will be automatically added to the `CHANGELOG.md` upon merging to `main`.