### PR TITLE
fix: organisation switch updates correctly in the UI

### DIFF
--- a/.changeset/green-icons-beam.md
+++ b/.changeset/green-icons-beam.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Fix organization switching by more precise cache invalidation

--- a/src/features/auth/hooks/useAuthHandle.ts
+++ b/src/features/auth/hooks/useAuthHandle.ts
@@ -129,6 +129,9 @@ export default function useAuthHandle() {
     mutationFn: async (params) => authFetch.post("switch-account", params),
     onSuccess: async () => {
       queryClient.removeQueries();
+      // queryClient.removeQueries({
+      //   predicate: (query) => query.queryKey[0] !== "authUser",
+      // });
       return queryClient.refetchQueries();
     },
   });

--- a/src/features/auth/hooks/useAuthHandle.ts
+++ b/src/features/auth/hooks/useAuthHandle.ts
@@ -128,10 +128,9 @@ export default function useAuthHandle() {
   >({
     mutationFn: async (params) => authFetch.post("switch-account", params),
     onSuccess: async () => {
-      queryClient.removeQueries();
-      // queryClient.removeQueries({
-      //   predicate: (query) => query.queryKey[0] !== "authUser",
-      // });
+      queryClient.removeQueries({
+        predicate: (query) => query.queryKey[0] !== "authUser",
+      });
       return queryClient.refetchQueries();
     },
   });

--- a/src/templates/dashboard/OrganisationSwitch/OrganisationSwitch.integration.test.tsx
+++ b/src/templates/dashboard/OrganisationSwitch/OrganisationSwitch.integration.test.tsx
@@ -1,0 +1,48 @@
+import { API_URL } from "@/constants";
+import useSidePanel from "@/hooks/useSidePanel";
+import { authResponse } from "@/tests/mocks/auth";
+import { renderWithProviders } from "@/tests/render";
+import server from "@/tests/server";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach } from "vitest";
+import OrganisationSwitch from "./OrganisationSwitch";
+
+vi.mock("@/hooks/useSidePanel");
+const closeSidePanel = vi.fn();
+
+describe("OrganisationSwitch (integration)", () => {
+  beforeEach(() => {
+    vi.mocked(useSidePanel, { partial: true }).mockReturnValue({
+      closeSidePanel,
+    });
+
+    server.use(
+      http.get(`${API_URL}me`, () => HttpResponse.json(authResponse)),
+    );
+  });
+
+  it("should update the displayed organisation after account switch", async () => {
+    renderWithProviders(<OrganisationSwitch />);
+
+    // Wait for the real auth context to fully load from MSW GET /me.
+    // authResponse has current_account = "test-account".
+    await waitFor(() => {
+      expect(
+        screen.getByRole("combobox", { name: /organization/i }),
+      ).toHaveValue("test-account");
+    });
+
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: /organization/i }),
+      "second-account",
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("combobox", { name: /organization/i }),
+      ).toHaveValue("second-account");
+    });
+  });
+});

--- a/src/templates/dashboard/OrganisationSwitch/OrganisationSwitch.integration.test.tsx
+++ b/src/templates/dashboard/OrganisationSwitch/OrganisationSwitch.integration.test.tsx
@@ -18,9 +18,7 @@ describe("OrganisationSwitch (integration)", () => {
       closeSidePanel,
     });
 
-    server.use(
-      http.get(`${API_URL}me`, () => HttpResponse.json(authResponse)),
-    );
+    server.use(http.get(`${API_URL}me`, () => HttpResponse.json(authResponse)));
   });
 
   it("should update the displayed organisation after account switch", async () => {

--- a/src/templates/dashboard/OrganisationSwitch/OrganisationSwitch.test.tsx
+++ b/src/templates/dashboard/OrganisationSwitch/OrganisationSwitch.test.tsx
@@ -88,6 +88,7 @@ describe("OrganisationSwitch", () => {
       expect(select).toHaveValue(defaultAccounts.currentAccount.name);
     });
 
+    // only tests function call, TODO check UI change after account switch as well
     it("should change the organisation and close side panel", async () => {
       await userEvent.selectOptions(
         screen.getByRole("combobox"),

--- a/src/tests/mocks/auth.ts
+++ b/src/tests/mocks/auth.ts
@@ -1,6 +1,7 @@
 import type { AuthStateResponse, AuthUser } from "@/features/auth";
 
 const testAccount = "test-account";
+const secondAccount = "second-account";
 
 export const authUser: AuthUser = {
   accounts: [
@@ -10,6 +11,13 @@ export const authUser: AuthUser = {
       name: testAccount,
       subdomain: null,
       title: "Test Account",
+    },
+    {
+      classic_dashboard_url: "",
+      default: false,
+      name: secondAccount,
+      subdomain: null,
+      title: "Second Account",
     },
   ],
   current_account: testAccount,

--- a/src/tests/mocks/user.ts
+++ b/src/tests/mocks/user.ts
@@ -89,13 +89,17 @@ export const users = [
 ] as const satisfies User[];
 
 const accountName = "test-account";
+const secondAccountName = "second-account";
 const email = "example@mail.com";
 
 export const userDetails: UserDetails = {
   email: email,
   name: "Test User",
   preferred_account: accountName,
-  accounts: [{ name: accountName, title: "Test Account", roles: ["Test"] }],
+  accounts: [
+    { name: accountName, title: "Test Account", roles: ["Test"] },
+    { name: secondAccountName, title: "Second Account", roles: ["Test"] },
+  ],
   allowable_emails: [email],
   oidc_identities: [],
   timezone: "America/New_York",


### PR DESCRIPTION
## Summary

Previously, switching the user's organization via the OrganisationSwitch component wouldn't update in the UI until the user navigated to a new page, or refreshed the page. Fixed by keeping authUser in the cache before refetching queries.

## Release Impact

According to the [Landscape Server Release Cycle](https://docs.google.com/document/d/1sKAp5IvArpfArhMNojFwKOHm9LEdHKB4Et6tu1_-0GY/edit?tab=t.0), this change will target the following release cycle:
- **Target Branch**: `dev` / `main` (Beta)
- **Version Impact**:
  - [X] Patch (Fix)
  - [ ] Minor (Feature)
  - [ ] Major (Breaking)

## Checklist
- [X] **Changeset Added**: I have run `pnpm changeset` and committed the resulting `.md` file.
- [X] **UI Verified**: I have verified the changes locally.
- [X] **Linting**: No linting errors are present (especially in `scripts/`).

## Versioning Reminder
> [!IMPORTANT]
> This repository now uses **CalVer** ($YY.0M.Point.Patch$).
> Please ensure your changeset description is clear, as it will be automatically added to the `CHANGELOG.md` upon merging to `main`.