### PR TITLE
Add icons to collapsed buttons inside dropdowns

### DIFF
--- a/.changeset/fluffy-hotels-divide.md
+++ b/.changeset/fluffy-hotels-divide.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+add icons to the collapsed buttons inside button dropdowns

--- a/.changeset/fluffy-hotels-divide.md
+++ b/.changeset/fluffy-hotels-divide.md
@@ -2,4 +2,4 @@
 "landscape-ui": patch
 ---
 
-add icons to the collapsed buttons inside button dropdowns
+Keep icons in the collapsed buttons inside button dropdowns

--- a/src/components/ui/ResponsiveButtons/ResponsiveButtons.test.tsx
+++ b/src/components/ui/ResponsiveButtons/ResponsiveButtons.test.tsx
@@ -113,4 +113,18 @@ describe("ResponsiveButtons", () => {
       screen.getByRole("button", { name: "Disabled button" }),
     ).toHaveAttribute("aria-disabled");
   });
+
+  it("preserves icon children in collapsed menu items", async () => {
+    setScreenSize("xs");
+
+    render(<ResponsiveButtons buttons={buttons} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /actions/i }));
+
+    const buttonWithIcon = screen.getByRole("button", {
+      name: "Button with icon",
+    });
+
+    expect(buttonWithIcon.querySelector(".p-icon--code")).toBeInTheDocument();
+  });
 });

--- a/src/components/ui/ResponsiveButtons/ResponsiveButtons.test.tsx
+++ b/src/components/ui/ResponsiveButtons/ResponsiveButtons.test.tsx
@@ -298,4 +298,18 @@ describe("ResponsiveButtons", () => {
 
     expect(menuClickFn).toHaveBeenCalled();
   });
+
+  it("preserves icon children in collapsed menu items", async () => {
+    setScreenSize("xs");
+
+    render(<ResponsiveButtons buttons={buttons} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /actions/i }));
+
+    const buttonWithIcon = screen.getByRole("button", {
+      name: "Button with icon",
+    });
+
+    expect(buttonWithIcon.querySelector(".p-icon--code")).toBeInTheDocument();
+  });
 });

--- a/src/components/ui/ResponsiveButtons/ResponsiveButtons.test.tsx
+++ b/src/components/ui/ResponsiveButtons/ResponsiveButtons.test.tsx
@@ -9,6 +9,7 @@ import { Button, ContextualMenu, Icon } from "@canonical/react-components";
 const simpleButtonClick = vi.fn();
 const buttonWithIconClick = vi.fn();
 const disabledButtonClick = vi.fn();
