### PR TITLE
fix: CSS ordering inconsistency between dev and production build

### DIFF
--- a/.changeset/ten-moles-hang.md
+++ b/.changeset/ten-moles-hang.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Fix CSS ordering inconsistency between dev and production builds

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,7 @@ export default defineConfig(
     ignores: [
       "dist",
       "dist-ssr",
+      "assets",
       "node_modules",
       "playwright-report",
       "playwright",
@@ -65,7 +66,7 @@ export default defineConfig(
         ...globals.jest,
       },
 
-      ecmaVersion: 5,
+      ecmaVersion: "latest",
 
       parserOptions: {
         projectService: true,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "vite --host",
     "build": "pnpm run lint && pnpm run tcm:run && tsc && vite build",
     "build:e2e": "pnpm run build --mode e2e",
-    "lint": "eslint --fix . --ext .ts,.tsx",
+    "lint": "eslint --fix src e2e",
     "preview": "vite preview",
     "test": "pnpm exec playwright test",
     "test:saas": "VITE_SELF_HOSTED_ENV=false pnpm exec playwright test --project=saas",

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -3,7 +3,10 @@
 
 // Vanilla
 @import "vanilla-framework";
-@include vanilla;
+
+@layer vanilla {
+  @include vanilla;
+}
 
 // Custom styles
 @import "partials/base";


### PR DESCRIPTION
## Problem

In Vite dev mode, CSS from SCSS modules (e.g. `TableFilter.module.scss`) is injected as inline `<style>` tags following the JS module import order. This means custom classes like `.toggle` naturally appear after Vanilla Framework styles and win the cascade.
In production builds, Vite extracts CSS into separate files where chunk ordering is not guaranteed. Vanilla Framework's button selectors (e.g. `.p-button--base with margin: 0 1rem 1.25rem 0`) can appear **after** our module styles, overriding them due to equal specificity + later source order. This causes visual regressions that only appear in deployed environments, but not on localhost.

## Solution

Wrap Vanilla Framework's CSS output in a @layer vanilla block. Per the CSS cascade spec, **unlayered styles always take priority over layered styles**, regardless of specificity or source order. This means that all CSS Modules and custom partials automatically win over Vanilla's rules without needing specificity hacks like doubled selectors (`.toggle.toggle`) or `!important`.

## Release Impact

According to the [Landscape Server Release Cycle](https://docs.google.com/document/d/1sKAp5IvArpfArhMNojFwKOHm9LEdHKB4Et6tu1_-0GY/edit?tab=t.0), this change will target the following release cycle:
- **Target Branch**: `dev` / `main` (Beta)
- **Version Impact**:
  - [x] Patch (Fix)
  - [ ] Minor (Feature)
  - [ ] Major (Breaking)

## Checklist
- [x] **Changeset Added**: I have run `pnpm changeset` and committed the resulting `.md` file.
- [x] **UI Verified**: I have verified the changes locally.
- [ ] **Linting**: No linting errors are present (especially in `scripts/`).

## Versioning Reminder
> [!IMPORTANT]
> This repository now uses **CalVer** ($YY.0M.Point.Patch$).
> Please ensure your changeset description is clear, as it will be automatically added to the `CHANGELOG.md` upon merging to `main`.