### PR TITLE
`RemoveMirrorModal` improvements

### DIFF
--- a/src/features/mirrors/components/MirrorPublicationsList/MirrorPublicationsList.tsx
+++ b/src/features/mirrors/components/MirrorPublicationsList/MirrorPublicationsList.tsx
@@ -9,10 +9,12 @@ import { Link } from "react-router";
 
 interface MirrorPublicationsListProps {
   readonly publications: Publication[];
+  readonly openInNewTab?: boolean;
 }
 
 const MirrorPublicationsList: FC<MirrorPublicationsListProps> = ({
   publications,
+  openInNewTab = false,
 }) => {
   const { count, increment, decrement } = useCounter(1);
 
@@ -27,6 +29,7 @@ const MirrorPublicationsList: FC<MirrorPublicationsListProps> = ({
                 pathname: "/repositories/publications",
                 search: `?sidePath=view&name=${publication.publicationId}`,
               }}
+              target={openInNewTab ? "_blank" : undefined}
             >
               {publication.label}
             </Link>
@@ -34,7 +37,7 @@ const MirrorPublicationsList: FC<MirrorPublicationsListProps> = ({
         },
       },
     ],
-    [],
+    [openInNewTab],
   );
 
   return (

--- a/src/features/mirrors/components/MirrorPublicationsList/MirrorPublicationsList.tsx
+++ b/src/features/mirrors/components/MirrorPublicationsList/MirrorPublicationsList.tsx
@@ -30,6 +30,7 @@ const MirrorPublicationsList: FC<MirrorPublicationsListProps> = ({
                 search: `?sidePath=view&name=${publication.publicationId}`,
               }}
               target={openInNewTab ? "_blank" : undefined}
+              rel={openInNewTab ? "noopener noreferrer" : undefined}
             >
               {publication.label}
             </Link>

--- a/src/features/mirrors/components/RemoveMirrorModal/RemoveMirrorModal.tsx
+++ b/src/features/mirrors/components/RemoveMirrorModal/RemoveMirrorModal.tsx
@@ -1,10 +1,11 @@
 import useDebug from "@/hooks/useDebug";
-import { ConfirmationModal, Icon } from "@canonical/react-components";
+import { Icon } from "@canonical/react-components";
 import type { FC } from "react";
 import { useDeleteMirror, useListPublications } from "../../api";
 import useNotify from "@/hooks/useNotify";
 import MirrorPublicationsList from "../MirrorPublicationsList";
 import usePageParams from "@/hooks/usePageParams";
+import TextConfirmationModal from "@/components/form/TextConfirmationModal";
 
 interface RemoveMirrorModalProps {
   readonly close: () => void;
@@ -31,10 +32,6 @@ const RemoveMirrorModal: FC<RemoveMirrorModalProps> = ({
   const { mutateAsync: deleteMirror, isPending: isDeletingMirror } =
     useDeleteMirror();
 
-  if (!isOpen) {
-    return;
-  }
-
   const tryRemoveMirror = async () => {
     try {
       await deleteMirror({
@@ -54,7 +51,9 @@ const RemoveMirrorModal: FC<RemoveMirrorModalProps> = ({
   };
 
   return (
-    <ConfirmationModal
+    <TextConfirmationModal
+      isOpen={isOpen}
+      confirmationText={`remove ${mirrorDisplayName}`}
       confirmButtonLabel={
         <>
           <Icon name="delete" light />
@@ -71,7 +70,7 @@ const RemoveMirrorModal: FC<RemoveMirrorModalProps> = ({
       {publications.length ? (
         <>
           <p>This mirror is associated with the following publications:</p>
-          <MirrorPublicationsList publications={publications} />
+          <MirrorPublicationsList publications={publications} openInNewTab />
           <p>
             After removal you won’t be able to update any of these publications,
             but they will continue to be available.{" "}
@@ -85,7 +84,7 @@ const RemoveMirrorModal: FC<RemoveMirrorModalProps> = ({
           <strong>This action is irreversible.</strong>
         </p>
       )}
-    </ConfirmationModal>
+    </TextConfirmationModal>
   );
 };
 


### PR DESCRIPTION
- Publication links open in a new tab
- Uses text confirmation

<img width="757" height="562" alt="image" src="https://github.com/user-attachments/assets/60b725fc-6acf-47e4-a660-c3cac5eb9d26" />