+const menuAction = vi.fn();
 
 const buttons: ComponentProps<typeof ResponsiveButtons>["buttons"] = [
   <button key="primary" onClick={simpleButtonClick}>
@@ -32,11 +33,25 @@ const buttons: ComponentProps<typeof ResponsiveButtons>["buttons"] = [
   >
     Disabled button
   </Button>,
+  <ContextualMenu
+    key="ctx-menu"
+    toggleLabel="More"
+    links={[
+      {
+        children: "Sub action",
+        onClick: menuAction,
+      },
+      {
+        children: "Read only link",
+      },
+    ]}
+  />,
 ];
 
 describe("ResponsiveButtons", () => {
   beforeEach(() => {
     resetScreenSize();
+    vi.clearAllMocks();
   });
 
   it("renders every button on large screens", () => {
@@ -311,5 +326,117 @@ describe("ResponsiveButtons", () => {
     });
 
     expect(buttonWithIcon.querySelector(".p-icon--code")).toBeInTheDocument();
+  });
+
+  it("applies custom className to wrapper", () => {
+    setScreenSize("lg");
+
+    const { container } = render(
+      <ResponsiveButtons
+        buttons={buttons}
+        collapseFrom="md"
+        className="custom-class"
+      />,
+    );
+
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+
+  it("disables the menu toggle when all collapsed items are disabled", () => {
+    setScreenSize("xs");
+
+    const allDisabledButtons = [
+      <Button key="d1" type="button" onClick={vi.fn()} disabled>
+        Disabled 1
+      </Button>,
+      <Button key="d2" type="button" onClick={vi.fn()} disabled>
+        Disabled 2
+      </Button>,
+    ];
+
+    render(<ResponsiveButtons buttons={allDisabledButtons} />);
+
+    expect(screen.getByRole("button", { name: /actions/i })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("keeps non-interactive nodes visible even on small screens", () => {
+    setScreenSize("xs");
+
+    const mixedButtons = [
+      <span key="text">Just a label</span>,
+      <Button key="action" type="button" onClick={vi.fn()}>
+        Action
+      </Button>,
+    ];
+
+    render(<ResponsiveButtons buttons={mixedButtons} />);
+
+    expect(screen.getByText("Just a label")).toBeInTheDocument();
+  });
+
+  it("collapses a ContextualMenu into the dropdown on small screens", async () => {
+    setScreenSize("xs");
+
+    render(<ResponsiveButtons buttons={buttons} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /actions/i }));
+    await userEvent.click(screen.getByRole("button", { name: "More" }));
+
+    expect(
+      screen.getByRole("button", { name: "Read only link" }),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Sub action" }));
+    expect(menuAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the menu after clicking a collapsed item", async () => {
+    setScreenSize("xs");
+
+    render(<ResponsiveButtons buttons={buttons} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /actions/i }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Simple button" }),
+    );
+
+    expect(simpleButtonClick).toHaveBeenCalledTimes(1);
+
+    expect(
+      screen.queryByRole("button", { name: "Simple button" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses custom menuLabel", () => {
+    setScreenSize("xs");
+
+    render(<ResponsiveButtons buttons={buttons} menuLabel="Custom Menu" />);
+
+    expect(
+      screen.getByRole("button", { name: /custom menu/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("extracts text from nested children for collapsed button label", async () => {
+    setScreenSize("xs");
+
+    const nestedButtons = [
+      <Button key="nested" type="button" onClick={vi.fn()}>
+        <span>
+          <span>Nested text</span>
+        </span>
+      </Button>,
+    ];
+
+    render(<ResponsiveButtons buttons={nestedButtons} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /actions/i }));
+
+    expect(
+      screen.getByRole("button", { name: "Nested text" }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/ui/ResponsiveButtons/ResponsiveButtons.test.tsx
+++ b/src/components/ui/ResponsiveButtons/ResponsiveButtons.test.tsx
@@ -35,22 +35,24 @@ const buttons: ComponentProps<typeof ResponsiveButtons>["buttons"] = [
   </Button>,
   <ContextualMenu
     key="ctx-menu"
-    toggleLabel="More"
+    toggleLabel="Menu"
     links={[
-      {
-        children: "Sub action",
-        onClick: menuAction,
-      },
       {
         children: (
           <>
             <Icon name="plus" />
-            <span>Read only link</span>
+            <span>Sub action</span>
           </>
         ),
+        onClick: menuAction,
+      },
+      "String link",
+      {
+        children: "Read only link",
       },
     ]}
   />,
+  <span key="text-node">Non button</span>,
 ];
 
 describe("ResponsiveButtons", () => {
@@ -152,7 +154,7 @@ describe("ResponsiveButtons", () => {
     expect(simpleButtonClick).toHaveBeenCalledTimes(1);
   });
 
-  it("disabled button for a collapsed menu item", async () => {
+  it("disables button for a collapsed menu item", async () => {
     setScreenSize("xs");
 
     render(<ResponsiveButtons buttons={buttons} />);
@@ -167,10 +169,9 @@ describe("ResponsiveButtons", () => {
   it("renders non-button nodes in visible list on large screens", () => {
     setScreenSize("lg");
 
-    const nonButtonNode = <span key="text-node">Text content</span>;
-    render(<ResponsiveButtons buttons={[nonButtonNode]} />);
+    render(<ResponsiveButtons buttons={buttons} />);
 
-    expect(screen.getByText("Text content")).toBeInTheDocument();
+    expect(screen.getByText("Non button")).toBeInTheDocument();
   });
 
   it("renders a single button without grouping", () => {
@@ -190,58 +191,12 @@ describe("ResponsiveButtons", () => {
     expect(screen.getByRole("button", { name: "Single" })).toBeInTheDocument();
   });
 
-  it("renders a ContextualMenu that is collapsed on small screens", async () => {
-    setScreenSize("xs");
-
-    const menuClickFn = vi.fn();
-    const contextualMenuButtons = [
-      <ContextualMenu
-        key="context-menu"
-        toggleLabel="Filter"
-        links={[{ children: "Option A", onClick: menuClickFn }]}
-      />,
-    ];
-
-    render(
-      <ResponsiveButtons
-        buttons={contextualMenuButtons}
-        alwaysVisible={0}
-        menuLabel="Actions"
-      />,
-    );
-
-    await userEvent.click(screen.getByRole("button", { name: /actions/i }));
-
-    expect(screen.getByText("Filter")).toBeInTheDocument();
-  });
-
-  it("disables the Actions menu when all buttons are disabled", () => {
-    setScreenSize("xs");
-
-    render(
-      <ResponsiveButtons
-        buttons={[
-          <Button key="a" type="button" onClick={vi.fn()} disabled>
-            A
-          </Button>,
-        ]}
-        alwaysVisible={0}
-        menuLabel="Actions"
-      />,
-    );
-
-    expect(screen.getByRole("button", { name: /actions/i })).toHaveAttribute(
-      "aria-disabled",
-    );
-  });
-
   it("pushes non-button nodes to visible on small screens", () => {
     setScreenSize("xs");
 
-    const nonButtonNode = <span key="text-node">Text content</span>;
-    render(<ResponsiveButtons buttons={[nonButtonNode]} alwaysVisible={0} />);
+    render(<ResponsiveButtons buttons={buttons} alwaysVisible={0} />);
 
-    expect(screen.getByText("Text content")).toBeInTheDocument();
+    expect(screen.getByText("Non button")).toBeInTheDocument();
   });
 
   it("renders a ContextualMenu in grouped view on large screens", () => {
@@ -266,57 +221,19 @@ describe("ResponsiveButtons", () => {
   it("skips string links inside a collapsed ContextualMenu", async () => {
     setScreenSize("xs");
 
-    const menuClickFn = vi.fn();
-    const contextualMenuButtons = [
-      <ContextualMenu
-        key="context-menu"
-        toggleLabel="Filter"
-        links={["string-link", { children: "Option A", onClick: menuClickFn }]}
-      />,
-    ];
-
     render(
       <ResponsiveButtons
-        buttons={contextualMenuButtons}
+        buttons={buttons}
         alwaysVisible={0}
         menuLabel="Actions"
       />,
     );
 
     await userEvent.click(screen.getByRole("button", { name: /actions/i }));
-    await userEvent.click(screen.getByRole("button", { name: "Filter" }));
+    await userEvent.click(screen.getByRole("button", { name: "Menu" }));
 
-    expect(screen.getByText("Option A")).toBeInTheDocument();
-    expect(screen.queryByText("string-link")).not.toBeInTheDocument();
-  });
-
-  it("calls link onClick when clicking a link inside a collapsed ContextualMenu", async () => {
-    setScreenSize("xs");
-
-    const menuClickFn = vi.fn();
-    const contextualMenuButtons = [
-      <ContextualMenu
-        key="context-menu"
-        toggleLabel="Filter"
-        links={[{ children: "Option A", onClick: menuClickFn }]}
-      />,
-    ];
-
-    render(
-      <ResponsiveButtons
-        buttons={contextualMenuButtons}
-        alwaysVisible={0}
-        menuLabel="Actions"
-      />,
-    );
-
-    await userEvent.click(screen.getByRole("button", { name: /actions/i }));
-    expect(screen.getByText("Filter")).toBeInTheDocument();
-
-    await userEvent.click(screen.getByRole("button", { name: "Filter" }));
-    await userEvent.click(screen.getByText("Option A"));
-
-    expect(menuClickFn).toHaveBeenCalled();
+    expect(screen.getByText("Sub action")).toBeInTheDocument();
+    expect(screen.queryByText("String link")).not.toBeInTheDocument();
   });
 
   it("preserves icon children in collapsed menu items", async () => {
@@ -326,11 +243,16 @@ describe("ResponsiveButtons", () => {
 
     await userEvent.click(screen.getByRole("button", { name: /actions/i }));
 
-    const buttonWithIcon = screen.getByRole("button", {
-      name: "Button with icon",
-    });
+    expect(
+      screen.getByRole("button", {
+        name: "Button with icon",
+      }),
+    ).toHaveIcon("code");
 
-    expect(buttonWithIcon.querySelector(".p-icon--code")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Menu" }));
+    expect(screen.getByRole("button", { name: "Sub action" })).toHaveIcon(
+      "plus",
+    );
   });
 
   it("applies custom className to wrapper", () => {
@@ -367,32 +289,17 @@ describe("ResponsiveButtons", () => {
     );
   });
 
-  it("keeps non-interactive nodes visible even on small screens", () => {
-    setScreenSize("xs");
-
-    const mixedButtons = [
-      <span key="text">Just a label</span>,
-      <Button key="action" type="button" onClick={vi.fn()}>
-        Action
-      </Button>,
-    ];
-
-    render(<ResponsiveButtons buttons={mixedButtons} />);
-
-    expect(screen.getByText("Just a label")).toBeInTheDocument();
-  });
-
-  it("collapses a ContextualMenu into the dropdown on small screens", async () => {
+  it("collapses a ContextualMenu into dropdown on small screens", async () => {
     setScreenSize("xs");
 
     render(<ResponsiveButtons buttons={buttons} />);
 
     await userEvent.click(screen.getByRole("button", { name: /actions/i }));
-    await userEvent.click(screen.getByRole("button", { name: "More" }));
+    await userEvent.click(screen.getByRole("button", { name: "Menu" }));
 
-    expect(screen.getByRole("button", { name: "Read only link" })).toHaveIcon(
-      "plus",
-    );
+    expect(
+      screen.getByRole("button", { name: "Read only link" }),
+    ).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: "Sub action" }));
     expect(menuAction).toHaveBeenCalledTimes(1);

--- a/src/components/ui/ResponsiveButtons/ResponsiveButtons.test.tsx
+++ b/src/components/ui/ResponsiveButtons/ResponsiveButtons.test.tsx
@@ -390,9 +390,9 @@ describe("ResponsiveButtons", () => {
     await userEvent.click(screen.getByRole("button", { name: /actions/i }));
     await userEvent.click(screen.getByRole("button", { name: "More" }));
 
-    expect(
-      screen.getByRole("button", { name: "Read only link" }),
-    ).toHaveIcon("plus");
+    expect(screen.getByRole("button", { name: "Read only link" })).toHaveIcon(
+      "plus",
+    );
 
     await userEvent.click(screen.getByRole("button", { name: "Sub action" }));
     expect(menuAction).toHaveBeenCalledTimes(1);

--- a/src/components/ui/ResponsiveButtons/ResponsiveButtons.test.tsx
+++ b/src/components/ui/ResponsiveButtons/ResponsiveButtons.test.tsx
@@ -42,7 +42,12 @@ const buttons: ComponentProps<typeof ResponsiveButtons>["buttons"] = [
         onClick: menuAction,
       },
       {
-        children: "Read only link",
+        children: (
+          <>
+            <Icon name="plus" />
+            <span>Read only link</span>
+          </>
+        ),
       },
     ]}
   />,
@@ -387,7 +392,7 @@ describe("ResponsiveButtons", () => {
 
     expect(
       screen.getByRole("button", { name: "Read only link" }),
-    ).toBeInTheDocument();
+    ).toHaveIcon("plus");
 
     await userEvent.click(screen.getByRole("button", { name: "Sub action" }));
     expect(menuAction).toHaveBeenCalledTimes(1);

--- a/src/components/ui/ResponsiveButtons/ResponsiveButtons.tsx
+++ b/src/components/ui/ResponsiveButtons/ResponsiveButtons.tsx
@@ -69,6 +69,7 @@ const ResponsiveButtons: FC<ResponsiveButtonGroupProps> = ({
                       }
                     }}
                     disabled={link.disabled}
+                    hasIcon={link.hasIcon}
                   >
                     {link.children}
                   </Button>

--- a/src/components/ui/ResponsiveButtons/ResponsiveButtons.tsx
+++ b/src/components/ui/ResponsiveButtons/ResponsiveButtons.tsx
@@ -99,9 +99,11 @@ const ResponsiveButtons: FC<ResponsiveButtonGroupProps> = ({
 
         collapsed.push({
           key: `action-${index}`,
-          children: textFromNode(el) || `Action ${index + 1}`,
+          children:
+            el.props.children || textFromNode(el) || `Action ${index + 1}`,
           onClick: el.props.onClick,
           disabled: el.props.disabled,
+          hasIcon: el.props.hasIcon,
         });
 
         return;
@@ -185,6 +187,7 @@ const ResponsiveButtons: FC<ResponsiveButtonGroupProps> = ({
                         }
                       }}
                       disabled={item.disabled}
+                      hasIcon={item.hasIcon}
                     >
                       {item.children}
                     </Button>

--- a/src/components/ui/ResponsiveButtons/ResponsiveButtons.tsx
+++ b/src/components/ui/ResponsiveButtons/ResponsiveButtons.tsx
@@ -73,6 +73,7 @@ const ResponsiveButtons: FC<ResponsiveButtonGroupProps> = ({
                       }
                     }}
                     disabled={link.disabled}
+                    hasIcon={link.hasIcon}
                   >
                     {link.children}
                   </Button>

--- a/src/components/ui/ResponsiveButtons/ResponsiveButtons.tsx
+++ b/src/components/ui/ResponsiveButtons/ResponsiveButtons.tsx
@@ -103,9 +103,11 @@ const ResponsiveButtons: FC<ResponsiveButtonGroupProps> = ({
 
         collapsed.push({
           key: `action-${index}`,
-          children: textFromNode(el) || `Action ${index + 1}`,
+          children:
+            el.props.children || textFromNode(el) || `Action ${index + 1}`,
           onClick: el.props.onClick,
           disabled: el.props.disabled,
+          hasIcon: el.props.hasIcon,
         });
 
         return;
@@ -189,6 +191,7 @@ const ResponsiveButtons: FC<ResponsiveButtonGroupProps> = ({
                         }
                       }}
                       disabled={item.disabled}
+                      hasIcon={item.hasIcon}
                     >
                       {item.children}
                     </Button>

--- a/src/components/ui/ResponsiveButtons/types.ts
+++ b/src/components/ui/ResponsiveButtons/types.ts
@@ -8,6 +8,7 @@ export interface ButtonLikeProps {
   className?: string;
   "aria-label"?: string;
   title?: string;
+  hasIcon?: boolean;
 }
 
 export interface ContextualMenuProps {

--- a/src/components/ui/ResponsiveDropdownItem/ResponsiveDropdownItem.module.scss
+++ b/src/components/ui/ResponsiveDropdownItem/ResponsiveDropdownItem.module.scss
@@ -6,9 +6,7 @@
 
 .label {
   display: flex;
-  gap: 0.5rem;
-  margin-bottom: 0;
-  margin-right: 0;
+  margin: 0;
   min-width: 12rem;
   place-items: center flex-start;
   text-align: left;
@@ -16,16 +14,12 @@
 
   .text {
     flex-grow: 1;
+    padding-right: 0.5rem;
   }
-}
-
-.icon {
-  rotate: -90deg;
 }
 
 .content {
   display: block;
-  min-width: 15rem;
   top: 0;
 }
 

--- a/src/components/ui/ResponsiveDropdownItem/ResponsiveDropdownItem.test.tsx
+++ b/src/components/ui/ResponsiveDropdownItem/ResponsiveDropdownItem.test.tsx
@@ -20,8 +20,10 @@ describe("ResponsiveDropdownItem", () => {
   it("renders an element", async () => {
     renderWithProviders(<ResponsiveDropdownItem el={element} />);
 
-    await user.click(screen.getByRole("button", { name: "Status" }));
+    const button = await screen.findByRole("button", { name: "Status" });
+    await user.click(button);
     expect(screen.getByText("Option 1")).toBeInTheDocument();
+    expect(button).toHaveIcon("chevron-right");
   });
 
   it("closes the menu when an element is clicked", async () => {
@@ -105,13 +107,14 @@ describe("ResponsiveDropdownItem", () => {
     expect(onMenuClose).toHaveBeenCalled();
   });
 
-  it("renders a disabled element with given label", async () => {
+  it("renders a disabled element with given label and right position", async () => {
     renderWithProviders(
-      <ResponsiveDropdownItem el={element} disabled label="Label" />,
+      <ResponsiveDropdownItem el={element} disabled label="Label" position="right" />,
     );
 
     const button = await screen.findByRole("button", { name: "Label" });
     expect(button).toHaveClass("is-disabled");
     expect(button).toHaveAttribute("aria-disabled", "true");
+    expect(button).toHaveIcon("chevron-left");
   });
 });

--- a/src/components/ui/ResponsiveDropdownItem/ResponsiveDropdownItem.test.tsx
+++ b/src/components/ui/ResponsiveDropdownItem/ResponsiveDropdownItem.test.tsx
@@ -38,38 +38,12 @@ describe("ResponsiveDropdownItem", () => {
   });
 
   it("does not call onMenuClose when it is not provided", async () => {
-    renderWithProviders(
-      <ResponsiveDropdownItem
-        el={
-          <PageParamFilter
-            pageParamKey="status"
-            label="Status"
-            options={[{ label: "Option 1", value: "option-1" }]}
-          />
-        }
-      />,
-    );
+    renderWithProviders(<ResponsiveDropdownItem el={element} />);
 
     await user.click(screen.getByRole("button", { name: "Status" }));
     await expect(
       user.click(screen.getByText("Option 1")),
     ).resolves.not.toThrow();
-  });
-
-  it("renders with explicit label prop", async () => {
-    renderWithProviders(
-      <ResponsiveDropdownItem el={<div>content</div>} label="Custom Label" />,
-    );
-
-    expect(screen.getByText("Custom Label")).toBeInTheDocument();
-  });
-
-  it("renders disabled button when disabled prop is true", () => {
-    renderWithProviders(
-      <ResponsiveDropdownItem el={<div>content</div>} label="Label" disabled />,
-    );
-
-    expect(screen.getByRole("button")).toHaveAttribute("aria-disabled");
   });
 
   it("renders without a label when neither label prop nor el.props.label is available", async () => {
@@ -86,15 +60,7 @@ describe("ResponsiveDropdownItem", () => {
   it("closes dropdown when clicking outside", async () => {
     renderWithProviders(
       <div>
-        <ResponsiveDropdownItem
-          el={
-            <PageParamFilter
-              pageParamKey="status"
-              label="Status"
-              options={[{ label: "Option 1", value: "option-1" }]}
-            />
-          }
-        />
+        <ResponsiveDropdownItem el={element} />
         <button>outside</button>
       </div>,
     );

--- a/src/components/ui/ResponsiveDropdownItem/ResponsiveDropdownItem.test.tsx
+++ b/src/components/ui/ResponsiveDropdownItem/ResponsiveDropdownItem.test.tsx
@@ -5,40 +5,28 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import ResponsiveDropdownItem from "./ResponsiveDropdownItem";
 
+const element = (
+  <PageParamFilter
+    pageParamKey="status"
+    label="Status"
+    options={[{ label: "Option 1", value: "option-1" }]}
+  />
+);
+
 describe("ResponsiveDropdownItem", () => {
   const user = userEvent.setup();
+  const onMenuClose = vi.fn();
 
   it("renders an element", async () => {
-    renderWithProviders(
-      <ResponsiveDropdownItem
-        el={
-          <PageParamFilter
-            pageParamKey="status"
-            label="Status"
-            options={[{ label: "Option 1", value: "option-1" }]}
-          />
-        }
-      />,
-    );
+    renderWithProviders(<ResponsiveDropdownItem el={element} />);
 
     await user.click(screen.getByRole("button", { name: "Status" }));
     expect(screen.getByText("Option 1")).toBeInTheDocument();
   });
 
-  it("calls onMenuClose when content area is clicked", async () => {
-    const onMenuClose = vi.fn();
-
+  it("closes the menu when an element is clicked", async () => {
     renderWithProviders(
-      <ResponsiveDropdownItem
-        el={
-          <PageParamFilter
-            pageParamKey="status"
-            label="Status"
-            options={[{ label: "Option 1", value: "option-1" }]}
-          />
-        }
-        onMenuClose={onMenuClose}
-      />,
+      <ResponsiveDropdownItem el={element} onMenuClose={onMenuClose} />,
     );
 
     await user.click(screen.getByRole("button", { name: "Status" }));
@@ -114,5 +102,16 @@ describe("ResponsiveDropdownItem", () => {
 
     await user.click(screen.getByRole("button", { name: "outside" }));
     expect(screen.queryByText("Option 1")).not.toBeInTheDocument();
+    expect(onMenuClose).toHaveBeenCalled();
+  });
+
+  it("renders a disabled element with given label", async () => {
+    renderWithProviders(
+      <ResponsiveDropdownItem el={element} disabled label="Label" />,
+    );
+
+    const button = await screen.findByRole("button", { name: "Label" });
+    expect(button).toHaveClass("is-disabled");
+    expect(button).toHaveAttribute("aria-disabled", "true");
   });
 });

--- a/src/components/ui/ResponsiveDropdownItem/ResponsiveDropdownItem.test.tsx
+++ b/src/components/ui/ResponsiveDropdownItem/ResponsiveDropdownItem.test.tsx
@@ -109,7 +109,12 @@ describe("ResponsiveDropdownItem", () => {
 
   it("renders a disabled element with given label and right position", async () => {
     renderWithProviders(
-      <ResponsiveDropdownItem el={element} disabled label="Label" position="right" />,
+      <ResponsiveDropdownItem
+        el={element}
+        disabled
+        label="Label"
+        position="right"
+      />,
     );
 
     const button = await screen.findByRole("button", { name: "Label" });

--- a/src/components/ui/ResponsiveDropdownItem/ResponsiveDropdownItem.tsx
+++ b/src/components/ui/ResponsiveDropdownItem/ResponsiveDropdownItem.tsx
@@ -54,6 +54,19 @@ const ResponsiveDropdownItem: FC<ResponsiveDropdownItemProps> = ({
   };
   const alignmentClass = alignmentClassMap[position];
 
+  const buttonContent =
+    position === "right" ? (
+      <>
+        <Icon name="chevron-left" />
+        <span className={classes.text}>{displayLabel}</span>
+      </>
+    ) : (
+      <>
+        <span className={classes.text}>{displayLabel}</span>
+        <Icon name="chevron-right" />
+      </>
+    );
+
   return (
     <div
       ref={ref}
@@ -65,9 +78,9 @@ const ResponsiveDropdownItem: FC<ResponsiveDropdownItemProps> = ({
         className={classNames(classes.label, { [classes.isOpen]: isOpen })}
         onClick={toggle}
         disabled={disabled}
+        hasIcon={position === "right"}
       >
-        <span className={classes.text}>{displayLabel}</span>
-        <Icon name="chevron-down" className={classes.icon} />
+        {buttonContent}
       </Button>
       {isOpen && (
         <div

--- a/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
+++ b/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
@@ -199,7 +199,7 @@ const InstancesPageActions = memo(function InstancesPageActions({
     );
   };
 
-  const allInstancesHaveToken = selectedInstances.every(
+  const allInstancesHaveToken = selectedInstances.length && selectedInstances.every(
     (instance) =>
       instance.ubuntu_pro_info?.result === "success" &&
       instance.ubuntu_pro_info.attached,
@@ -208,16 +208,25 @@ const InstancesPageActions = memo(function InstancesPageActions({
   const proServicesLinks = [
     allInstancesHaveToken
       ? {
-          children: <span>Replace token</span>,
+          children: <>
+            <Icon name="change-version" />
+            <span>Replace token</span>
+          </>,
           onClick: handleReplaceToken,
         }
       : {
-          children: <span>Attach token</span>,
+          children: <>
+            <Icon name="private-key" />
+            <span>Attach token</span>
+          </>,
           onClick: handleAttachToken,
         },
     isFeatureEnabled("ubuntu_pro_licensing")
       ? {
-          children: <span>Detach token</span>,
+          children: <>
+            <Icon name="disconnect" />
+            <span>Detach token</span>
+          </>,
           onClick: openDetachModal,
         }
       : {},
@@ -230,7 +239,7 @@ const InstancesPageActions = memo(function InstancesPageActions({
         buttons={[
           <Button
             key="shutdown-instances"
-            className="has-icon"
+            hasIcon
             type="button"
             disabled={0 === selectedInstances.length || isGettingInstances}
             onClick={openShutdownModal}
@@ -255,6 +264,7 @@ const InstancesPageActions = memo(function InstancesPageActions({
               className="u-no-margin--bottom"
               onClick={proServicesLinks[0].onClick}
               disabled={0 === selectedInstances.length}
+              hasIcon
             >
               {proServicesLinks[0].children}
             </Button>
@@ -274,6 +284,7 @@ const InstancesPageActions = memo(function InstancesPageActions({
             <Button
               key="report-view"
               type="button"
+              hasIcon
               onClick={handleReportView}
               disabled={0 === selectedInstances.length}
             >

--- a/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
+++ b/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
@@ -199,34 +199,42 @@ const InstancesPageActions = memo(function InstancesPageActions({
     );
   };
 
-  const allInstancesHaveToken = selectedInstances.length && selectedInstances.every(
-    (instance) =>
-      instance.ubuntu_pro_info?.result === "success" &&
-      instance.ubuntu_pro_info.attached,
-  );
+  const hasInstanceWithoutToken =
+    !selectedInstances.length ||
+    selectedInstances.some(
+      (instance) =>
+        !instance.ubuntu_pro_info?.attached ||
+        instance.ubuntu_pro_info.result !== "success",
+    );
 
   const proServicesLinks = [
-    allInstancesHaveToken
+    hasInstanceWithoutToken
       ? {
-          children: <>
-            <Icon name="change-version" />
-            <span>Replace token</span>
-          </>,
-          onClick: handleReplaceToken,
+          children: (
+            <>
+              <Icon name="private-key" />
+              <span>Attach token</span>
+            </>
+          ),
+          onClick: handleAttachToken,
         }
       : {
-          children: <>
-            <Icon name="private-key" />
-            <span>Attach token</span>
-          </>,
-          onClick: handleAttachToken,
+          children: (
+            <>
+              <Icon name="change-version" />
+              <span>Replace token</span>
+            </>
+          ),
+          onClick: handleReplaceToken,
         },
     isFeatureEnabled("ubuntu_pro_licensing")
       ? {
-          children: <>
-            <Icon name="disconnect" />
-            <span>Detach token</span>
-          </>,
+          children: (
+            <>
+              <Icon name="disconnect" />
+              <span>Detach token</span>
+            </>
+          ),
           onClick: openDetachModal,
         }
       : {},

--- a/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
+++ b/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
@@ -199,26 +199,15 @@ const InstancesPageActions = memo(function InstancesPageActions({
     );
   };
 
-  const hasInstanceWithoutToken =
-    !selectedInstances.length ||
-    selectedInstances.some(
-      (instance) =>
-        !instance.ubuntu_pro_info?.attached ||
-        instance.ubuntu_pro_info.result !== "success",
-    );
+  const allInstancesHaveToken = selectedInstances.every(
+    (instance) =>
+      instance.ubuntu_pro_info?.result === "success" &&
+      instance.ubuntu_pro_info.attached,
+  );
 
   const proServicesLinks = [
-    hasInstanceWithoutToken
+    allInstancesHaveToken
       ? {
-          children: (
-            <>
-              <Icon name="private-key" />
-              <span>Attach token</span>
-            </>
-          ),
-          onClick: handleAttachToken,
-        }
-      : {
           children: (
             <>
               <Icon name="change-version" />
@@ -226,6 +215,17 @@ const InstancesPageActions = memo(function InstancesPageActions({
             </>
           ),
           onClick: handleReplaceToken,
+          hasIcon: true,
+        }
+      : {
+          children: (
+            <>
+              <Icon name="private-key" />
+              <span>Attach token</span>
+            </>
+          ),
+          onClick: handleAttachToken,
+          hasIcon: true,
         },
     isFeatureEnabled("ubuntu_pro_licensing")
       ? {
@@ -236,6 +236,7 @@ const InstancesPageActions = memo(function InstancesPageActions({
             </>
           ),
           onClick: openDetachModal,
+          hasIcon: true,
         }
       : {},
   ].filter((link) => link.children);
@@ -272,7 +273,7 @@ const InstancesPageActions = memo(function InstancesPageActions({
               className="u-no-margin--bottom"
               onClick={proServicesLinks[0].onClick}
               disabled={0 === selectedInstances.length}
-              hasIcon
+              hasIcon={proServicesLinks[0].hasIcon}
             >
               {proServicesLinks[0].children}
             </Button>

--- a/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
+++ b/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
@@ -199,34 +199,42 @@ const InstancesPageActions = memo(function InstancesPageActions({
     );
   };
 
-  const allInstancesHaveToken = selectedInstances.length && selectedInstances.every(
-    (instance) =>
-      instance.ubuntu_pro_info?.result === "success" &&
-      instance.ubuntu_pro_info.attached,
-  );
+  const hasInstanceWithoutToken =
+    !selectedInstances.length ||
+    selectedInstances.some(
+      (instance) =>
+        !instance.ubuntu_pro_info?.attached ||
+        instance.ubuntu_pro_info.result !== "success",
+    );
 
   const proServicesLinks = [
-    allInstancesHaveToken
+    hasInstanceWithoutToken
       ? {
-          children: <>
-            <Icon name="change-version" />
-            <span>Replace token</span>
-          </>,
-          onClick: handleReplaceToken,
+          children: (
+            <>
+              <Icon name="private-key" />
+              <span>Attach token</span>
+            </>
+          ),
+          onClick: handleAttachToken,
         }
       : {
-          children: <>
-            <Icon name="private-key" />
-            <span>Attach token</span>
-          </>,
-          onClick: handleAttachToken,
+          children: (
+            <>
+              <Icon name="change-version" />
+              <span>Replace token</span>
+            </>
+          ),
+          onClick: handleReplaceToken,
         },
     isFeatureEnabled("ubuntu-pro-licensing")
       ? {
-          children: <>
-            <Icon name="disconnect" />
-            <span>Detach token</span>
-          </>,
+          children: (
+            <>
+              <Icon name="disconnect" />
+              <span>Detach token</span>
+            </>
+          ),
           onClick: openDetachModal,
         }
       : {},

--- a/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
+++ b/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
@@ -199,7 +199,7 @@ const InstancesPageActions = memo(function InstancesPageActions({
     );
   };
 
-  const allInstancesHaveToken = selectedInstances.every(
+  const allInstancesHaveToken = selectedInstances.length && selectedInstances.every(
     (instance) =>
       instance.ubuntu_pro_info?.result === "success" &&
       instance.ubuntu_pro_info.attached,
@@ -208,16 +208,25 @@ const InstancesPageActions = memo(function InstancesPageActions({
   const proServicesLinks = [
     allInstancesHaveToken
       ? {
-          children: <span>Replace token</span>,
+          children: <>
+            <Icon name="change-version" />
+            <span>Replace token</span>
+          </>,
           onClick: handleReplaceToken,
         }
       : {
-          children: <span>Attach token</span>,
+          children: <>
+            <Icon name="private-key" />
+            <span>Attach token</span>
+          </>,
           onClick: handleAttachToken,
         },
     isFeatureEnabled("ubuntu-pro-licensing")
       ? {
-          children: <span>Detach token</span>,
+          children: <>
+            <Icon name="disconnect" />
+            <span>Detach token</span>
+          </>,
           onClick: openDetachModal,
         }
       : {},
@@ -230,7 +239,7 @@ const InstancesPageActions = memo(function InstancesPageActions({
         buttons={[
           <Button
             key="shutdown-instances"
-            className="has-icon"
+            hasIcon
             type="button"
             disabled={0 === selectedInstances.length || isGettingInstances}
             onClick={openShutdownModal}
@@ -255,6 +264,7 @@ const InstancesPageActions = memo(function InstancesPageActions({
               className="u-no-margin--bottom"
               onClick={proServicesLinks[0].onClick}
               disabled={0 === selectedInstances.length}
+              hasIcon
             >
               {proServicesLinks[0].children}
             </Button>
@@ -274,6 +284,7 @@ const InstancesPageActions = memo(function InstancesPageActions({
             <Button
               key="report-view"
               type="button"
+              hasIcon
               onClick={handleReportView}
               disabled={0 === selectedInstances.length}
             >

--- a/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
+++ b/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
@@ -199,26 +199,15 @@ const InstancesPageActions = memo(function InstancesPageActions({
     );
   };
 
-  const hasInstanceWithoutToken =
-    !selectedInstances.length ||
-    selectedInstances.some(
-      (instance) =>
-        !instance.ubuntu_pro_info?.attached ||
-        instance.ubuntu_pro_info.result !== "success",
-    );
+  const allInstancesHaveToken = selectedInstances.every(
+    (instance) =>
+      instance.ubuntu_pro_info?.result === "success" &&
+      instance.ubuntu_pro_info.attached,
+  );
 
   const proServicesLinks = [
-    hasInstanceWithoutToken
+    allInstancesHaveToken
       ? {
-          children: (
-            <>
-              <Icon name="private-key" />
-              <span>Attach token</span>
-            </>
-          ),
-          onClick: handleAttachToken,
-        }
-      : {
           children: (
             <>
               <Icon name="change-version" />
@@ -226,6 +215,17 @@ const InstancesPageActions = memo(function InstancesPageActions({
             </>
           ),
           onClick: handleReplaceToken,
+          hasIcon: true,
+        }
+      : {
+          children: (
+            <>
+              <Icon name="private-key" />
+              <span>Attach token</span>
+            </>
+          ),
+          onClick: handleAttachToken,
+          hasIcon: true,
         },
     isFeatureEnabled("ubuntu-pro-licensing")
       ? {
@@ -236,6 +236,7 @@ const InstancesPageActions = memo(function InstancesPageActions({
             </>
           ),
           onClick: openDetachModal,
+          hasIcon: true,
         }
       : {},
   ].filter((link) => link.children);
@@ -272,7 +273,7 @@ const InstancesPageActions = memo(function InstancesPageActions({
               className="u-no-margin--bottom"
               onClick={proServicesLinks[0].onClick}
               disabled={0 === selectedInstances.length}
-              hasIcon
+              hasIcon={proServicesLinks[0].hasIcon}
             >
               {proServicesLinks[0].children}
             </Button>

--- a/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
+++ b/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
@@ -279,7 +279,7 @@ const InstancesPageActions = memo(function InstancesPageActions({
             </Button>
           ) : (
             <ContextualMenu
-              position="left"
+              position="right"
               key="pro-services"
               hasToggleIcon
               links={proServicesLinks}

--- a/src/features/packages/components/PackageActions/PackageActions.tsx
+++ b/src/features/packages/components/PackageActions/PackageActions.tsx
@@ -81,6 +81,7 @@ const PackageActions: FC<PackageActionsProps> = ({ selectedPackages }) => {
               onClick={() => {
                 handleExistingPackages(packageAction);
               }}
+              hasIcon
             >
               <Icon name={INSTALLED_PACKAGE_ACTIONS[packageAction].icon} />
               <span>{INSTALLED_PACKAGE_ACTIONS[packageAction].label}</span>

--- a/src/features/snaps/components/SnapsActions/SnapsActions.tsx
+++ b/src/features/snaps/components/SnapsActions/SnapsActions.tsx
@@ -81,6 +81,7 @@ const SnapsActions: FC<SnapsActionProps> = ({
               onClick={() => {
                 handleEditSnap(EditSnapType.Switch);
               }}
+              hasIcon
             >
               <Icon name="fork" />
               <span>Switch channel</span>
@@ -94,6 +95,7 @@ const SnapsActions: FC<SnapsActionProps> = ({
             onClick={() => {
               handleEditSnap(EditSnapType.Uninstall);
             }}
+            hasIcon
           >
             <Icon name={ICONS.delete} />
             <span>Uninstall</span>
@@ -107,6 +109,7 @@ const SnapsActions: FC<SnapsActionProps> = ({
               onClick={() => {
                 handleEditSnap(EditSnapType.Hold);
               }}
+              hasIcon
             >
               <Icon name="pause" />
               <span>Hold</span>
@@ -121,6 +124,7 @@ const SnapsActions: FC<SnapsActionProps> = ({
               onClick={() => {
                 handleEditSnap(EditSnapType.Unhold);
               }}
+              hasIcon
             >
               <Icon name="play" />
               <span>Unhold</span>
@@ -134,6 +138,7 @@ const SnapsActions: FC<SnapsActionProps> = ({
             onClick={() => {
               handleEditSnap(EditSnapType.Refresh);
             }}
+            hasIcon
           >
             <Icon name="change-version" />
             <span>Refresh</span>

--- a/src/features/snaps/components/SnapsActions/SnapsActions.tsx
+++ b/src/features/snaps/components/SnapsActions/SnapsActions.tsx
@@ -33,16 +33,19 @@ const SnapsActions: FC<SnapsActionProps> = ({
   const { held, unheld } = getSnapUpgradeCounts(selectedSnaps);
 
   const handleEditSnap = (action: EditSnapType) => {
-    const count =
-      action === EditSnapType.Unhold
-        ? held
-        : action === EditSnapType.Hold
-          ? unheld
-          : selectedSnapIds.length;
+    const getCount = () => {
+      if (action === EditSnapType.Unhold) {
+        return held;
+      }
+      if (action === EditSnapType.Hold) {
+        return unheld;
+      }
+      return selectedSnapIds.length;
+    };
 
     const title = singleSnap
       ? `${action} ${singleSnap.snap.name}${action === EditSnapType.Switch ? "'s channel" : ""}`
-      : `${action} ${pluralizeWithCount(count, "snap")}`;
+      : `${action} ${pluralizeWithCount(getCount(), "snap")}`;
 
     setSidePanelContent(
       title,


### PR DESCRIPTION
## Summary

- Added icons to the buttons inside the dropdown of `ResponsiveButtons`
- Changed chevron icon to be on the left when `ResponsiveDropdownItem` opens to the left

## Release Impact

According to the [Landscape Server Release Cycle](https://docs.google.com/document/d/1sKAp5IvArpfArhMNojFwKOHm9LEdHKB4Et6tu1_-0GY/edit?tab=t.0), this change will target the following release cycle:
- **Target Branch**: `main` (Beta)
- **Version Impact**:
  - [x] Patch (Fix)
  - [ ] Minor (Feature)
  - [ ] Major (Breaking)

## Checklist
- [x] **Changeset Added**: I have run `pnpm changeset` and committed the resulting `.md` file.
- [x] **UI Verified**: I have verified the changes locally.
- [x] **Linting**: No linting errors are present (especially in `scripts/`).

## Versioning Reminder
> [!IMPORTANT]
> This repository now uses **CalVer** ($YY.0M.Point.Patch$).
> Please ensure your changeset description is clear, as it will be automatically added to the `CHANGELOG.md` upon merging to `main`.

## UI Changes

BEFORE:
<img width="871" height="107" alt="image" src="https://github.com/user-attachments/assets/8e12aa1a-e4e3-4662-8fcb-eb1c36403cf0" />
<img width="834" height="115" alt="image" src="https://github.com/user-attachments/assets/589b5526-5107-4c37-bbdf-b97138709bc1" />
<img height="300" alt="image" src="https://github.com/user-attachments/assets/1b868331-1195-46d9-a297-244b22e397b0" />

<br />
<br />

AFTER: 
<img width="890" height="123" alt="image" src="https://github.com/user-attachments/assets/97e4fc34-fd9b-41a1-9e66-df9b0a7759b4" />
<img height="300" alt="image" src="https://github.com/user-attachments/assets/6cc2ec94-2ed8-42d7-928d-3402948ef72b" /> <img height="300" alt="image" src="https://github.com/user-attachments/assets/213171e0-5f9b-4099-b28c-3e987c3722b6" />