### PR TITLE
include access_group in repository profiles PUT

### DIFF
--- a/.changeset/strict-peaches-turn.md
+++ b/.changeset/strict-peaches-turn.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Add access_group param to repository profile PUTs so that the backend doesn't reset it to Global

--- a/.github/workflows/run-tests-and-tics.yml
+++ b/.github/workflows/run-tests-and-tics.yml
@@ -81,6 +81,7 @@ jobs:
     env:
       VITE_API_URL: ${{ vars.API_URL }}
       VITE_API_URL_OLD: ${{ vars.API_URL_OLD }}
+      VITE_API_URL_DEB_ARCHIVE: /v1beta1/
       VITE_APP_TITLE: Landscape
       VITE_ROOT_PATH: /new_dashboard/
       VITE_REPORT_VIEW_ENABLED: false

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -97,6 +97,7 @@ jobs:
     env:
       VITE_API_URL: ${{ vars.API_URL }}
       VITE_API_URL_OLD: ${{ vars.API_URL_OLD }}
+      VITE_API_URL_DEB_ARCHIVE: /v1beta1/
       VITE_APP_TITLE: Landscape
       VITE_ROOT_PATH: /new_dashboard/
       VITE_REPORT_VIEW_ENABLED: false

--- a/.github/workflows/tics-full.yml
+++ b/.github/workflows/tics-full.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       VITE_API_URL: ${{ vars.API_URL }}
       VITE_API_URL_OLD: ${{ vars.API_URL_OLD }}
+      VITE_API_URL_DEB_ARCHIVE: /v1beta1/
       VITE_APP_TITLE: Landscape
       VITE_ROOT_PATH: /new_dashboard/
       VITE_REPORT_VIEW_ENABLED: false

