### PR TITLE
Resolve LNDENG-4197

### DIFF
--- a/.changeset/some-dryers-bake.md
+++ b/.changeset/some-dryers-bake.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Added line wrapping to error output on /repositories/mirrors

--- a/src/features/activities/components/ActivityDetails/ActivityDetails.tsx
+++ b/src/features/activities/components/ActivityDetails/ActivityDetails.tsx
@@ -113,6 +113,7 @@ const ActivityDetails: FC<ActivityDetailsProps> = ({ activityId }) => {
           className={classes.output}
           blocks={[
             {
+              wrapLines: true,
               title: "Output",
               code: activity.result_text,
             },


### PR DESCRIPTION
## Summary

Added line wrapping to error output in ActivityDetails.tsx to make it more readable. Set wrapLines: true on CodeSnippet for mirror error output.

## Release Impact

According to the [Landscape Server Release Cycle](https://docs.google.com/document/d/1sKAp5IvArpfArhMNojFwKOHm9LEdHKB4Et6tu1_-0GY/edit?tab=t.0), this change will target the following release cycle:
- **Target Branch**: `main`
- **Version Impact**:
  - [X] Patch (Fix)
  - [ ] Minor (Feature)
  - [ ] Major (Breaking)

## Checklist
- [X] **Changeset Added**: I have run `pnpm changeset` and committed the resulting `.md` file.
- [X] **UI Verified**: I have verified the changes locally.
- [X] **Linting**: No linting errors are present (especially in `scripts/`).

## Versioning Reminder
> [!IMPORTANT]
> This repository now uses **CalVer** ($YY.0M.Point.Patch$).
> Please ensure your changeset description is clear, as it will be automatically added to the `CHANGELOG.md` upon merging to `main`.