### PR TITLE
refactor: replace spinners with inline loading states across components

### DIFF
--- a/src/components/layout/LoadingState/LoadingState.tsx
+++ b/src/components/layout/LoadingState/LoadingState.tsx
@@ -17,7 +17,7 @@ const LoadingState: FC<LoadingStateProps> = ({ centerOnScreen, inline }) => {
   );
 
   if (inline) {
-    return <div role="status">{spinningElement}</div>;
+    return <span role="status">{spinningElement}</span>;
   }
 
   return (

--- a/src/components/layout/Redirecting/Redirecting.test.tsx
+++ b/src/components/layout/Redirecting/Redirecting.test.tsx
@@ -6,12 +6,7 @@ describe("Redirecting", () => {
     render(<Redirecting />);
 
     expect(screen.getByRole("status")).toBeInTheDocument();
-
-    const labelSpans = screen.getAllByText("Redirecting...");
-
-    expect(labelSpans).toHaveLength(2);
-
-    expect(labelSpans[0]).toBeOffScreen();
-    expect(labelSpans[1]).not.toBeOffScreen();
+    expect(screen.getByText("Loading...")).toBeOffScreen();
+    expect(screen.getByText("Redirecting...")).not.toBeOffScreen();
   });
 });

--- a/src/components/layout/Redirecting/Redirecting.tsx
+++ b/src/components/layout/Redirecting/Redirecting.tsx
@@ -1,12 +1,12 @@
+import LoadingState from "../LoadingState";
 import type { FC } from "react";
 import classes from "./Redirecting.module.scss";
 
 const Redirecting: FC = () => {
   return (
     <div className={classes.root}>
-      <span role="status" className={classes.icon}>
-        <span className="u-off-screen">Redirecting...</span>
-        <i className="p-icon--spinner u-animation--spin" aria-hidden />
+      <span className={classes.icon}>
+        <LoadingState inline />
       </span>
       <span>Redirecting...</span>
     </div>

--- a/src/features/access-groups/components/AccessGroupInstanceCountCell/AccessGroupInstanceCountCell.tsx
+++ b/src/features/access-groups/components/AccessGroupInstanceCountCell/AccessGroupInstanceCountCell.tsx
@@ -1,6 +1,6 @@
+import LoadingState from "@/components/layout/LoadingState";
 import { useGetInstances } from "@/features/instances";
 import { pluralizeWithCount } from "@/utils/_helpers";
-import { Spinner } from "@canonical/react-components";
 import { type FC } from "react";
 import { Link } from "react-router";
 import type { AccessGroupWithInstancesCount } from "../../types/AccessGroup";
@@ -21,12 +21,7 @@ const AccessGroupInstanceCountCell: FC<AccessGroupInstanceCountCellProps> = ({
   });
 
   if (isGettingInstances) {
-    return (
-      <>
-        <span className="u-off-screen">Loading...</span>
-        <Spinner aria-hidden />
-      </>
-    );
+    return <LoadingState inline />;
   }
 
   if (instancesCount) {

--- a/src/pages/auth/handle/oidc/OidcAuthPage/OidcAuthPage.module.scss
+++ b/src/pages/auth/handle/oidc/OidcAuthPage/OidcAuthPage.module.scss
@@ -1,6 +1,12 @@
+@import "vanilla-framework/scss/settings_spacing";
+
 .container {
   align-items: center;
   display: flex;
   height: 100vh;
   justify-content: center;
+}
+
+.loading {
+  margin-right: $sph--large;
 }

--- a/src/pages/auth/handle/oidc/OidcAuthPage/OidcAuthPage.tsx
+++ b/src/pages/auth/handle/oidc/OidcAuthPage/OidcAuthPage.tsx
@@ -6,6 +6,7 @@ import {
   GENERIC_DOMAIN,
   HOMEPAGE_PATH,
 } from "@/constants";
+import LoadingState from "@/components/layout/LoadingState";
 import { useGetOidcAuth } from "@/features/auth";
 import useAuth from "@/hooks/useAuth";
 import useEnv from "@/hooks/useEnv";
@@ -85,9 +86,8 @@ const OidcAuthPage: FC = () => {
     <div className={classes.container}>
       {isLoading ? (
         <div className="u-align-text--center">
-          <span role="status" style={{ marginRight: "1rem" }}>
-            <span className="u-off-screen">Loading...</span>
-            <i className="p-icon--spinner u-animation--spin" aria-hidden />
+          <span className={classes.loading}>
+            <LoadingState inline />
           </span>
           <span>Please wait while your request is being processed...</span>
         </div>

--- a/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.module.scss
+++ b/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.module.scss
@@ -1,6 +1,12 @@
+@import "vanilla-framework/scss/settings_spacing";
+
 .container {
   align-items: center;
   display: flex;
   height: 100vh;
   justify-content: center;
+}
+
+.loading {
+  margin-right: $sph--large;
 }

--- a/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.tsx
+++ b/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.tsx
@@ -6,6 +6,7 @@ import {
   GENERIC_DOMAIN,
   HOMEPAGE_PATH,
 } from "@/constants";
+import LoadingState from "@/components/layout/LoadingState";
 import useAuth from "@/hooks/useAuth";
 import useEnv from "@/hooks/useEnv";
 import { useGetStandaloneAccount } from "@/features/account-creation";
@@ -74,9 +75,8 @@ const UbuntuOneAuthPage: FC = () => {
     <div className={classes.container}>
       {isLoading ? (
         <div className="u-align-text--center">
-          <span role="status" style={{ marginRight: "1rem" }}>
-            <span className="u-off-screen">Loading...</span>
-            <i className="p-icon--spinner u-animation--spin" aria-hidden />
+          <span className={classes.loading}>
+            <LoadingState inline />
           </span>
           <span>Please wait while your request is being processed...</span>
         </div>

--- a/src/pages/dashboard/instances/[single]/SingleInstanceTabs/helpers.tsx
+++ b/src/pages/dashboard/instances/[single]/SingleInstanceTabs/helpers.tsx
@@ -1,7 +1,8 @@
+import LoadingState from "@/components/layout/LoadingState";
 import { getFeatures } from "@/features/instances";
 import useAuth from "@/hooks/useAuth";
 import type { Instance } from "@/types/Instance";
-import { Badge, Spinner } from "@canonical/react-components";
+import { Badge } from "@canonical/react-components";
 
 interface GetTabLabelProps {
   id: string;
@@ -32,7 +33,7 @@ const getTabLabel = ({
     return (
       <>
         <span>{label}</span>
-        <Spinner className="u-no-margin--bottom u-no-padding--top" />
+        <LoadingState inline />
       </>
     );
   }


### PR DESCRIPTION
## Summary

This item is related to [this Jira ticket](https://warthogs.atlassian.net/browse/LNDENG-4081). Moving all loading elements to use `LoadingState` (with inline or without it) makes it easier to maintain in the codebase. 

This is just a refactor and doesnt introduce new behavior

## Release Impact

According to the [Landscape Server Release Cycle](https://docs.google.com/document/d/1sKAp5IvArpfArhMNojFwKOHm9LEdHKB4Et6tu1_-0GY/edit?tab=t.0), this change will target the following release cycle:
- **Target Branch**: `dev` / `main` (Beta)
- **Version Impact**:
  - [ ] Patch (Fix)
  - [ ] Minor (Feature)
  - [ ] Major (Breaking)

## Checklist
- [ ] **Changeset Added**: I have run `pnpm changeset` and committed the resulting `.md` file.
- [x] **UI Verified**: I have verified the changes locally.
- [x] **Linting**: No linting errors are present (especially in `scripts/`).

## Versioning Reminder
> [!IMPORTANT]
> This repository now uses **CalVer** ($YY.0M.Point.Patch$).
> Please ensure your changeset description is clear, as it will be automatically added to the `CHANGELOG.md` upon merging to `main`.