### PR TITLE
Fix mirror packages count

### DIFF
--- a/.changeset/late-moments-cry.md
+++ b/.changeset/late-moments-cry.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Fix mirror packages count to also consider `""` as not having a `nextPageToken`.

--- a/src/features/mirrors/components/MirrorPackagesCount/MirrorPackagesCount.tsx
+++ b/src/features/mirrors/components/MirrorPackagesCount/MirrorPackagesCount.tsx
@@ -17,7 +17,7 @@ const MirrorPackagesCount: FC<MirrorPackagesCount> = ({ mirrorName }) => {
   if (isError || !data) return <NoData />;
 
   return pluralizeNew(data.data.mirrorPackages?.length, "package", {
-    showCount: data.data.nextPageToken === undefined ? "exact" : "limited",
+    showCount: data.data.nextPageToken ? "limited" : "exact",
   });
 };
 

--- a/src/features/mirrors/components/MirrorPublicationsLink/MirrorPublicationsLinks.tsx
+++ b/src/features/mirrors/components/MirrorPublicationsLink/MirrorPublicationsLinks.tsx
@@ -28,7 +28,7 @@ const MirrorPublicationsLink: FC<MirrorPublicationsLinkProps> = ({
       }}
     >
       {pluralizeNew(data.data.publications.length, "publication", {
-        showCount: data.data.nextPageToken === undefined ? "exact" : "limited",
+        showCount: data.data.nextPageToken ? "limited" : "exact",
       })}
     </StaticLink>
   );


### PR DESCRIPTION
## Summary

Fix mirror packages count to also consider `""` as not having a `nextPageToken`.

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
