### PR TITLE
build: extend release process with point releases

### DIFF
--- a/.github/workflows/release-and-build.yml
+++ b/.github/workflows/release-and-build.yml
@@ -2,7 +2,7 @@ name: Release and PPA Build
 
 on:
   push:
-    branches: [main, dev, stable, "release/**"]
+    branches: [main, dev, stable, "release/**", "point/**"]
 
 permissions:
   contents: write
@@ -29,7 +29,7 @@ jobs:
           VERSION=$(node scripts/calculate-version.cjs)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-          if [[ $GITHUB_REF == 'refs/heads/main' ]]; then DEST="ppa-build";
+          if [[ $GITHUB_REF == 'refs/heads/main' || $GITHUB_REF == refs/heads/point/* ]]; then DEST="ppa-build";
           elif [[ $GITHUB_REF == 'refs/heads/dev' ]]; then DEST="ppa-build-dev";
           elif [[ $GITHUB_REF == 'refs/heads/stable' ]]; then DEST="ppa-build-stable";
           else DEST="ppa-build-${GITHUB_REF##*/}"; fi

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,12 +6,13 @@ Landscape UI follows the [Landscape Server Release Cycle](https://docs.google.co
 
 ## 1. Branching Strategy
 
-| Branch          | Release Tier      | Logic                                                                    |
-|-----------------|-------------------|--------------------------------------------------------------------------|
-| `dev`           | **Development**   | Internal testing. Deploys to  `ppa-build-dev`.                           |
-| `main`          | **Beta**          | Feature-complete but may have breaking changes. Deploys to  `ppa-build`. |
-| `stable`        | **Latest Stable** | Production-ready with latest features. Updated every 6 months.           |
-| `release/YY.04` | **LTS**           | Mission-critical stability.                                              |
+| Branch              | Release Tier      | Logic                                                                    |
+|---------------------|-------------------|--------------------------------------------------------------------------|
+| `dev`               | **Development**   | Internal testing. Deploys to  `ppa-build-dev`.                           |
+| `main`              | **Beta**          | Feature-complete but may have breaking changes. Deploys to  `ppa-build`. |
+| `point/YYYY-MM-DD`  | **Beta (pinned)** | Cherry-picked beta from a pinned commit. Deploys to `ppa-build`.         |
+| `stable`            | **Latest Stable** | Production-ready with latest features. Updated every 6 months.           |
+| `release/YY.04`     | **LTS**           | Mission-critical stability.                                              |
 
 ---
 
@@ -84,6 +85,38 @@ Use this workflow if a customer reports a critical bug in an LTS version (e.g., 
 5. **Write Summary:** `Fixed a regression where the search bar would overlap with the sidebar on mobile devices.`
 6. **Push:** Push directly to `release/24.04`.
 7. **Result:** The CI detects the LTS branch and generates a **Point Release** (e.g., $24.04.1.15$) for the specific LTS PPA.
+
+---
+
+### Example C: Shipping a Pinned Beta (Target: Point Release)
+
+Use this workflow when `main` has moved ahead with new features or breaking changes, but you need to ship a beta with only specific fixes on top of an older, known-good commit.
+
+1. **Identify the base commit:** Find the last commit you want to build from (e.g., `07bb3c298`).
+2. **Create the point branch:**
+   ```bash
+   git checkout -b point/2026-04-14 07bb3c298
+   ```
+3. **Cherry-pick the changes you need:**
+   ```bash
+   git cherry-pick <commit-hash-1>
+   git cherry-pick <commit-hash-2>
+   ```
+4. **Generate Changeset:** Run `pnpm changeset`.
+5. **Select Type:** Choose `patch`.
+6. **Write Summary:** `Point release with alert fix and MSW refactor.`
+7. **Push:** Push to `point/2026-04-14`.
+8. **Result:** The CI treats this as a beta and deploys to `ppa-build` (e.g., `26.04.0.63-beta`).
+
+**Adding more changes later:** Push additional cherry-picks to the same `point/` branch. Each push triggers a new CI run with the next `GITHUB_RUN_NUMBER`.
+
+**When main catches up:** Delete the point branch once `main` is ready to resume normal beta releases:
+
+```bash
+git push origin --delete point/2026-04-14
+```
+
+**Multiple point releases per month:** Use the date suffix to keep them unique (e.g., `point/2026-04-14`, `point/2026-04-28`).
 
 ## 6. Troubleshooting
    

--- a/scripts/calculate-version.cjs
+++ b/scripts/calculate-version.cjs
@@ -11,7 +11,7 @@ function getVersion() {
   const branch = execSync("git rev-parse --abbrev-ref HEAD").toString().trim();
   const buildNum = process.env.GITHUB_RUN_NUMBER || "0";
 
-  if (branch === "main") {
+  if (branch === "main" || branch.startsWith("point/")) {
     return `${calVerBase}.0.${buildNum}-beta`;
   }
   if (branch === "dev") {


### PR DESCRIPTION
This pull request introduces support for "point" branches, enabling the creation and deployment of pinned beta releases based on specific commits and cherry-picked fixes. The changes update the release workflow, versioning logic, and documentation to clarify how and when to use these point releases.

**Release workflow and branching strategy updates:**

* The `.github/workflows/release-and-build.yml` workflow now triggers on pushes to `point/**` branches and treats them as beta releases, deploying to the `ppa-build` target. [[1]](diffhunk://#diff-f2835b43bdce313fb566e57a07425b551df5a05cf100af870ab5779713ed3659L5-R5) [[2]](diffhunk://#diff-f2835b43bdce313fb566e57a07425b551df5a05cf100af870ab5779713ed3659L32-R32)
* The `scripts/calculate-version.cjs` script is updated to generate beta version numbers for `point/` branches, matching the format used for `main`.

**Documentation improvements:**

* `RELEASES.md` now documents the new `point/YYYY-MM-DD` branch type, its purpose, and how it fits into the overall branching strategy.
* A detailed example workflow ("Example C: Shipping a Pinned Beta") is added to `RELEASES.md`, explaining how to create, use, and retire point branches for targeted beta releases.## Summary

Summarize the changes made in this pull request. Include any relevant context or background information that would help reviewers understand the purpose and scope of the changes.

## Release Impact

According to the [Landscape Server Release Cycle
This pull request introduces support for "point" branches, which enable the creation of pinned beta releases based on specific commits and cherry-picked fixes. The changes update the branching strategy documentation, CI workflow, and version calculation logic to recognize and handle `point/YYYY-MM-DD` branches as beta releases. This allows for more flexible and controlled beta releases without disrupting ongoing development on `main`.

**Branching and Release Process Updates:**

* Updated the documented branching strategy in `RELEASES.md` to include `point/YYYY-MM-DD` as a new branch type for pinned beta releases, clarifying its purpose and deployment target.
* Added a detailed example workflow in `RELEASES.md` for creating and managing point releases, including branch creation, cherry-picking, and cleanup instructions.

**CI/CD and Versioning Enhancements:**

* Modified the GitHub Actions workflow in `.github/workflows/release-and-build.yml` to trigger on pushes to `point/**` branches, ensuring CI builds are run for point releases.
* Updated the build destination logic in the workflow so that builds from `main` or any `point/**` branch are deployed to the `ppa-build` beta channel.
* Adjusted the version calculation script (`scripts/calculate-version.cjs`) to treat `point/` branches like `main`, assigning them a beta version suffix.](https://docs.google.com/document/d/1sKAp5IvArpfArhMNojFwKOHm9LEdHKB4Et6tu1_-0GY/edit?tab=t.0), this change will target the following release cycle:
- **Target Branch**: `dev` / `main` (Beta)
- **Version Impact**:
  - [ ] Patch (Fix)
  - [ ] Minor (Feature)
  - [ ] Major (Breaking)

## Checklist
- [ ] **Changeset Added**: I have run `pnpm changeset` and committed the resulting `.md` file.
- [ ] **UI Verified**: I have verified the changes locally.
- [ ] **Linting**: No linting errors are present (especially in `scripts/`).

## Versioning Reminder
> [!IMPORTANT]
> This repository now uses **CalVer** ($YY.0M.Point.Patch$).
> Please ensure your changeset description is clear, as it will be automatically added to the `CHANGELOG.md` upon merging to `main`.