### PR TITLE
refactor: remove recovery key functionality for Windows instances

### DIFF
--- a/src/features/employees/components/EmployeeInstancesTableActions/EmployeeInstancesTableActions.test.tsx
+++ b/src/features/employees/components/EmployeeInstancesTableActions/EmployeeInstancesTableActions.test.tsx
@@ -10,6 +10,7 @@ import {
   instanceFailedActivityWithKey,
   instanceNoActivityNoKey,
   instanceNoActivityWithKey,
+  windowsInstance,
 } from "@/tests/mocks/instance";
 
 describe("EmployeeInstancesTableContextualMenu", () => {
@@ -256,6 +257,28 @@ describe("EmployeeInstancesTableContextualMenu", () => {
         name: `Regenerate recovery key for "${instanceActivityNoKey.title}"`,
       }),
     ).toBeVisible();
+  });
+
+  it("does not show recovery key actions for Windows instances", async () => {
+    renderWithProviders(
+      <EmployeeInstancesTableActions instance={windowsInstance} />,
+    );
+
+    await user.click(
+      screen.getByLabelText(`${windowsInstance.title} profile actions`),
+    );
+
+    expect(
+      screen.queryByLabelText(`View ${windowsInstance.title} recovery key`),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(`Generate ${windowsInstance.title} recovery key`),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(
+        `Regenerate ${windowsInstance.title} recovery key`,
+      ),
+    ).not.toBeInTheDocument();
   });
 
   it("opens and confirms the sanitize modal", async () => {

--- a/src/features/employees/components/EmployeeInstancesTableActions/EmployeeInstancesTableActions.tsx
+++ b/src/features/employees/components/EmployeeInstancesTableActions/EmployeeInstancesTableActions.tsx
@@ -3,6 +3,7 @@ import ListActions from "@/components/layout/ListActions";
 import { useActivities } from "@/features/activities";
 import {
   GenerateRecoveryKeyModal,
+  getFeatures,
   isRecoveryKeyActivityInProgress,
   InstanceRemoveFromLandscapeModal,
   RegenerateRecoveryKeyModal,
@@ -35,10 +36,12 @@ const EmployeeInstancesTableActions: FC<EmployeeInstancesTableActionsProps> = ({
   const { sanitizeInstance, isSanitizingInstance } = useSanitizeInstance();
   const { recoveryKey, recoveryKeyActivityStatus, isRecoveryKeyFetched } =
     useGetRecoveryKey(instance.id);
+  const instanceFeatures = getFeatures(instance);
   const isRecoveryKeyGenerationActivityInProgress =
     isRecoveryKeyActivityInProgress(recoveryKeyActivityStatus);
   const hasRecoveryKey = Boolean(recoveryKey);
-  const shouldShowRecoveryKeyActions = isRecoveryKeyFetched;
+  const shouldShowRecoveryKeyActions =
+    isRecoveryKeyFetched && instanceFeatures.recoveryKey;
 
   const handleCloseModal = () => {
     setSelectedAction("");

--- a/src/features/instances/helpers.ts
+++ b/src/features/instances/helpers.ts
@@ -56,6 +56,7 @@ export function getFeatures(instance: InstanceWithoutRelation) {
     power: isLinux,
     pro: !isNonUbuntuLinux,
     processes: isLinux,
+    recoveryKey: isLinux,
     sanitization: isLinux && !isUbuntuCore && !instance.is_wsl_instance,
     scripts: isLinux,
     snaps: isLinux,

--- a/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.test.tsx
@@ -12,6 +12,7 @@ import {
   instanceFailedActivityWithKey,
   instanceNoActivityNoKey,
   instanceNoActivityWithKey,
+  windowsInstance,
 } from "@/tests/mocks/instance";
 import { renderWithProviders } from "@/tests/render";
 import type { FeatureKey } from "@/types/FeatureKey";
@@ -177,6 +178,33 @@ describe("InfoPanel", () => {
   });
 
   describe("Recovery key buttons", () => {
+    it("should not render recovery key buttons for Windows instances", async () => {
+      renderWithProviders(<InfoPanel instance={windowsInstance} />);
+
+      await expectLoadingState();
+
+      expect(
+        screen.queryByRole("button", {
+          name: "More actions",
+        }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("menuitem", {
+          name: "View recovery key",
+        }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("menuitem", {
+          name: "Generate recovery key",
+        }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("menuitem", {
+          name: "Regenerate recovery key",
+        }),
+      ).not.toBeInTheDocument();
+    });
+
     describe("View recovery key button", () => {
       it("should render 'View recovery key' button if instance has recovery key", async () => {
         renderWithProviders(<InfoPanel instance={instanceActivityWithKey} />);

--- a/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.tsx
@@ -264,11 +264,13 @@ const InfoPanel: FC<InfoPanelProps> = ({ instance }) => {
     ? getAccessGroupQueryResult.data
     : [];
 
+  const instanceFeatures = getFeatures(instance);
   const hasRecoveryKey = Boolean(recoveryKey);
   const shouldShowRecoveryKeyWarningInLabel = Boolean(
     recoveryKeyRegenerationAttemptMessage,
   );
-  const shouldShowRecoveryKeyActions = isRecoveryKeyFetched;
+  const shouldShowRecoveryKeyActions =
+    isRecoveryKeyFetched && instanceFeatures.recoveryKey;
   const shouldShowGenerateRecoveryKey =
     shouldShowRecoveryKeyActions &&
     !hasRecoveryKey &&
@@ -325,19 +327,19 @@ const InfoPanel: FC<InfoPanelProps> = ({ instance }) => {
               icon: "restart",
               label: "Restart",
               onClick: openRestartModal,
-              excluded: !getFeatures(instance).power,
+              excluded: !instanceFeatures.power,
             },
             {
               icon: "power-off",
               label: "Shut down",
               onClick: openShutDownModal,
-              excluded: !getFeatures(instance).power,
+              excluded: !instanceFeatures.power,
             },
             {
               icon: "code",
               label: "Run script",
               onClick: openRunScriptForm,
-              excluded: !getFeatures(instance).scripts,
+              excluded: !instanceFeatures.scripts,
             },
             {
               icon: "private-key",
@@ -360,7 +362,7 @@ const InfoPanel: FC<InfoPanelProps> = ({ instance }) => {
               collapsed: true,
               excluded:
                 !isFeatureEnabled("employee-management") ||
-                !getFeatures(instance).employees ||
+                !instanceFeatures.employees ||
                 instance.employee_id !== null,
             },
             {
@@ -370,7 +372,7 @@ const InfoPanel: FC<InfoPanelProps> = ({ instance }) => {
               collapsed: true,
               excluded:
                 !isFeatureEnabled("employee-management") ||
-                !getFeatures(instance).employees ||
+                !instanceFeatures.employees ||
                 instance.employee_id === null,
             },
           ],
@@ -380,14 +382,14 @@ const InfoPanel: FC<InfoPanelProps> = ({ instance }) => {
               label: "Reinstall",
               onClick: openReinstallModal,
               collapsed: true,
-              excluded: !getFeatures(instance).uninstallation,
+              excluded: !instanceFeatures.uninstallation,
             },
             {
               icon: "close",
               label: "Uninstall",
               onClick: openUninstallModal,
               collapsed: true,
-              excluded: !getFeatures(instance).uninstallation,
+              excluded: !instanceFeatures.uninstallation,
             },
             {
               icon: "restart",

--- a/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.tsx
@@ -409,7 +409,7 @@ const InfoPanel: FC<InfoPanelProps> = ({ instance }) => {
               label: "Sanitize",
               onClick: openSanitizeModal,
               collapsed: true,
-              excluded: !getFeatures(instance).sanitization,
+              excluded: !instanceFeatures.sanitization,
             },
           ],
         }}
@@ -455,47 +455,52 @@ const InfoPanel: FC<InfoPanelProps> = ({ instance }) => {
               value={getProfilesValue()}
               type="truncated"
             />
-            {getFeatures(instance).employees && (
+            {instanceFeatures.employees && (
               <InfoGrid.Item
                 label="Associated employee"
                 value={employee?.name}
               />
             )}
-            <InfoGrid.Item
-              label={
-                <>
-                  Recovery key
-                  {shouldShowRecoveryKeyWarningInLabel && (
-                    <Tooltip
-                      position="top-center"
-                      message={recoveryKeyRegenerationAttemptMessage}
-                      className={classes.recoveryKeyTooltip}
-                    >
-                      <Icon name="warning" aria-label="Recovery key warning" />
-                    </Tooltip>
-                  )}
-                </>
-              }
-              value={
-                <RecoveryKeyStatus
-                  instanceId={instance.id}
-                  showWarningTooltip={false}
-                />
-              }
-            />
+            {instanceFeatures.recoveryKey && (
+              <InfoGrid.Item
+                label={
+                  <>
+                    Recovery key
+                    {shouldShowRecoveryKeyWarningInLabel && (
+                      <Tooltip
+                        position="top-center"
+                        message={recoveryKeyRegenerationAttemptMessage}
+                        className={classes.recoveryKeyTooltip}
+                      >
+                        <Icon
+                          name="warning"
+                          aria-label="Recovery key warning"
+                        />
+                      </Tooltip>
+                    )}
+                  </>
+                }
+                value={
+                  <RecoveryKeyStatus
+                    instanceId={instance.id}
+                    showWarningTooltip={false}
+                  />
+                }
+              />
+            )}
           </InfoGrid>
         </Blocks.Item>
         <Blocks.Item title="Registration details">
           <InfoGrid>
             <InfoGrid.Item label="Hostname" value={instance.hostname} />
             <InfoGrid.Item label="ID" value={instance.id} />
-            {getFeatures(instance).hardware && (
+            {instanceFeatures.hardware && (
               <InfoGrid.Item
                 label="Serial number"
                 value={instance.grouped_hardware?.system.serial}
               />
             )}
-            {getFeatures(instance).hardware && (
+            {instanceFeatures.hardware && (
               <InfoGrid.Item
                 label="Product identifier"
                 value={instance.grouped_hardware?.system.model}
@@ -505,7 +510,7 @@ const InfoPanel: FC<InfoPanelProps> = ({ instance }) => {
               label="OS"
               value={instance.distribution_info?.description}
             />
-            {getFeatures(instance).hardware && (
+            {instanceFeatures.hardware && (
               <InfoGrid.Item
                 label="IP addresses"
                 value={

--- a/src/tests/server/handlers/instance.ts
+++ b/src/tests/server/handlers/instance.ts
@@ -349,10 +349,17 @@ export default [
     `${API_URL}computers/:computerId/recovery-key`,
     async ({ params }) => {
       const computerId = Number(params.computerId);
-      const hasInstance = instances.some((inst) => inst.id === computerId);
+      const instance = instances.find((inst) => inst.id === computerId);
 
-      if (!hasInstance) {
+      if (!instance) {
         return new HttpResponse(null, { status: 404 });
+      }
+
+      if (instance.distribution_info?.distributor === "Microsoft") {
+        return HttpResponse.json({
+          activity: null,
+          fde_recovery_key: null,
+        });
       }
 
       const activity = getMockRecoveryKeyActivity(computerId);


### PR DESCRIPTION
## Summary

This PR fixes [this Jira ticket](https://warthogs.atlassian.net/browse/LNDENG-4334)

Recovery key management is not available to windows instances.

## Release Impact

According to the [Landscape Server Release Cycle](https://docs.google.com/document/d/1sKAp5IvArpfArhMNojFwKOHm9LEdHKB4Et6tu1_-0GY/edit?tab=t.0), this change will target the following release cycle:
- **Target Branch**: `dev` / `main` (Beta)
- **Version Impact**:
  - [ ] Patch (Fix)
  - [ ] Minor (Feature)
  - [ ] Major (Breaking)

## Checklist
- [ ] **Changeset Added**: I have run `pnpm changeset` and committed the resulting `.md` file.
- [x] **UI Verified**: I have verified the changes locally.
- [x] **Linting**: No linting errors are present (especially in `scripts/`).

## Versioning Reminder
> [!IMPORTANT]
> This repository now uses **CalVer** ($YY.0M.Point.Patch$).
> Please ensure your changeset description is clear, as it will be automatically added to the `CHANGELOG.md` upon merging to `main`.