--- a/src/features/package-profiles/components/PackageProfileEditSidePanel/PackageProfileEditSidePanel.test.tsx
+++ b/src/features/package-profiles/components/PackageProfileEditSidePanel/PackageProfileEditSidePanel.test.tsx
@@ -23,7 +23,9 @@ describe("PackageProfileEditSidePanel", () => {
     expect(screen.getByRole("textbox", { name: /description/i })).toHaveValue(
       packageProfiles[0].description,
     );
-    expect(screen.getByLabelText(/access group/i)).toBeDisabled();
+    expect(
+      screen.getByText(packageProfiles[0].access_group),
+    ).toBeInTheDocument();
     expect(screen.getByText("Association")).toBeInTheDocument();
 
     if (packageProfiles[0].all_computers) {

--- a/src/features/package-profiles/components/PackageProfileEditSidePanel/components/PackageProfileEditForm/PackageProfileEditForm.tsx
+++ b/src/features/package-profiles/components/PackageProfileEditSidePanel/components/PackageProfileEditForm/PackageProfileEditForm.tsx
@@ -1,12 +1,13 @@
 import AssociationBlock from "@/components/form/AssociationBlock";
+import ReadOnlyField from "@/components/form/ReadOnlyField";
 import SidePanelFormButtons from "@/components/form/SidePanelFormButtons";
 import useDebug from "@/hooks/useDebug";
 import useNotify from "@/hooks/useNotify";
 import usePageParams from "@/hooks/usePageParams";
 import useRoles from "@/hooks/useRoles";
-import { type SelectOption } from "@/types/SelectOption";
 import { getFormikError } from "@/utils/formikErrors";
-import { Form, Input, Select } from "@canonical/react-components";
+import { getTitleByName } from "@/utils/_helpers";
+import { Form, Input } from "@canonical/react-components";
 import { useFormik } from "formik";
 import type { FC } from "react";
 import { usePackageProfiles } from "../../../../hooks";
@@ -26,14 +27,8 @@ const PackageProfileEditForm: FC<PackageProfileEditFormProps> = ({
   const { editPackageProfileQuery } = usePackageProfiles();
   const { getAccessGroupQuery } = useRoles();
 
-  const { data: getAccessGroupQueryResult } = getAccessGroupQuery();
+  const { data: accessGroupsData } = getAccessGroupQuery();
   const { mutateAsync: editPackageProfile } = editPackageProfileQuery;
-
-  const accessGroupOptions: SelectOption[] =
-    getAccessGroupQueryResult?.data.map(({ name, title }) => ({
-      label: title,
-      value: name,
-    })) ?? [];
 
   const closeSidePanel = createPageParamsSetter({ sidePath: [], name: "" });
 
@@ -83,11 +78,10 @@ const PackageProfileEditForm: FC<PackageProfileEditFormProps> = ({
         {...formik.getFieldProps("description")}
       />
 
-      <Select
+      <ReadOnlyField
         label="Access group"
-        disabled
-        options={accessGroupOptions}
-        value={profile.access_group}
+        value={getTitleByName(profile.access_group, accessGroupsData)}
+        tooltipMessage="You can't change the access group after the package profile has been created"
       />
 
       <AssociationBlock formik={formik} />

--- a/src/features/reboot-profiles/components/RebootProfilesForm/RebootProfilesForm.test.tsx
+++ b/src/features/reboot-profiles/components/RebootProfilesForm/RebootProfilesForm.test.tsx
@@ -75,9 +75,12 @@ describe("RebootProfilesForm", () => {
     expect(screen.getByLabelText(/access group/i)).toBeEnabled();
   });
 
-  it("shows disabled access group field in edit mode", () => {
-    renderWithProviders(<RebootProfilesForm action="edit" profile={profile} />);
+  it("shows read-only access group field in edit mode", () => {
+    const { container } = renderWithProviders(
+      <RebootProfilesForm action="edit" profile={profile} />,
+    );
 
-    expect(screen.getByLabelText(/access group/i)).toBeDisabled();
+    expect(container.querySelector(".p-icon--lock-locked")).toBeInTheDocument();
+    expect(screen.getByText(profile.access_group)).toBeInTheDocument();
   });
 });

--- a/src/features/reboot-profiles/components/RebootProfilesForm/RebootProfilesForm.tsx
+++ b/src/features/reboot-profiles/components/RebootProfilesForm/RebootProfilesForm.tsx
@@ -1,12 +1,14 @@
 import AssociationBlock from "@/components/form/AssociationBlock";
 import { RandomizationBlock } from "@/components/form/DeliveryScheduling";
 import MultiSelectField from "@/components/form/MultiSelectField";
+import ReadOnlyField from "@/components/form/ReadOnlyField";
 import SidePanelFormButtons from "@/components/form/SidePanelFormButtons";
 import useDebug from "@/hooks/useDebug";
 import useNotify from "@/hooks/useNotify";
 import usePageParams from "@/hooks/usePageParams";
 import useRoles from "@/hooks/useRoles";
 import { getFormikError } from "@/utils/formikErrors";
+import { getTitleByName } from "@/utils/_helpers";
 import {
   Form,
   Icon,
@@ -37,13 +39,13 @@ const RebootProfilesForm: FC<RebootProfilesFormProps> = (props) => {
   const { sidePath, popSidePath, createPageParamsSetter } = usePageParams();
   const { notify } = useNotify();
 
-  const { data: getAccessGroupQueryResult } = getAccessGroupQuery();
+  const { data: accessGroupsData } = getAccessGroupQuery();
   const { createRebootProfile, isCreatingRebootProfile } =
     useCreateRebootProfileQuery();
   const { editRebootProfile, isEditingRebootProfile } =
     useEditRebootProfileQuery();
   const accessGroupOptions =
-    getAccessGroupQueryResult?.data.map(({ name, title }) => ({
+    accessGroupsData?.data.map(({ name, title }) => ({
       label: title,
       value: name,
     })) ?? [];
@@ -109,14 +111,21 @@ const RebootProfilesForm: FC<RebootProfilesFormProps> = (props) => {
           error={getFormikError(formik, "title")}
         />
 
-        <Select
-          label="Access group"
-          aria-label="Access group"
-          options={accessGroupOptions}
-          disabled={props.action === "edit"}
-          {...formik.getFieldProps("access_group")}
-          error={getFormikError(formik, "access_group")}
-        />
+        {props.action === "edit" ? (
+          <ReadOnlyField
+            label="Access group"
+            value={getTitleByName(props.profile.access_group, accessGroupsData)}
+            tooltipMessage="You can't change the access group after the reboot profile has been created"
+          />
+        ) : (
+          <Select
+            label="Access group"
+            aria-label="Access group"
+            options={accessGroupOptions}
+            {...formik.getFieldProps("access_group")}
+            error={getFormikError(formik, "access_group")}
+          />
+        )}
 
         <div className={classes.container}>
           <p className="p-heading--5">Schedule</p>

--- a/src/features/removal-profiles/components/SingleRemovalProfileForm/SingleRemovalProfileForm.test.tsx
+++ b/src/features/removal-profiles/components/SingleRemovalProfileForm/SingleRemovalProfileForm.test.tsx
@@ -53,11 +53,12 @@ describe("SingleRemovalProfileForm", () => {
     expect(screen.getByLabelText(/access group/i)).toBeEnabled();
   });
 
-  it("shows disabled access group field in edit mode", () => {
-    renderWithProviders(
+  it("shows read-only access group field in edit mode", () => {
+    const { container } = renderWithProviders(
       <SingleRemovalProfileForm action="edit" profile={profile} />,
     );
 
-    expect(screen.getByLabelText(/access group/i)).toBeDisabled();
+    expect(container.querySelector(".p-icon--lock-locked")).toBeInTheDocument();
+    expect(screen.getByText(profile.access_group)).toBeInTheDocument();
   });
 });

--- a/src/features/removal-profiles/components/SingleRemovalProfileForm/SingleRemovalProfileForm.tsx
+++ b/src/features/removal-profiles/components/SingleRemovalProfileForm/SingleRemovalProfileForm.tsx
@@ -6,6 +6,7 @@ import useNotify from "@/hooks/useNotify";
 import usePageParams from "@/hooks/usePageParams";
 import useRoles from "@/hooks/useRoles";
 import { getFormikError } from "@/utils/formikErrors";
+import { getTitleByName } from "@/utils/_helpers";
 import { Form, Input, Select } from "@canonical/react-components";
 import { useFormik } from "formik";
 import type { FC } from "react";
@@ -34,13 +35,13 @@ const SingleRemovalProfileForm: FC<SingleRemovalProfileFormProps> = (props) => {
     useRemovalProfiles();
   const { getAccessGroupQuery } = useRoles();
 
-  const { data: getAccessGroupQueryResult } = getAccessGroupQuery(
+  const { data: accessGroupsData } = getAccessGroupQuery(
     {},
     { enabled: props.action === "add" },
   );
 
   const accessGroupOptions =
-    getAccessGroupQueryResult?.data.map(({ name, title }) => ({
+    accessGroupsData?.data.map(({ name, title }) => ({
       label: title,
       value: name,
     })) ?? [];
@@ -129,8 +130,8 @@ const SingleRemovalProfileForm: FC<SingleRemovalProfileFormProps> = (props) => {
       {props.action === "edit" ? (
         <ReadOnlyField
           label="Access group"
+          value={getTitleByName(props.profile.access_group, accessGroupsData)}
           tooltipMessage="You can't change the access group after the removal profile has been created"
-          {...formik.getFieldProps("access_group")}
         />
       ) : (
         <Select

--- a/src/features/removal-profiles/components/SingleRemovalProfileForm/SingleRemovalProfileForm.tsx
+++ b/src/features/removal-profiles/components/SingleRemovalProfileForm/SingleRemovalProfileForm.tsx
@@ -1,4 +1,5 @@
 import AssociationBlock from "@/components/form/AssociationBlock";
+import ReadOnlyField from "@/components/form/ReadOnlyField";
 import SidePanelFormButtons from "@/components/form/SidePanelFormButtons";
 import useDebug from "@/hooks/useDebug";
 import useNotify from "@/hooks/useNotify";
@@ -89,6 +90,7 @@ const SingleRemovalProfileForm: FC<SingleRemovalProfileFormProps> = (props) => {
     initialValues:
       props.action === "edit"
         ? {
+            access_group: props.profile.access_group,
             all_computers: props.profile.all_computers,
             days_without_exchange: props.profile.days_without_exchange,
             tags: props.profile.tags,
@@ -124,13 +126,20 @@ const SingleRemovalProfileForm: FC<SingleRemovalProfileFormProps> = (props) => {
         <span className={classes.inputDescription}>days</span>
       </div>
 
-      <Select
-        label="Access group"
-        options={accessGroupOptions}
-        disabled={props.action === "edit"}
-        {...formik.getFieldProps("access_group")}
-        error={getFormikError(formik, "access_group")}
-      />
+      {props.action === "edit" ? (
+        <ReadOnlyField
+          label="Access group"
+          tooltipMessage="You can't change the access group after the removal profile has been created"
+          {...formik.getFieldProps("access_group")}
+        />
+      ) : (
+        <Select
+          label="Access group"
+          options={accessGroupOptions}
+          {...formik.getFieldProps("access_group")}
+          error={getFormikError(formik, "access_group")}
+        />
+      )}
 
       <AssociationBlock formik={formik} />
 

--- a/src/features/repository-profiles/api/useRepositoryProfiles.ts
+++ b/src/features/repository-profiles/api/useRepositoryProfiles.ts
@@ -32,6 +32,7 @@ interface EditRepositoryProfileParams {
   description?: string;
   tags?: string[];
   title?: string;
+  access_group?: string;
 }
 
 interface RemoveRepositoryProfileParams {

--- a/src/features/repository-profiles/components/RepositoryProfileForm/RepositoryProfileForm.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileForm/RepositoryProfileForm.tsx
@@ -91,6 +91,7 @@ const RepositoryProfileForm: FC<RepositoryProfileFormProps> = (props) => {
           name: props.profile.name,
           ...valuesToSubmit,
           add_apt_sources: values.apt_sources.filter((s) => s.id === 0),
+          access_group: props.profile.access_group, // Access group cannot be edited, but API requires it in the payload
           remove_apt_sources: originalSources
             .filter(
               (orig) => !values.apt_sources.some((cur) => cur.id === orig.id),

--- a/src/features/repository-profiles/components/RepositoryProfileFormDetailsPanel/RepositoryProfileFormDetailsPanel.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileFormDetailsPanel/RepositoryProfileFormDetailsPanel.tsx
@@ -21,6 +21,10 @@ const RepositoryProfileFormDetailsPanel: FC<
     value: name,
   }));
 
+  const accessGroupTitle =
+    accessGroups.find((ag) => ag.name === formik.values.access_group)?.title ??
+    formik.values.access_group;
+
   return (
     <>
       <Input
@@ -41,8 +45,8 @@ const RepositoryProfileFormDetailsPanel: FC<
       {isAccessGroupDisabled ? (
         <ReadOnlyField
           label="Access group"
+          value={accessGroupTitle}
           tooltipMessage={`You can't change the access group after the repository profile has been created`}
-          {...formik.getFieldProps("access_group")}
         />
       ) : (
         <Select

--- a/src/features/upgrade-profiles/components/SingleUpgradeProfileForm/SingleUpgradeProfileForm.test.tsx
+++ b/src/features/upgrade-profiles/components/SingleUpgradeProfileForm/SingleUpgradeProfileForm.test.tsx
@@ -90,11 +90,14 @@ describe("SingleUpgradeProfileForm", () => {
     expect(screen.getByLabelText(/access group/i)).toBeEnabled();
   });
 
-  it("shows disabled access group field in edit mode", () => {
-    renderWithProviders(
+  it("shows read-only access group field in edit mode", () => {
+    const { container } = renderWithProviders(
       <SingleUpgradeProfileForm action="edit" profile={upgradeProfiles[0]} />,
     );
 
-    expect(screen.getByLabelText(/access group/i)).toBeDisabled();
+    expect(container.querySelector(".p-icon--lock-locked")).toBeInTheDocument();
+    expect(
+      screen.getByText(upgradeProfiles[0].access_group),
+    ).toBeInTheDocument();
   });
 });

--- a/src/features/upgrade-profiles/components/SingleUpgradeProfileForm/SingleUpgradeProfileForm.tsx
+++ b/src/features/upgrade-profiles/components/SingleUpgradeProfileForm/SingleUpgradeProfileForm.tsx
@@ -1,4 +1,5 @@
 import AssociationBlock from "@/components/form/AssociationBlock";
+import ReadOnlyField from "@/components/form/ReadOnlyField";
 import SidePanelFormButtons from "@/components/form/SidePanelFormButtons";
 import useDebug from "@/hooks/useDebug";
 import useNotify from "@/hooks/useNotify";
@@ -111,6 +112,7 @@ const SingleUpgradeProfileForm: FC<SingleUpgradeProfileFormProps> = (props) => {
     initialValues:
       props.action === "edit"
         ? {
+            access_group: props.profile.access_group,
             all_computers: props.profile.all_computers,
             at_hour: props.profile.at_hour
               ? parseInt(props.profile.at_hour)
@@ -163,14 +165,21 @@ const SingleUpgradeProfileForm: FC<SingleUpgradeProfileFormProps> = (props) => {
         checked={formik.values.autoremove}
       />
 
-      <Select
-        label="Access group"
-        aria-label="Access group"
-        options={accessGroupOptions}
-        disabled={props.action === "edit"}
-        {...formik.getFieldProps("access_group")}
-        error={getFormikError(formik, "access_group")}
-      />
+      {props.action === "edit" ? (
+        <ReadOnlyField
+          label="Access group"
+          tooltipMessage="You can't change the access group after the upgrade profile has been created"
+          {...formik.getFieldProps("access_group")}
+        />
+      ) : (
+        <Select
+          label="Access group"
+          aria-label="Access group"
+          options={accessGroupOptions}
+          {...formik.getFieldProps("access_group")}
+          error={getFormikError(formik, "access_group")}
+        />
+      )}
 
       <UpgradeProfileScheduleBlock formik={formik} />
 

--- a/src/features/upgrade-profiles/components/SingleUpgradeProfileForm/SingleUpgradeProfileForm.tsx
+++ b/src/features/upgrade-profiles/components/SingleUpgradeProfileForm/SingleUpgradeProfileForm.tsx
@@ -6,6 +6,7 @@ import useNotify from "@/hooks/useNotify";
 import usePageParams from "@/hooks/usePageParams";
 import useRoles from "@/hooks/useRoles";
 import { getFormikError } from "@/utils/formikErrors";
+import { getTitleByName } from "@/utils/_helpers";
 import { Form, Input, Select } from "@canonical/react-components";
 import { useFormik } from "formik";
 import type { FC } from "react";
@@ -33,13 +34,13 @@ const SingleUpgradeProfileForm: FC<SingleUpgradeProfileFormProps> = (props) => {
     useUpgradeProfiles();
   const { getAccessGroupQuery } = useRoles();
 
-  const { data: getAccessGroupQueryResult } = getAccessGroupQuery(
+  const { data: accessGroupsData } = getAccessGroupQuery(
     {},
     { enabled: props.action === "add" },
   );
 
   const accessGroupOptions =
-    getAccessGroupQueryResult?.data.map(({ name, title }) => ({
+    accessGroupsData?.data.map(({ name, title }) => ({
       label: title,
       value: name,
     })) ?? [];
@@ -168,8 +169,8 @@ const SingleUpgradeProfileForm: FC<SingleUpgradeProfileFormProps> = (props) => {
       {props.action === "edit" ? (
         <ReadOnlyField
           label="Access group"
+          value={getTitleByName(props.profile.access_group, accessGroupsData)}
           tooltipMessage="You can't change the access group after the upgrade profile has been created"
-          {...formik.getFieldProps("access_group")}
         />
       ) : (
         <Select

--- a/src/features/usg-profiles/hooks/useUsgProfileFormBenchmarkStep.tsx
+++ b/src/features/usg-profiles/hooks/useUsgProfileFormBenchmarkStep.tsx
@@ -1,4 +1,5 @@
 import FileInput from "@/components/form/FileInput";
+import ReadOnlyField from "@/components/form/ReadOnlyField";
 import LabelWithDescription from "@/components/layout/LabelWithDescription";
 import { CustomSelect, Notification } from "@canonical/react-components";
 import type { FormikContextType } from "formik";
@@ -19,23 +20,56 @@ export default function useUsgProfileFormBenchmarkStep<
     await formik.setFieldValue("tailoring_file", null);
   };
 
+  const getTailoringFileValue = () => {
+    const file = formik.values.tailoring_file;
+    if (!file) return "None";
+    if (typeof file === "string") return file;
+    return file.name;
+  };
+
   return {
     isValid: !formik.errors.benchmark && !formik.errors.mode,
     isLoading: false,
     description:
       "Select a USG profile benchmark, choose the profile mode, and optionally upload a tailoring file to customize the USG profile.",
-    content: (
+    content: disabled ? (
       <>
-        {!disabled && (
-          <Notification severity="caution" title="Changes restricted:" inline>
-            After profile creation, the USG profile benchmark and mode cannot be
-            changed. Please review before proceeding.
-          </Notification>
-        )}
+        <ReadOnlyField
+          label="Base profile"
+          value={
+            USG_PROFILE_BENCHMARK_LABELS[
+              formik.values
+                .benchmark as keyof typeof USG_PROFILE_BENCHMARK_LABELS
+            ] ?? formik.values.benchmark
+          }
+          tooltipMessage="You can't change the base profile after the USG profile has been created"
+        />
+
+        <ReadOnlyField
+          label="Mode"
+          value={
+            USG_PROFILE_MODE_LABELS[
+              formik.values.mode as keyof typeof USG_PROFILE_MODE_LABELS
+            ] ?? formik.values.mode
+          }
+          tooltipMessage="You can't change the mode after the USG profile has been created"
+        />
+
+        <ReadOnlyField
+          label="Tailoring file"
+          value={getTailoringFileValue()}
+          tooltipMessage="You can't change the tailoring file after the USG profile has been created"
+        />
+      </>
+    ) : (
+      <>
+        <Notification severity="caution" title="Changes restricted:" inline>
+          After profile creation, the USG profile benchmark and mode cannot be
+          changed. Please review before proceeding.
+        </Notification>
 
         <CustomSelect
           label="Base profile"
-          disabled={disabled}
           options={[
             {
               label: (
@@ -106,7 +140,6 @@ export default function useUsgProfileFormBenchmarkStep<
 
         <CustomSelect
           label="Mode"
-          disabled={disabled}
           options={[
             {
               label: (
@@ -150,7 +183,6 @@ export default function useUsgProfileFormBenchmarkStep<
 
         <FileInput
           label="Upload tailoring file"
-          disabled={disabled}
           accept=".xml"
           {...formik.getFieldProps("tailoring_file")}
           help={

--- a/src/features/usg-profiles/hooks/useUsgProfileFormNameStep.tsx
+++ b/src/features/usg-profiles/hooks/useUsgProfileFormNameStep.tsx
@@ -1,7 +1,8 @@
+import ReadOnlyField from "@/components/form/ReadOnlyField";
 import { useOrgSettings } from "@/features/organisation-settings";
 import useEnv from "@/hooks/useEnv";
 import useRoles from "@/hooks/useRoles";
-import { pluralizeWithCount } from "@/utils/_helpers";
+import { getTitleByName, pluralizeWithCount } from "@/utils/_helpers";
 import { getFormikError } from "@/utils/formikErrors";
 import { Input, Select } from "@canonical/react-components";
 import type { FormikContextType } from "formik";
@@ -18,7 +19,7 @@ export default function useUsgProfileFormNameStep<
   const {
     data: getAccessGroupQueryResponse,
     isLoading: isLoadingAccessGroups,
-  } = getAccessGroupQuery({}, { enabled: formMode === "add" });
+  } = getAccessGroupQuery();
 
   const {
     data: getOrganisationPreferencesResponse,
@@ -50,26 +51,34 @@ export default function useUsgProfileFormNameStep<
           error={getFormikError(formik, "title")}
           required
         />
-        <Select
-          label="Access group"
-          options={getAccessGroupQueryResponse?.data.map((group) => ({
-            label: group.title,
-            value: group.name,
-          }))}
-          {...formik.getFieldProps("access_group")}
-          error={getFormikError(formik, "access_group")}
-          required
-          disabled={isLoadingAccessGroups || formMode === "edit"}
-        />
+        {formMode === "edit" ? (
+          <ReadOnlyField
+            label="Access group"
+            value={getTitleByName(
+              formik.values.access_group,
+              getAccessGroupQueryResponse,
+            )}
+            tooltipMessage="You can't change the access group after the USG profile has been created"
+          />
+        ) : (
+          <Select
+            label="Access group"
+            options={getAccessGroupQueryResponse?.data.map((group) => ({
+              label: group.title,
+              value: group.name,
+            }))}
+            {...formik.getFieldProps("access_group")}
+            error={getFormikError(formik, "access_group")}
+            required
+            disabled={isLoadingAccessGroups}
+          />
+        )}
 
         {isSelfHosted && (
-          <Input
-            type="text"
+          <ReadOnlyField
             label="Audit retention"
-            required
-            disabled
             value={getAuditRetentionPeriod()}
-            help="You can change this limit in the Landscape server configuration file."
+            tooltipMessage="You can change this limit in the Landscape server configuration file"
           />
         )}
       </>

--- a/src/features/wsl-profiles/components/WslProfileEditSidePanel/components/WslProfileEditForm/WslProfileEditForm.tsx
+++ b/src/features/wsl-profiles/components/WslProfileEditSidePanel/components/WslProfileEditForm/WslProfileEditForm.tsx
@@ -1,17 +1,15 @@
 import AssociationBlock from "@/components/form/AssociationBlock";
+import ReadOnlyField from "@/components/form/ReadOnlyField";
 import SidePanelFormButtons from "@/components/form/SidePanelFormButtons";
-import { useGetWslInstanceTypes } from "@/features/wsl";
 import useDebug from "@/hooks/useDebug";
 import useNotify from "@/hooks/useNotify";
 import usePageParams from "@/hooks/usePageParams";
-import useRoles from "@/hooks/useRoles";
 import { getFormikError } from "@/utils/formikErrors";
-import { Form, Input, Notification, Select } from "@canonical/react-components";
+import { Form, Input, Notification } from "@canonical/react-components";
 import { useFormik } from "formik";
 import { type FC } from "react";
 import { useEditWslProfile } from "../../../../api";
 import type { WslProfile } from "../../../../types";
-import { CLOUD_INIT_OPTIONS } from "../../../constants";
 import { getValidationSchema } from "./helpers";
 import classes from "./WslProfileEditForm.module.scss";
 
@@ -22,41 +20,30 @@ interface WslProfileEditFormProps {
 interface FormProps {
   title: string;
   description: string;
-  instanceType: string;
-  customImageName: string;
-  rootfsImage: string;
   all_computers: boolean;
   tags: string[];
 }
 
 const WslProfileEditForm: FC<WslProfileEditFormProps> = ({ profile }) => {
-  const { getAccessGroupQuery } = useRoles();
   const debug = useDebug();
   const { sidePath, popSidePath, createPageParamsSetter } = usePageParams();
   const { notify } = useNotify();
 
   const { editWslProfile } = useEditWslProfile();
-  const { wslInstanceTypes } = useGetWslInstanceTypes();
 
-  const instanceQueryResultOptions =
-    wslInstanceTypes.map(({ label, name }) => ({
-      label,
-      value: name,
-    })) || [];
+  const rootfsImageValue = profile.image_source
+    ? "From URL"
+    : profile.image_name;
 
-  const ROOTFS_IMAGE_OPTIONS = [
-    { label: "Select", value: "" },
-    ...instanceQueryResultOptions,
-    { label: "From URL", value: "custom" },
-  ];
-
-  const { data: getAccessGroupQueryResult } = getAccessGroupQuery();
-
-  const accessGroupResultOptions =
-    getAccessGroupQueryResult?.data.map(({ name, title }) => ({
-      label: title,
-      value: name,
-    })) ?? [];
+  const getCloudInitValue = () => {
+    if (profile.cloud_init_contents) return "Plain text";
+    if (profile.cloud_init_secret_name) return "From a file";
+    return "None";
+  };
+  const cloudInitValue = getCloudInitValue();
+  const complianceValue = profile.only_landscape_created
+    ? "Uninstall non-Landscape instances"
+    : "Ignore non-Landscape instances";
 
   const closeSidePanel = createPageParamsSetter({ sidePath: [], name: "" });
 
@@ -85,9 +72,6 @@ const WslProfileEditForm: FC<WslProfileEditFormProps> = ({ profile }) => {
     initialValues: {
       title: profile.title,
       description: profile.description ?? "",
-      instanceType: profile.image_source ? "custom" : profile.image_name,
-      customImageName: profile.image_source ? profile.image_name : "",
-      rootfsImage: profile.image_source || "",
       all_computers: profile.all_computers,
       tags: profile.tags,
     },
@@ -120,69 +104,44 @@ const WslProfileEditForm: FC<WslProfileEditFormProps> = ({ profile }) => {
         error={getFormikError(formik, "description")}
       />
 
-      <Select
+      <ReadOnlyField
         label="Access group"
-        aria-label="Access group"
-        options={accessGroupResultOptions}
-        disabled
-        required
+        value={profile.access_group}
+        tooltipMessage="You can't change the access group after the WSL profile has been created"
       />
 
       <div className={classes.block}>
-        <Select
-          disabled
+        <ReadOnlyField
           label="rootfs image"
-          aria-label="rootfs image"
-          options={ROOTFS_IMAGE_OPTIONS}
-          {...formik.getFieldProps("instanceType")}
-          error={getFormikError(formik, "instanceType")}
+          value={rootfsImageValue}
+          tooltipMessage="You can't change the rootfs image after the WSL profile has been created"
         />
 
-        {formik.values.instanceType === "custom" && (
+        {profile.image_source && (
           <>
-            <Input
-              disabled
+            <ReadOnlyField
               label="Image name"
-              type="text"
-              required
-              {...formik.getFieldProps("customImageName")}
-              error={getFormikError(formik, "customImageName")}
+              value={profile.image_name}
+              tooltipMessage="You can't change the image name after the WSL profile has been created"
             />
-            <Input
-              disabled
-              type="text"
+            <ReadOnlyField
               label="rootfs image URL"
-              required
-              {...formik.getFieldProps("rootfsImage")}
-              error={getFormikError(formik, "rootfsImage")}
-              help="The file path must be reachable by the affected WSL instances."
+              value={profile.image_source}
+              tooltipMessage="You can't change the rootfs image URL after the WSL profile has been created"
             />
           </>
         )}
 
-        <Select
+        <ReadOnlyField
           label="cloud-init"
-          aria-label="cloud-init"
-          options={CLOUD_INIT_OPTIONS}
-          disabled
+          value={cloudInitValue}
+          tooltipMessage="You can't change the cloud-init value after the WSL profile has been created"
         />
 
-        <Select
+        <ReadOnlyField
           label="Compliance settings"
-          options={[
-            {
-              label:
-                "Ignore WSL child instances that have not been created by Landscape",
-              value: "ignore",
-            },
-            {
-              label:
-                "Uninstall WSL child instances that have not been created by Landscape",
-              value: "uninstall",
-            },
-          ]}
-          disabled
-          value={profile.only_landscape_created ? "uninstall" : "ignore"}
+          value={complianceValue}
+          tooltipMessage="You can't change the compliance settings after the WSL profile has been created"
         />
       </div>
 

--- a/src/features/wsl-profiles/components/WslProfileEditSidePanel/components/WslProfileEditForm/WslProfileEditForm.tsx
+++ b/src/features/wsl-profiles/components/WslProfileEditSidePanel/components/WslProfileEditForm/WslProfileEditForm.tsx
@@ -4,7 +4,9 @@ import SidePanelFormButtons from "@/components/form/SidePanelFormButtons";
 import useDebug from "@/hooks/useDebug";
 import useNotify from "@/hooks/useNotify";
 import usePageParams from "@/hooks/usePageParams";
+import useRoles from "@/hooks/useRoles";
 import { getFormikError } from "@/utils/formikErrors";
+import { getTitleByName } from "@/utils/_helpers";
 import { Form, Input, Notification } from "@canonical/react-components";
 import { useFormik } from "formik";
 import { type FC } from "react";
@@ -28,8 +30,10 @@ const WslProfileEditForm: FC<WslProfileEditFormProps> = ({ profile }) => {
   const debug = useDebug();
   const { sidePath, popSidePath, createPageParamsSetter } = usePageParams();
   const { notify } = useNotify();
+  const { getAccessGroupQuery } = useRoles();
 
   const { editWslProfile } = useEditWslProfile();
+  const { data: accessGroupsData } = getAccessGroupQuery();
 
   const rootfsImageValue = profile.image_source
     ? "From URL"
@@ -106,7 +110,7 @@ const WslProfileEditForm: FC<WslProfileEditFormProps> = ({ profile }) => {
 
       <ReadOnlyField
         label="Access group"
-        value={profile.access_group}
+        value={getTitleByName(profile.access_group, accessGroupsData)}
         tooltipMessage="You can't change the access group after the WSL profile has been created"
       />
 

--- a/src/features/wsl-profiles/components/WslProfileEditSidePanel/components/WslProfileEditForm/WslProfileEditForm.tsx
+++ b/src/features/wsl-profiles/components/WslProfileEditSidePanel/components/WslProfileEditForm/WslProfileEditForm.tsx
@@ -12,7 +12,7 @@ import { useFormik } from "formik";
 import { type FC } from "react";
 import { useEditWslProfile } from "../../../../api";
 import type { WslProfile } from "../../../../types";
-import { getValidationSchema } from "./helpers";
+import { getCloudInitValue, getValidationSchema } from "./helpers";
 import classes from "./WslProfileEditForm.module.scss";
 
 interface WslProfileEditFormProps {
@@ -39,12 +39,7 @@ const WslProfileEditForm: FC<WslProfileEditFormProps> = ({ profile }) => {
     ? "From URL"
     : profile.image_name;
 
-  const getCloudInitValue = () => {
-    if (profile.cloud_init_contents) return "Plain text";
-    if (profile.cloud_init_secret_name) return "From a file";
-    return "None";
-  };
-  const cloudInitValue = getCloudInitValue();
+  const cloudInitValue = getCloudInitValue(profile);
   const complianceValue = profile.only_landscape_created
     ? "Uninstall non-Landscape instances"
     : "Ignore non-Landscape instances";

--- a/src/features/wsl-profiles/components/WslProfileEditSidePanel/components/WslProfileEditForm/helpers.ts
+++ b/src/features/wsl-profiles/components/WslProfileEditSidePanel/components/WslProfileEditForm/helpers.ts
@@ -1,3 +1,4 @@
+import type { WslProfile } from "../../../../types";
 import * as Yup from "yup";
 
 export const getValidationSchema = () => {
@@ -7,4 +8,10 @@ export const getValidationSchema = () => {
     all_computers: Yup.boolean(),
     tags: Yup.array().of(Yup.string()),
   });
+};
+
+export const getCloudInitValue = (profile: WslProfile) => {
+  if (profile.cloud_init_contents) return "Plain text";
+  if (profile.cloud_init_secret_name) return "From a file";
+  return "None";
 };


### PR DESCRIPTION
## Summary

- access_group param needs to be included in PUT for repository profiles, otherwise the backend resets the field to Global on any PUT that doesn't include it.
- add ReadOnlyField for profiles where applicable
- fix display issues for access_group on other profiles

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [X] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [X] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [X] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [X] **UI verified** — I have verified the changes locally.
- [X] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
