### PR TITLE
fix: add missing search terms

### DIFF
--- a/.changeset/floppy-badgers-dream.md
+++ b/.changeset/floppy-badgers-dream.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Add missing search terms

--- a/src/components/filter/SearchQueryEditor/SearchQueryEditor.tsx
+++ b/src/components/filter/SearchQueryEditor/SearchQueryEditor.tsx
@@ -20,6 +20,7 @@ interface SearchQueryEditorProps {
   readonly labelClassName?: string;
   readonly headerContent?: React.ReactNode;
   readonly options?: React.ComponentProps<typeof CodeEditor>["options"];
+  readonly warning?: string | false;
   readonly languageId: string;
   readonly terms: string[];
   readonly languageConfig: LanguageConfig;
@@ -42,6 +43,7 @@ const SearchQueryEditor: FC<SearchQueryEditorProps> = ({
   labelClassName,
   headerContent,
   options,
+  warning,
   languageId,
   terms,
   languageConfig,
@@ -63,6 +65,7 @@ const SearchQueryEditor: FC<SearchQueryEditorProps> = ({
       onChange={onChange}
       onBlur={onBlur}
       error={error}
+      warning={warning}
       required={required}
       className={className}
       labelClassName={labelClassName}

--- a/src/components/form/CodeEditor.module.scss
+++ b/src/components/form/CodeEditor.module.scss
@@ -10,12 +10,16 @@
   margin-bottom: $input-margin-bottom;
   min-height: 16rem;
 
+  &:not(.error):not(.warning) {
+    border-bottom-color: $colors--theme--border-high-contrast;
+  }
+
   &.error {
     border-bottom-color: map-get($states, "error");
   }
 
-  &:not(.error) {
-    border-bottom-color: $colors--theme--border-high-contrast;
+  &.warning {
+    border-bottom-color: map-get($states, "caution");
   }
 }
 

--- a/src/components/form/CodeEditor.module.scss
+++ b/src/components/form/CodeEditor.module.scss
@@ -10,7 +10,7 @@
   margin-bottom: $input-margin-bottom;
   min-height: 16rem;
 
-  &:not(.error):not(.warning) {
+  &:not(.error, .warning) {
     border-bottom-color: $colors--theme--border-high-contrast;
   }
 

--- a/src/components/form/CodeEditorInner.tsx
+++ b/src/components/form/CodeEditorInner.tsx
@@ -12,6 +12,7 @@ interface CodeEditorProps {
   readonly value: string | undefined;
   readonly className?: string;
   readonly error?: string | false;
+  readonly warning?: string | false;
   readonly labelClassName?: string;
   readonly onChange?: (value: string | undefined) => void;
   readonly onBlur?: () => void;
@@ -39,6 +40,7 @@ const CodeEditorInner: FC<CodeEditorProps> = ({
   monacoBeforeMount,
   onMount,
   onBlur,
+  warning,
 }) => {
   const { isDarkMode } = useTheme();
 
@@ -55,7 +57,7 @@ const CodeEditorInner: FC<CodeEditorProps> = ({
     <div
       className={classNames(
         "p-form__group p-form-validation",
-        { "is-error": error },
+        { "is-error": error, "is-caution": warning },
         classes.container,
       )}
     >
@@ -89,7 +91,7 @@ const CodeEditorInner: FC<CodeEditorProps> = ({
           theme={isDarkMode ? "vs-dark" : "vs-light"}
           className={classNames(
             classes.highlighter,
-            { [classes.error]: error },
+            { [classes.error]: error, [classes.warning]: warning },
             className,
           )}
           value={value}
@@ -108,6 +110,13 @@ const CodeEditorInner: FC<CodeEditorProps> = ({
           <p className="p-form-validation__message" id="code-error-message">
             <strong>Error: </strong>
             <span>{error}</span>
+          </p>
+        )}
+
+        {warning && (
+          <p className="p-form-validation__message" id="code-warning-message">
+            <strong>Warning: </strong>
+            <span>{warning}</span>
           </p>
         )}
       </div>

--- a/src/features/instances/components/InstancesHeader/hooks/useInstanceSearchHelpTerms.tsx
+++ b/src/features/instances/components/InstancesHeader/hooks/useInstanceSearchHelpTerms.tsx
@@ -51,7 +51,7 @@ const useInstanceSearchHelpTerms = () => {
             <code>package-reporter</code>, <code>esm-disabled</code>,{" "}
             <code>computer-offline</code>,<code>computer-reboot</code>,{" "}
             <code>computer-duplicates</code>, <code>unapproved-activities</code>
-            .
+            , <code>child-instance-profiles</code>.
           </span>
         </>
       ),
@@ -97,6 +97,15 @@ const useInstanceSearchHelpTerms = () => {
       ),
     },
     {
+      term: "access-group-recursive:<name>",
+      description: (
+        <span>
+          Instances associated with the <code>&lt;name&gt;</code> access group
+          or its descendants
+        </span>
+      ),
+    },
+    {
       term: "search:<name>",
       description: (
         <span>
@@ -121,6 +130,126 @@ const useInstanceSearchHelpTerms = () => {
           Instances associated with the <code>&lt;name&gt;</code> removal
           profile
         </span>
+      ),
+    },
+    {
+      term: "vendor:<string>",
+      description: "Instances containing hardware with the matched vendor.",
+    },
+    {
+      term: "product:<string>",
+      description: "Instances containing hardware with the matched product.",
+    },
+    {
+      term: "uuid:<string>",
+      description: "Instances containing hardware with the matched UUID.",
+    },
+    {
+      term: "cpu.<attribute>:<string>",
+      description: (
+        <>
+          <span>
+            Instances containing a CPU with the matched{" "}
+            <code>&lt;attribute&gt;</code>.
+          </span>
+          <br />
+          <span>
+            <code>&lt;attribute&gt;</code> can be <code>vendor</code>,{" "}
+            <code>product</code>, <code>version</code>, or <code>size</code>. If{" "}
+            <code>size</code> is searched, a value or range must be provided,
+            e.g. <code>cpu.size:[1Ghz TO 4Ghz]</code>.
+          </span>
+        </>
+      ),
+    },
+    {
+      term: "disk.<attribute>:<string>",
+      description: (
+        <>
+          <span>
+            Instances containing a disk with the matched{" "}
+            <code>&lt;attribute&gt;</code>.
+          </span>
+          <br />
+          <span>
+            <code>&lt;attribute&gt;</code> can be <code>vendor</code>,{" "}
+            <code>product</code>, <code>version</code>, or <code>size</code>. If{" "}
+            <code>size</code> is searched, a value or range must be provided,
+            e.g. <code>disk.size:[10Gb TO 2Tb]</code>.
+          </span>
+        </>
+      ),
+    },
+    {
+      term: "display.<attribute>:<string>",
+      description: (
+        <span>
+          Instances containing a display with the matched{" "}
+          <code>&lt;attribute&gt;</code>. <code>&lt;attribute&gt;</code> can be{" "}
+          <code>vendor</code>, <code>product</code>, or <code>version</code>.
+        </span>
+      ),
+    },
+    {
+      term: "firmware.<attribute>:<string>",
+      description: (
+        <span>
+          Instances containing firmware with the matched{" "}
+          <code>&lt;attribute&gt;</code>. <code>&lt;attribute&gt;</code> can be{" "}
+          <code>vendor</code>, <code>product</code>, or <code>version</code>.
+        </span>
+      ),
+    },
+    {
+      term: "memory.<attribute>:<string>",
+      description: (
+        <>
+          <span>
+            Instances containing memory with the matched{" "}
+            <code>&lt;attribute&gt;</code>.
+          </span>
+          <br />
+          <span>
+            <code>&lt;attribute&gt;</code> can be <code>vendor</code>,{" "}
+            <code>product</code>, <code>version</code>, or <code>size</code>. If{" "}
+            <code>size</code> is searched, a value or range must be provided,
+            e.g. <code>memory.size:[1Gb TO 8Gb]</code>.
+          </span>
+        </>
+      ),
+    },
+    {
+      term: "network.capacity:<value_or_range>",
+      description: (
+        <span>
+          Instances with a network interface of the specified capacity. A value
+          or range must be provided, e.g.{" "}
+          <code>network.capacity:[100Mb TO 1Gb]</code>.
+        </span>
+      ),
+    },
+    {
+      term: "network.<attribute>:<string>",
+      description: (
+        <span>
+          Instances containing a network interface with the matched{" "}
+          <code>&lt;attribute&gt;</code>. <code>&lt;attribute&gt;</code> can be{" "}
+          <code>vendor</code>, <code>product</code>, or <code>version</code>.
+        </span>
+      ),
+    },
+    {
+      term: "network.serial:<mac_address>",
+      description: (
+        <span>
+          Instances with a network interface matching the specified MAC address.
+        </span>
+      ),
+    },
+    {
+      term: "serial:<serialnumber>",
+      description: (
+        <span>Instances with the specified hardware serial number.</span>
       ),
     },
     {
@@ -177,6 +306,24 @@ const useInstanceSearchHelpTerms = () => {
       ),
     },
     {
+      term: "availability-zone:<str>",
+      description: (
+        <span>
+          Instances with the availability zone <code>&lt;str&gt;</code>, or use{" "}
+          <code>null</code> for instances without one.
+        </span>
+      ),
+    },
+    {
+      term: "contract-expires-within-days:<days>",
+      description: (
+        <span>
+          Instances associated with an Ubuntu Pro contract that expires within{" "}
+          <code>&lt;days&gt;</code> days.
+        </span>
+      ),
+    },
+    {
       term: "license-expires-within-days:<days>",
       description: (
         <span>
@@ -189,6 +336,16 @@ const useInstanceSearchHelpTerms = () => {
       term: "needs:license OR license-id:none",
       description:
         "Search for instances that do not have a Landscape license, and, as a result, are not managed",
+    },
+    {
+      term: "last-ping:<nr-of-hours>",
+      description: (
+        <span>
+          Instances that were active in the last{" "}
+          <code>&lt;nr-of-hours&gt;</code> hours, where{" "}
+          <code>&lt;nr-of-hours&gt;</code> is a value between 0 and 8760.
+        </span>
+      ),
     },
     {
       term: "has-pro-management:<option>",
@@ -207,6 +364,30 @@ const useInstanceSearchHelpTerms = () => {
           Optionally specify <code>annotation:&lt;key&gt;:&lt;string&gt;</code>{" "}
           which will only return instances whose key matches and value also
           contains the <code>&lt;string&gt;</code> specified
+        </span>
+      ),
+    },
+    {
+      term: "instance-id:<id>",
+      description: (
+        <span>
+          Cloud instances with a specific instance <code>&lt;id&gt;</code>.
+        </span>
+      ),
+    },
+    {
+      term: "instance-type:<id>",
+      description: (
+        <span>
+          Cloud instances with a specific instance type <code>&lt;id&gt;</code>.
+        </span>
+      ),
+    },
+    {
+      term: "ami-id:<id>",
+      description: (
+        <span>
+          Cloud instances with a specific AMI <code>&lt;id&gt;</code>.
         </span>
       ),
     },

--- a/src/features/saved-searches/components/SavedSearchForm/SavedSearchForm.test.tsx
+++ b/src/features/saved-searches/components/SavedSearchForm/SavedSearchForm.test.tsx
@@ -17,12 +17,14 @@ vi.mock("@/components/filter/SearchQueryEditor", () => {
       onChange,
       onBlur,
       error,
+      warning,
     }: {
       label: string;
       value: string | undefined;
       onChange?: (value: string | undefined) => void;
       onBlur?: () => void;
       error?: string | false;
+      warning?: string | false;
     }) => (
       <div>
         <label>
@@ -35,6 +37,7 @@ vi.mock("@/components/filter/SearchQueryEditor", () => {
           />
         </label>
         {error && <span>{error}</span>}
+        {warning && <span>{warning}</span>}
       </div>
     ),
   };
@@ -123,7 +126,7 @@ describe("SavedSearchForm", () => {
     ).toBeInTheDocument();
   });
 
-  it("blocks submit and shows search error when search is invalid (strict)", async () => {
+  it("blocks submit and shows search warning when search is invalid (strict)", async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
 
     renderWithProviders(
@@ -144,7 +147,7 @@ describe("SavedSearchForm", () => {
 
     await user.click(submitButton);
 
-    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onSubmit).toHaveBeenCalled();
 
     expect(
       screen.getByText('"alert" has invalid value "compu".'),

--- a/src/features/saved-searches/components/SavedSearchForm/SavedSearchForm.tsx
+++ b/src/features/saved-searches/components/SavedSearchForm/SavedSearchForm.tsx
@@ -13,7 +13,7 @@ import { useMemo, useState } from "react";
 import { USG_STATUSES, WSL_STATUSES } from "./constants";
 import { configureSearchLanguage } from "./helpers/searchQueryLanguage";
 import { VALIDATION_SCHEMA } from "./helpers/searchQuerySchema";
-import { validateSearchField } from "./helpers/searchQueryValidation";
+import { validateSearchQuery } from "./helpers/searchQueryValidation";
 import type { FormProps } from "./types";
 
 const INSTANCE_SEARCH_LANGUAGE_ID = "instance-search-query";
@@ -53,12 +53,12 @@ const SavedSearchForm: FC<SavedSearchFormProps> = ({
 
   const hasInitialSearch = Boolean(initialValues.search?.trim());
 
-  const initialSearchError = hasInitialSearch
-    ? validateSearchField(initialValues.search, "strict", validationConfig)
+  const initialSearchWarning = hasInitialSearch
+    ? validateSearchQuery(initialValues.search, true, validationConfig)
     : undefined;
 
-  const [searchError, setSearchError] = useState<string | undefined>(
-    initialSearchError,
+  const [searchWarning, setSearchWarning] = useState<string | undefined>(
+    initialSearchWarning,
   );
 
   const formik = useFormik<FormProps>({
@@ -82,7 +82,7 @@ const SavedSearchForm: FC<SavedSearchFormProps> = ({
           instanceSearchHelpTerms.flatMap(({ term }) =>
             term
               .split(/\s+OR\s+/i)
-              .map((part) => part.split(":")[0])
+              .map((part) => part.split(":")[0]?.split(".")[0])
               .filter((part) => part !== undefined),
           ),
         ),
@@ -92,36 +92,18 @@ const SavedSearchForm: FC<SavedSearchFormProps> = ({
 
   const handleSearchBlur = () => {
     formik.setFieldTouched("search", true, false);
-
-    const strictError = validateSearchField(
-      formik.values.search,
-      "strict",
-      validationConfig,
+    setSearchWarning(
+      validateSearchQuery(formik.values.search, true, validationConfig),
     );
-    setSearchError(strictError);
   };
 
   const handleFormSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-
-    const strictSearchError = validateSearchField(
-      formik.values.search,
-      "strict",
-      validationConfig,
+    setSearchWarning(
+      validateSearchQuery(formik.values.search, true, validationConfig),
     );
-    setSearchError(strictSearchError);
-
-    if (strictSearchError) {
-      return;
-    }
-
     formik.handleSubmit();
   };
-
-  const submitDisabled =
-    formik.isSubmitting ||
-    !formik.values.search.trim() ||
-    Boolean(formik.errors.title);
 
   return (
     <Form noValidate onSubmit={handleFormSubmit}>
@@ -147,14 +129,12 @@ const SavedSearchForm: FC<SavedSearchFormProps> = ({
           formik.setFieldValue("search", newValue);
           formik.setFieldTouched("search", true, false);
 
-          const typingError = validateSearchField(
-            newValue,
-            "typing",
-            validationConfig,
+          setSearchWarning(
+            validateSearchQuery(newValue, false, validationConfig),
           );
-          setSearchError(typingError);
         }}
-        error={formik.touched.search ? searchError : undefined}
+        error={getFormikError(formik, "search")}
+        warning={searchWarning}
         languageId={INSTANCE_SEARCH_LANGUAGE_ID}
         terms={searchTerms}
         options={{
@@ -171,7 +151,7 @@ const SavedSearchForm: FC<SavedSearchFormProps> = ({
           mode === "create" ? "Add saved search" : "Save changes"
         }
         submitButtonLoading={formik.isSubmitting}
-        submitButtonDisabled={submitDisabled}
+        submitButtonDisabled={formik.isSubmitting}
         hasBackButton={Boolean(onBackButtonPress)}
         onBackButtonPress={onBackButtonPress}
       />

--- a/src/features/saved-searches/components/SavedSearchForm/constants.ts
+++ b/src/features/saved-searches/components/SavedSearchForm/constants.ts
@@ -27,6 +27,16 @@ export const VALID_ROOT_KEYS = [
   "license-expires-within-days",
   "has-pro-management",
   "release-upgrade",
+  "access-group-recursive",
+  "vendor",
+  "product",
+  "uuid",
+  "serial",
+  "instance-id",
+  "instance-type",
+  "ami-id",
+  "availability-zone",
+  "last-ping",
 ] as const;
 export const PROFILE_TYPES = [
   "security",
@@ -41,6 +51,17 @@ export const PROFILE_TYPES = [
 export const DISTRIBUTION_UPGRADE_STATUSES = ["available"] as const;
 export const USG_STATUSES = ["pass", "fail", "in-progress"] as const;
 export const WSL_STATUSES = ["compliant", "noncompliant"] as const;
+export const HARDWARE_ATTRIBUTES = {
+  cpu: ["vendor", "product", "version", "size"],
+  disk: ["vendor", "product", "version", "size"],
+  display: ["vendor", "product", "version"],
+  firmware: ["vendor", "product", "version"],
+  memory: ["vendor", "product", "version", "size"],
+  network: ["vendor", "product", "version", "capacity", "serial"],
+} as const;
+export const HARDWARE_ROOT_KEYS = Object.keys(
+  HARDWARE_ATTRIBUTES,
+) as (keyof typeof HARDWARE_ATTRIBUTES)[];
 export const LICENSE_TYPES = [
   "unlicensed",
   "pro",
@@ -54,6 +75,7 @@ export const NUMERIC_KEYS: ValidRootKey[] = [
   "contract",
   "contract-expires-within-days",
   "license-expires-within-days",
+  "last-ping",
 ];
 
 export const INTEGER_REGEX = /^\d+$/;

--- a/src/features/saved-searches/components/SavedSearchForm/helpers/searchQueryHelpers.test.ts
+++ b/src/features/saved-searches/components/SavedSearchForm/helpers/searchQueryHelpers.test.ts
@@ -328,3 +328,67 @@ describe("validateSearchField with ValidationConfig", () => {
     );
   });
 });
+
+describe("validateSearchQuery hardware dot-notation", () => {
+  it("accepts valid hardware key:attribute:value tokens", () => {
+    expect(validateSearchQuery("cpu.vendor:Intel ")).toBeUndefined();
+    expect(validateSearchQuery("cpu.size:3Ghz ")).toBeUndefined();
+    expect(validateSearchQuery("disk.vendor:Samsung ")).toBeUndefined();
+    expect(validateSearchQuery("disk.size:500Gb ")).toBeUndefined();
+    expect(validateSearchQuery("display.product:HD ")).toBeUndefined();
+    expect(validateSearchQuery("firmware.version:1.0 ")).toBeUndefined();
+    expect(validateSearchQuery("memory.size:8Gb ")).toBeUndefined();
+    expect(validateSearchQuery("network.capacity:1Gb ")).toBeUndefined();
+    expect(
+      validateSearchQuery("network.serial:aa:bb:cc:dd:ee:ff "),
+    ).toBeUndefined();
+  });
+
+  it("rejects hardware key without a dot", () => {
+    expect(validateSearchQuery("cpu:Intel ")).toBe(
+      '"cpu" requires a dot-separated attribute. Valid attributes: vendor, product, version, size.',
+    );
+    expect(validateSearchQuery("disk:Samsung ")).toBe(
+      '"disk" requires a dot-separated attribute. Valid attributes: vendor, product, version, size.',
+    );
+  });
+
+  it("rejects hardware key with invalid attribute", () => {
+    expect(validateSearchQuery("cpu.colour:red ")).toBe(
+      '"cpu.colour" has invalid attribute "colour". Valid attributes: vendor, product, version, size.',
+    );
+    expect(validateSearchQuery("network.colour:blue ")).toBe(
+      '"network.colour" has invalid attribute "colour". Valid attributes: vendor, product, version, capacity, serial.',
+    );
+  });
+
+  it("rejects hardware key with missing value", () => {
+    expect(validateSearchQuery("cpu.vendor: ")).toBe(
+      '"cpu.vendor" requires a value.',
+    );
+  });
+
+  it("allows hardware terms while typing incomplete last token", () => {
+    expect(validateSearchQuery("cpu.vendor:Int")).toBeUndefined();
+    expect(validateSearchQuery("disk.size:")).toBeUndefined();
+  });
+});
+
+describe("validateSearchQuery new keys added alongside hardware", () => {
+  it("validates last-ping as numeric", () => {
+    expect(validateSearchQuery("last-ping:24 ")).toBeUndefined();
+    expect(validateSearchQuery("last-ping:8760 ")).toBeUndefined();
+    expect(validateSearchQuery("last-ping:two-hours ")).toBe(
+      '"last-ping" requires a number.',
+    );
+  });
+
+  it("validates contract-expires-within-days as numeric", () => {
+    expect(
+      validateSearchQuery("contract-expires-within-days:30 "),
+    ).toBeUndefined();
+    expect(validateSearchQuery("contract-expires-within-days:soon ")).toBe(
+      '"contract-expires-within-days" requires a number.',
+    );
+  });
+});

--- a/src/features/saved-searches/components/SavedSearchForm/helpers/searchQueryLanguage.test.ts
+++ b/src/features/saved-searches/components/SavedSearchForm/helpers/searchQueryLanguage.test.ts
@@ -1,0 +1,480 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Monaco } from "@monaco-editor/react";
+import {
+  createRootKeyRegex,
+  configureSearchLanguage,
+} from "./searchQueryLanguage";
+import {
+  ALERT_TYPES,
+  BOOLEANS,
+  DISTRIBUTION_UPGRADE_STATUSES,
+  HARDWARE_ATTRIBUTES,
+  HARDWARE_ROOT_KEYS,
+  LICENSE_TYPES,
+  LOGICAL_OPERATORS,
+} from "../constants";
+
+// Each call returns a unique ID to prevent cross-test interference
+// with the module-level registeredLanguages / registeredCompletionProviders Sets.
+let langCounter = 0;
+const nextLangId = () => `test-lang-${++langCounter}`;
+
+interface CompletionItem {
+  label: string;
+  insertText: string;
+  kind: number;
+  detail: string;
+}
+
+type ProviderFn = (
+  model: unknown,
+  position: unknown,
+) => { suggestions: CompletionItem[] };
+
+/** Builds a minimal Monaco mock and exposes the captured completion provider. */
+function createMonacoMock() {
+  let capturedProvider: ProviderFn | null = null;
+
+  const monaco = {
+    languages: {
+      register: vi.fn(),
+      setMonarchTokensProvider: vi.fn(),
+      registerCompletionItemProvider: vi.fn(
+        (_langId: string, provider: { provideCompletionItems: ProviderFn }) => {
+          capturedProvider = provider.provideCompletionItems;
+        },
+      ),
+      CompletionItemKind: {
+        Keyword: 1,
+        EnumMember: 2,
+        Operator: 3,
+        Text: 4,
+        Property: 5,
+      },
+    },
+  } as unknown as Monaco;
+
+  return {
+    monaco,
+    getProvider: () => capturedProvider,
+  };
+}
+
+/**
+ * One-stop helper: creates a fresh Monaco mock, configures the language once,
+ * and returns the captured provider (always non-null after a fresh langId).
+ */
+function setupLanguage(
+  terms: string[],
+  config: {
+    profileTypes: readonly string[];
+    usgStatuses?: readonly string[];
+    wslStatuses?: readonly string[];
+  } = {
+    profileTypes: ["security", "wsl", "script"],
+    usgStatuses: ["pass", "fail"],
+    wslStatuses: ["compliant", "noncompliant"],
+  },
+) {
+  const { monaco, getProvider } = createMonacoMock();
+  const langId = nextLangId();
+  configureSearchLanguage(monaco, langId, terms, {
+    profileTypes: config.profileTypes,
+    usgStatuses: config.usgStatuses ?? [],
+    wslStatuses: config.wslStatuses ?? [],
+  });
+  const provider = getProvider();
+  if (!provider) throw new Error("Completion provider was not registered");
+  return { monaco, provider, langId };
+}
+
+/** Invokes a provider as if the cursor sits at the end of textBeforeCursor. */
+function callProvider(provider: ProviderFn, textBeforeCursor: string) {
+  const column = textBeforeCursor.length + 1;
+  const model = {
+    getWordUntilPosition: vi
+      .fn()
+      .mockReturnValue({ startColumn: 1, endColumn: column }),
+    getLineContent: vi.fn().mockReturnValue(textBeforeCursor),
+  };
+  const position = { lineNumber: 1, column };
+  return provider(model, position).suggestions;
+}
+
+describe("createRootKeyRegex", () => {
+  it("matches a single term before a colon", () => {
+    const regex = createRootKeyRegex("alert");
+    expect("alert:value").toMatch(regex);
+  });
+
+  it("does not match a term that is not followed by a colon", () => {
+    const regex = createRootKeyRegex("alert");
+    expect("alertvalue").not.toMatch(regex);
+    expect("alert ").not.toMatch(regex);
+  });
+
+  it("matches each of multiple alternated terms", () => {
+    const regex = createRootKeyRegex("alert|hostname|id");
+    expect("alert:x").toMatch(regex);
+    expect("hostname:x").toMatch(regex);
+    expect("id:x").toMatch(regex);
+    expect("other:x").not.toMatch(regex);
+  });
+
+  it("escapes special regex characters so dots are matched literally", () => {
+    const regex = createRootKeyRegex("cpu\\.vendor");
+    expect("cpu.vendor:x").toMatch(regex);
+    // Without escaping a raw dot would match "cpuXvendor"; with escaping it must not
+    expect("cpuXvendor:x").not.toMatch(regex);
+  });
+
+  it("uses a word boundary so partial suffix matches don't trigger", () => {
+    const regex = createRootKeyRegex("id");
+    expect("id:1").toMatch(regex);
+    expect("acid:1").not.toMatch(regex);
+  });
+});
+
+describe("configureSearchLanguage - registration", () => {
+  it("registers the language on the first call", () => {
+    const { monaco } = createMonacoMock();
+    const langId = nextLangId();
+    configureSearchLanguage(monaco, langId, ["hostname"], {
+      profileTypes: [],
+      usgStatuses: [],
+      wslStatuses: [],
+    });
+    expect(monaco.languages.register).toHaveBeenCalledWith({ id: langId });
+  });
+
+  it("does not re-register the language on subsequent calls with the same ID", () => {
+    const { monaco } = createMonacoMock();
+    const langId = nextLangId();
+    const cfg = { profileTypes: [], usgStatuses: [], wslStatuses: [] };
+    configureSearchLanguage(monaco, langId, ["hostname"], cfg);
+    configureSearchLanguage(monaco, langId, ["hostname", "tag"], cfg);
+    expect(monaco.languages.register).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls setMonarchTokensProvider on every call to refresh the tokenizer", () => {
+    const { monaco } = createMonacoMock();
+    const langId = nextLangId();
+    const cfg = { profileTypes: [], usgStatuses: [], wslStatuses: [] };
+    configureSearchLanguage(monaco, langId, ["hostname"], cfg);
+    configureSearchLanguage(monaco, langId, ["hostname", "tag"], cfg);
+    expect(monaco.languages.setMonarchTokensProvider).toHaveBeenCalledTimes(2);
+  });
+
+  it("registers the completion provider only once per language ID", () => {
+    const { monaco } = createMonacoMock();
+    const langId = nextLangId();
+    const cfg = { profileTypes: [], usgStatuses: [], wslStatuses: [] };
+    configureSearchLanguage(monaco, langId, ["hostname"], cfg);
+    configureSearchLanguage(monaco, langId, ["hostname", "tag"], cfg);
+    expect(
+      monaco.languages.registerCompletionItemProvider,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("deduplicates and trims whitespace from terms before storing", () => {
+    const { provider } = setupLanguage([
+      " hostname ",
+      "hostname",
+      "tag",
+      "tag",
+    ]);
+    const suggestions = callProvider(provider, "");
+    const labels = suggestions
+      .filter((s) => s.detail === "Search term")
+      .map((s) => s.label);
+    expect(labels.filter((l) => l === "hostname")).toHaveLength(1);
+    expect(labels.filter((l) => l === "tag")).toHaveLength(1);
+  });
+});
+
+describe("completion provider - key context (no colon in token)", () => {
+  it("returns configured terms as Keyword suggestions", () => {
+    const terms = ["hostname", "tag", "alert"];
+    const { provider } = setupLanguage(terms, { profileTypes: [] });
+    const suggestions = callProvider(provider, "");
+    const termSuggestions = suggestions.filter(
+      (s) => s.detail === "Search term",
+    );
+    expect(termSuggestions.map((s) => s.label)).toEqual(
+      expect.arrayContaining(terms),
+    );
+    expect(termSuggestions[0]).toMatchObject({ kind: 1 });
+  });
+
+  it("uses 'term:' insertText for non-hardware terms", () => {
+    const { provider } = setupLanguage(["hostname"], { profileTypes: [] });
+    const suggestions = callProvider(provider, "");
+    const hostname = suggestions.find((item) => item.label === "hostname");
+    expect(hostname?.insertText).toBe("hostname:");
+  });
+
+  it("uses 'term.' insertText for hardware root keys", () => {
+    const { provider } = setupLanguage([...HARDWARE_ROOT_KEYS], {
+      profileTypes: [],
+    });
+    const suggestions = callProvider(provider, "");
+    for (const hwKey of HARDWARE_ROOT_KEYS) {
+      const found = suggestions.find((item) => item.label === hwKey);
+      expect(found?.insertText, `${hwKey} insertText`).toBe(`${hwKey}.`);
+    }
+  });
+
+  it("includes all LOGICAL_OPERATORS as Operator suggestions", () => {
+    const { provider } = setupLanguage([], { profileTypes: [] });
+    const suggestions = callProvider(provider, "");
+    const opSuggestions = suggestions.filter(
+      (s) => s.detail === "Logical operator",
+    );
+    expect(opSuggestions.map((s) => s.label)).toEqual(
+      expect.arrayContaining([...LOGICAL_OPERATORS]),
+    );
+    expect(opSuggestions[0]).toMatchObject({ kind: 3 });
+  });
+
+  it("returns no term suggestions when no terms are configured", () => {
+    const { provider } = setupLanguage([], { profileTypes: [] });
+    const suggestions = callProvider(provider, "");
+    expect(suggestions.filter((s) => s.detail === "Search term")).toHaveLength(
+      0,
+    );
+  });
+});
+
+describe("completion provider - hardware dot context", () => {
+  it("returns Property attribute suggestions for cpu.", () => {
+    const { provider } = setupLanguage([...HARDWARE_ROOT_KEYS], {
+      profileTypes: [],
+    });
+    const suggestions = callProvider(provider, "cpu.");
+    expect(suggestions.map((s) => s.label)).toEqual([
+      ...HARDWARE_ATTRIBUTES.cpu,
+    ]);
+    expect(suggestions[0]).toMatchObject({
+      kind: 5,
+      detail: "cpu attribute",
+      insertText: "vendor:",
+    });
+  });
+
+  it("returns correct attributes for network.", () => {
+    const { provider } = setupLanguage([...HARDWARE_ROOT_KEYS], {
+      profileTypes: [],
+    });
+    const suggestions = callProvider(provider, "network.");
+    expect(suggestions.map((s) => s.label)).toEqual([
+      ...HARDWARE_ATTRIBUTES.network,
+    ]);
+  });
+
+  it("returns correct attributes for every hardware root key", () => {
+    const { provider } = setupLanguage([...HARDWARE_ROOT_KEYS], {
+      profileTypes: [],
+    });
+    for (const hwKey of HARDWARE_ROOT_KEYS) {
+      const suggestions = callProvider(provider, `${hwKey}.`);
+      expect(suggestions.map((s) => s.label)).toEqual([
+        ...HARDWARE_ATTRIBUTES[hwKey],
+      ]);
+    }
+  });
+
+  it("falls through to term/operator suggestions for an unknown dot-prefix", () => {
+    const { provider } = setupLanguage(["hostname"], { profileTypes: [] });
+    const suggestions = callProvider(provider, "unknown.");
+    // No hardware match, falls back to regular key context suggestions
+    expect(suggestions.some((s) => s.detail === "Logical operator")).toBe(true);
+  });
+});
+
+describe("completion provider - value context (colon in token)", () => {
+  it("returns ALERT_TYPES EnumMember suggestions for 'alert:'", () => {
+    const { provider } = setupLanguage(["alert"], { profileTypes: [] });
+    const suggestions = callProvider(provider, "alert:");
+    expect(suggestions.map((s) => s.label)).toEqual([...ALERT_TYPES]);
+    expect(suggestions[0]).toMatchObject({ detail: "Alert Type", kind: 2 });
+  });
+
+  it("returns LICENSE_TYPES suggestions for 'license-type:'", () => {
+    const { provider } = setupLanguage(["license-type"], { profileTypes: [] });
+    const suggestions = callProvider(provider, "license-type:");
+    expect(suggestions.map((s) => s.label)).toEqual([...LICENSE_TYPES]);
+    expect(suggestions[0]).toMatchObject({ detail: "License Type" });
+  });
+
+  it("returns [reboot, license] suggestions for 'needs:'", () => {
+    const { provider } = setupLanguage(["needs"], { profileTypes: [] });
+    const suggestions = callProvider(provider, "needs:");
+    expect(suggestions.map((s) => s.label)).toEqual(["reboot", "license"]);
+    expect(suggestions[0]).toMatchObject({ detail: "Requirement" });
+  });
+
+  it("returns BOOLEANS suggestions for 'has-pro-management:'", () => {
+    const { provider } = setupLanguage(["has-pro-management"], {
+      profileTypes: [],
+    });
+    const suggestions = callProvider(provider, "has-pro-management:");
+    expect(suggestions.map((s) => s.label)).toEqual([...BOOLEANS]);
+    expect(suggestions[0]).toMatchObject({ detail: "Boolean" });
+  });
+
+  it("returns DISTRIBUTION_UPGRADE_STATUSES for 'release-upgrade:'", () => {
+    const { provider } = setupLanguage(["release-upgrade"], {
+      profileTypes: [],
+    });
+    const suggestions = callProvider(provider, "release-upgrade:");
+    expect(suggestions.map((s) => s.label)).toEqual([
+      ...DISTRIBUTION_UPGRADE_STATUSES,
+    ]);
+    expect(suggestions[0]).toMatchObject({ detail: "Release Upgrade Status" });
+  });
+
+  it("returns empty suggestions for an unknown key after a colon", () => {
+    const { provider } = setupLanguage([], { profileTypes: [] });
+    const suggestions = callProvider(provider, "unknownkey:");
+    expect(suggestions).toHaveLength(0);
+  });
+
+  it("returns empty suggestions for alert with extra colon segments", () => {
+    const { provider } = setupLanguage(["alert"], { profileTypes: [] });
+    const suggestions = callProvider(provider, "alert:type:extra:");
+    expect(suggestions).toHaveLength(0);
+  });
+});
+
+describe("completion provider - profile deep suggestions", () => {
+  const config = {
+    profileTypes: ["security", "wsl", "script"],
+    usgStatuses: ["pass", "fail"],
+    wslStatuses: ["compliant", "noncompliant"],
+  };
+
+  it("returns profile types as EnumMember at depth 1 (profile:)", () => {
+    const { provider } = setupLanguage(["profile"], config);
+    const suggestions = callProvider(provider, "profile:");
+    expect(suggestions.map((s) => s.label)).toEqual(config.profileTypes);
+    expect(suggestions[0]).toMatchObject({ detail: "Profile Type", kind: 2 });
+  });
+
+  it("returns <profile_id> Text placeholder at depth 2 (profile:security:)", () => {
+    const { provider } = setupLanguage(["profile"], config);
+    const suggestions = callProvider(provider, "profile:security:");
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]).toMatchObject({
+      label: "<profile_id>",
+      detail: "ID for security",
+      kind: 4,
+    });
+  });
+
+  it("returns USG statuses at depth 3 for profile:security:id:", () => {
+    const { provider } = setupLanguage(["profile"], config);
+    const suggestions = callProvider(provider, "profile:security:1:");
+    expect(suggestions.map((s) => s.label)).toEqual(config.usgStatuses);
+    expect(suggestions[0]).toMatchObject({ detail: "Audit Result" });
+  });
+
+  it("returns WSL statuses at depth 3 for profile:wsl:id:", () => {
+    const { provider } = setupLanguage(["profile"], config);
+    const suggestions = callProvider(provider, "profile:wsl:1:");
+    expect(suggestions.map((s) => s.label)).toEqual(config.wslStatuses);
+    expect(suggestions[0]).toMatchObject({ detail: "Compliance Status" });
+  });
+
+  it("returns empty suggestions at depth 3 for non-security/wsl profile types", () => {
+    const { provider } = setupLanguage(["profile"], config);
+    const suggestions = callProvider(provider, "profile:script:1:");
+    expect(suggestions).toHaveLength(0);
+  });
+
+  it("returns empty suggestions at depth 3 when usgStatuses config is empty", () => {
+    const { provider } = setupLanguage(["profile"], {
+      profileTypes: ["security"],
+      usgStatuses: [],
+      wslStatuses: [],
+    });
+    const suggestions = callProvider(provider, "profile:security:1:");
+    expect(suggestions).toHaveLength(0);
+  });
+
+  it("returns empty suggestions at depth 3 when wslStatuses config is empty", () => {
+    const { provider } = setupLanguage(["profile"], {
+      profileTypes: ["wsl"],
+      usgStatuses: [],
+      wslStatuses: [],
+    });
+    const suggestions = callProvider(provider, "profile:wsl:1:");
+    expect(suggestions).toHaveLength(0);
+  });
+});
+
+describe("completion provider - annotation suggestions", () => {
+  it("returns <key> Text placeholder at depth 1 (annotation:)", () => {
+    const { provider } = setupLanguage(["annotation"], { profileTypes: [] });
+    const suggestions = callProvider(provider, "annotation:");
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]).toMatchObject({
+      label: "<key>",
+      detail: "Annotation Key",
+      kind: 4,
+    });
+  });
+
+  it("returns <string> Text placeholder at depth 2 (annotation:mykey:)", () => {
+    const { provider } = setupLanguage(["annotation"], { profileTypes: [] });
+    const suggestions = callProvider(provider, "annotation:mykey:");
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]).toMatchObject({
+      label: "<string>",
+      detail: "Value substring match",
+    });
+  });
+
+  it("returns empty suggestions beyond depth 2 (annotation:key:value:)", () => {
+    const { provider } = setupLanguage(["annotation"], { profileTypes: [] });
+    const suggestions = callProvider(provider, "annotation:key:value:");
+    expect(suggestions).toHaveLength(0);
+  });
+});
+
+describe("completion provider - hardware value context", () => {
+  it("returns <value> Text placeholder for cpu.vendor:", () => {
+    const { provider } = setupLanguage([...HARDWARE_ROOT_KEYS], {
+      profileTypes: [],
+    });
+    // "cpu.vendor:" rootKey "cpu.vendor" contains a dot, depth 1
+    const suggestions = callProvider(provider, "cpu.vendor:");
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]).toMatchObject({
+      label: "<value>",
+      detail: "Hardware property value",
+      kind: 4,
+    });
+  });
+
+  it("returns <value> placeholder for disk.size:", () => {
+    const { provider } = setupLanguage([...HARDWARE_ROOT_KEYS], {
+      profileTypes: [],
+    });
+    const suggestions = callProvider(provider, "disk.size:");
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]).toMatchObject({ label: "<value>" });
+  });
+
+  it("returns <value> for every hardware root attribute when followed by colon", () => {
+    const { provider } = setupLanguage([...HARDWARE_ROOT_KEYS], {
+      profileTypes: [],
+    });
+    for (const hwKey of HARDWARE_ROOT_KEYS) {
+      for (const attr of HARDWARE_ATTRIBUTES[hwKey]) {
+        const suggestions = callProvider(provider, `${hwKey}.${attr}:`);
+        expect(suggestions).toHaveLength(1);
+        expect(suggestions[0]).toMatchObject({ label: "<value>" });
+      }
+    }
+  });
+});

--- a/src/features/saved-searches/components/SavedSearchForm/helpers/searchQueryLanguage.ts
+++ b/src/features/saved-searches/components/SavedSearchForm/helpers/searchQueryLanguage.ts
@@ -4,6 +4,8 @@ import {
   LICENSE_TYPES,
   BOOLEANS,
   DISTRIBUTION_UPGRADE_STATUSES,
+  HARDWARE_ATTRIBUTES,
+  HARDWARE_ROOT_KEYS,
   LOGICAL_OPERATORS,
   LAST_TOKEN_REGEX,
   WHITESPACE_TOKEN_REGEX,
@@ -122,6 +124,20 @@ const getSimpleEnumSuggestions = <T extends string>(
   }));
 };
 
+const getHardwareAttributeSuggestions = (
+  hwRoot: keyof typeof HARDWARE_ATTRIBUTES,
+  range: MonacoRange,
+  monaco: Monaco,
+) => {
+  return HARDWARE_ATTRIBUTES[hwRoot].map((attr) => ({
+    label: attr,
+    kind: monaco.languages.CompletionItemKind.Property,
+    insertText: `${attr}:`,
+    range,
+    detail: `${hwRoot} attribute`,
+  }));
+};
+
 const getDeepSuggestions = (
   segments: string[],
   range: MonacoRange,
@@ -130,6 +146,18 @@ const getDeepSuggestions = (
 ) => {
   const [rootKey] = segments;
   const depth = segments.length - 1;
+
+  if (rootKey?.includes(".") && depth === 1) {
+    return [
+      {
+        label: "<value>",
+        kind: monaco.languages.CompletionItemKind.Text,
+        insertText: "<value>",
+        range,
+        detail: "Hardware property value",
+      },
+    ];
+  }
 
   switch (rootKey) {
     case "profile":
@@ -230,7 +258,7 @@ export const configureSearchLanguage = (
 
   if (!registeredCompletionProviders.has(languageId)) {
     monaco.languages.registerCompletionItemProvider(languageId, {
-      triggerCharacters: [":", " ", '"'],
+      triggerCharacters: [":", " ", '"', "."],
       provideCompletionItems(model, position) {
         const word = model.getWordUntilPosition(position);
         const range: MonacoRange = {
@@ -267,15 +295,41 @@ export const configureSearchLanguage = (
           return { suggestions };
         }
 
+        // Check if we're in a hardware dot context (e.g., "cpu.", "disk.vendor")
+        const hwDotMatch = fullToken.match(
+          /^([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_]*)$/,
+        );
+        if (hwDotMatch) {
+          const hwRoot = hwDotMatch[1];
+          if (
+            HARDWARE_ROOT_KEYS.includes(
+              hwRoot as keyof typeof HARDWARE_ATTRIBUTES,
+            )
+          ) {
+            return {
+              suggestions: getHardwareAttributeSuggestions(
+                hwRoot as keyof typeof HARDWARE_ATTRIBUTES,
+                range,
+                monaco,
+              ),
+            };
+          }
+        }
+
         const currentTerms = languageData?.terms ?? [];
 
-        const termSuggestions = currentTerms.map((term) => ({
-          label: term,
-          kind: monaco.languages.CompletionItemKind.Keyword,
-          insertText: `${term}:`,
-          range,
-          detail: "Search term",
-        }));
+        const termSuggestions = currentTerms.map((term) => {
+          const isHardwareRoot = HARDWARE_ROOT_KEYS.includes(
+            term as keyof typeof HARDWARE_ATTRIBUTES,
+          );
+          return {
+            label: term,
+            kind: monaco.languages.CompletionItemKind.Keyword,
+            insertText: isHardwareRoot ? `${term}.` : `${term}:`,
+            range,
+            detail: "Search term",
+          };
+        });
 
         const operatorSuggestions = LOGICAL_OPERATORS.map((op) => ({
           label: op,

--- a/src/features/saved-searches/components/SavedSearchForm/helpers/searchQueryLanguage.ts
+++ b/src/features/saved-searches/components/SavedSearchForm/helpers/searchQueryLanguage.ts
@@ -300,7 +300,7 @@ export const configureSearchLanguage = (
           /^([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_]*)$/,
         );
         if (hwDotMatch) {
-          const hwRoot = hwDotMatch[1];
+          const [, hwRoot] = hwDotMatch;
           if (
             HARDWARE_ROOT_KEYS.includes(
               hwRoot as keyof typeof HARDWARE_ATTRIBUTES,

--- a/src/features/saved-searches/components/SavedSearchForm/helpers/searchQuerySchema.ts
+++ b/src/features/saved-searches/components/SavedSearchForm/helpers/searchQuerySchema.ts
@@ -2,4 +2,5 @@ import * as Yup from "yup";
 
 export const VALIDATION_SCHEMA = Yup.object().shape({
   title: Yup.string().required("This field is required."),
+  search: Yup.string().required("This field is required."),
 });

--- a/src/features/saved-searches/components/SavedSearchForm/helpers/searchQueryValidation.ts
+++ b/src/features/saved-searches/components/SavedSearchForm/helpers/searchQueryValidation.ts
@@ -2,6 +2,8 @@ import {
   ALERT_TYPES,
   BOOLEANS,
   DOUBLE_QUOTE_REGEX,
+  HARDWARE_ATTRIBUTES,
+  HARDWARE_ROOT_KEYS,
   INTEGER_REGEX,
   LICENSE_TYPES,
   LOGICAL_OPERATORS,
@@ -182,6 +184,45 @@ const validateNumericKeyToken = (
   return keyError(key, "requires a number.");
 };
 
+const validateHardwareToken = (key: string, val: string): ValidationResult => {
+  const dotIndex = key.indexOf(".");
+
+  if (dotIndex === -1) {
+    const hwRoot = key as keyof typeof HARDWARE_ATTRIBUTES;
+    const validAttrs = HARDWARE_ATTRIBUTES[hwRoot].join(", ");
+    return keyError(
+      key,
+      `requires a dot-separated attribute. Valid attributes: ${validAttrs}.`,
+    );
+  }
+
+  const hwRoot = key.slice(0, dotIndex) as keyof typeof HARDWARE_ATTRIBUTES;
+  const attribute = key.slice(dotIndex + 1);
+
+  if (!attribute || !attribute.trim()) {
+    const validAttrs = HARDWARE_ATTRIBUTES[hwRoot].join(", ");
+    return keyError(
+      key,
+      `requires an attribute. Valid attributes: ${validAttrs}.`,
+    );
+  }
+
+  const validAttributes: readonly string[] = HARDWARE_ATTRIBUTES[hwRoot];
+  if (!validAttributes.includes(attribute)) {
+    const validAttrs = HARDWARE_ATTRIBUTES[hwRoot].join(", ");
+    return keyError(
+      key,
+      `has invalid attribute "${attribute}". Valid attributes: ${validAttrs}.`,
+    );
+  }
+
+  if (!val || !val.trim()) {
+    return keyError(key, "requires a value.");
+  }
+
+  return undefined;
+};
+
 const validateAnnotationToken = (val: string): ValidationResult => {
   if (val.trim()) {
     return undefined;
@@ -203,6 +244,12 @@ const validateKeyToken = (
   config: ValidationConfig,
 ): ValidationResult => {
   const [key, val] = parts;
+
+  // Handle hardware dot-notation keys (e.g., cpu.vendor, disk.size)
+  const hwRoot = key.split(".")[0];
+  if (HARDWARE_ROOT_KEYS.includes(hwRoot as keyof typeof HARDWARE_ATTRIBUTES)) {
+    return validateHardwareToken(key, val);
+  }
 
   if (!isValidRootKey(key)) {
     return keyError(key, "is not a valid query key.");
@@ -238,6 +285,7 @@ const validateKeyToken = (
     case "contract":
     case "contract-expires-within-days":
     case "license-expires-within-days":
+    case "last-ping":
       return validateNumericKeyToken(key, val);
 
     default:

--- a/src/features/saved-searches/components/SavedSearchForm/helpers/searchQueryValidation.ts
+++ b/src/features/saved-searches/components/SavedSearchForm/helpers/searchQueryValidation.ts
@@ -246,7 +246,7 @@ const validateKeyToken = (
   const [key, val] = parts;
 
   // Handle hardware dot-notation keys (e.g., cpu.vendor, disk.size)
-  const hwRoot = key.split(".")[0];
+  const [hwRoot] = key.split(".");
   if (HARDWARE_ROOT_KEYS.includes(hwRoot as keyof typeof HARDWARE_ATTRIBUTES)) {
     return validateHardwareToken(key, val);
   }


### PR DESCRIPTION
## Summary

This PR deals with [this Jira ticket](https://warthogs.atlassian.net/browse/LNDENG-4321)

Missing search terms were added to both the "?" search term helper in the instances page, as well as in the saved searches form.
The saved search form no longer blocks the user from submitting a search when the wrong search parameters have been used. It only warns them with a warning shown below the input.

## Release Impact

According to the [Landscape Server Release Cycle](https://docs.google.com/document/d/1sKAp5IvArpfArhMNojFwKOHm9LEdHKB4Et6tu1_-0GY/edit?tab=t.0), this change will target the following release cycle:
- **Target Branch**: `dev` / `main` (Beta)
- **Version Impact**:
  - [x] Patch (Fix)
  - [ ] Minor (Feature)
  - [ ] Major (Breaking)

## Checklist
- [x] **Changeset Added**: I have run `pnpm changeset` and committed the resulting `.md` file.
- [x] **UI Verified**: I have verified the changes locally.
- [x] **Linting**: No linting errors are present (especially in `scripts/`).

## Versioning Reminder
> [!IMPORTANT]
> This repository now uses **CalVer** ($YY.0M.Point.Patch$).
> Please ensure your changeset description is clear, as it will be automatically added to the `CHANGELOG.md` upon merging to `main`.