### PR TITLE
Use batchGet for fewer API calls, standardize missing dates.

### DIFF
--- a/.changeset/ripe-apples-attend.md
+++ b/.changeset/ripe-apples-attend.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Use batchGet for fewer API calls, standardize missing dates.

--- a/src/features/publication-targets/api/index.ts
+++ b/src/features/publication-targets/api/index.ts
@@ -3,3 +3,4 @@ export { default as useGetPublicationsByTarget } from "./useGetPublicationsByTar
 export { default as useCreatePublicationTarget } from "./useCreatePublicationTarget";
 export { default as useEditPublicationTarget } from "./useEditPublicationTarget";
 export { default as useRemovePublicationTarget } from "./useRemovePublicationTarget";
+export { useBatchGetPublicationTargets } from "./useBatchGetPublicationTargets";

--- a/src/features/publication-targets/api/useBatchGetPublicationTargets.ts
+++ b/src/features/publication-targets/api/useBatchGetPublicationTargets.ts
@@ -1,0 +1,39 @@
+import useFetchDebArchive from "@/hooks/useFetchDebArchive";
+import type {
+  BatchGetPublicationTargetsError,
+  BatchGetPublicationTargetsResponse,
+} from "@canonical/landscape-openapi";
+import { useQuery } from "@tanstack/react-query";
+import type { AxiosError } from "axios";
+
+export const useBatchGetPublicationTargets = (names: string[]) => {
+  const authFetchDebArchive = useFetchDebArchive();
+
+  const { data, isLoading } = useQuery<
+    Record<string, string>,
+    AxiosError<BatchGetPublicationTargetsError>
+  >({
+    queryKey: ["publicationTargets", "batch", names],
+    queryFn: async () => {
+      const response =
+        await authFetchDebArchive.post<BatchGetPublicationTargetsResponse>(
+          "publicationTargets:batchGet",
+          { names },
+        );
+
+      const lookup: Record<string, string> = {};
+      for (const target of response.data.publicationTargets ?? []) {
+        if (target.name) {
+          lookup[target.name] = target.displayName;
+        }
+      }
+      return lookup;
+    },
+    enabled: names.length > 0,
+  });
+
+  return {
+    publicationTargetDisplayNames: data ?? {},
+    isLoadingPublicationTargetDisplayNames: isLoading,
+  };
+};

--- a/src/features/publication-targets/api/useBatchGetPublicationTargets.ts
+++ b/src/features/publication-targets/api/useBatchGetPublicationTargets.ts
@@ -24,7 +24,7 @@ export const useBatchGetPublicationTargets = (names: string[]) => {
       const lookup: Record<string, string> = {};
       for (const target of response.data.publicationTargets ?? []) {
         if (target.name) {
-          lookup[target.name] = target.displayName;
+          lookup[target.name] = target.displayName ?? target.name;
         }
       }
       return lookup;

--- a/src/features/publication-targets/components/TargetDetails/TargetDetails.tsx
+++ b/src/features/publication-targets/components/TargetDetails/TargetDetails.tsx
@@ -214,14 +214,12 @@ const TargetDetails: FC<TargetDetailsProps> = ({ target }) => {
 
         {!isGettingPublications && publications.length > 0 && (
           <Blocks.Item title="Used In" titleClassName="p-text--small-caps">
-            {isLoadingDisplayNames ? (
-              <LoadingState />
-            ) : (
-              <AssociatedPublicationsList
-                publications={publications}
-                sourceDisplayNames={sourceDisplayNames}
-              />
-            )}
+            <AssociatedPublicationsList
+              publications={publications}
+              sourceDisplayNames={
+                isLoadingDisplayNames ? undefined : sourceDisplayNames
+              }
+            />
           </Blocks.Item>
         )}
       </Blocks>

--- a/src/features/publication-targets/components/TargetDetails/TargetDetails.tsx
+++ b/src/features/publication-targets/components/TargetDetails/TargetDetails.tsx
@@ -4,6 +4,7 @@ import useGetPublicationsByTarget from "../../api/useGetPublicationsByTarget";
 import usePageParams from "@/hooks/usePageParams";
 import { Button, Icon, ICONS } from "@canonical/react-components";
 import type { FC } from "react";
+import { useMemo } from "react";
 import { createPortal } from "react-dom";
 import { useBoolean } from "usehooks-ts";
 import RemoveTargetForm from "../RemoveTargetForm";
@@ -14,6 +15,8 @@ import {
 } from "../EditTargetForm/EditTargetForm";
 import { AssociatedPublicationsList } from "@/features/publications";
 import type { PublicationTarget } from "@canonical/landscape-openapi";
+import { useBatchGetMirrors } from "@/features/mirrors";
+import { useBatchGetLocals } from "@/features/local-repositories";
 
 interface TargetDetailsProps {
   readonly target: PublicationTarget;
@@ -24,6 +27,42 @@ const TargetDetails: FC<TargetDetailsProps> = ({ target }) => {
   const { publications, isGettingPublications } = useGetPublicationsByTarget(
     target.publicationTargetId,
   );
+
+  const mirrorNames = useMemo(
+    () => [
+      ...new Set(
+        publications
+          .map((p) => p.source)
+          .filter((s) => s.startsWith("mirrors/")),
+      ),
+    ],
+    [publications],
+  );
+
+  const localNames = useMemo(
+    () => [
+      ...new Set(
+        publications
+          .map((p) => p.source)
+          .filter((s) => s.startsWith("locals/")),
+      ),
+    ],
+    [publications],
+  );
+
+  const { mirrorDisplayNames, isLoadingMirrorDisplayNames } =
+    useBatchGetMirrors(mirrorNames);
+  const { localDisplayNames, isLoadingLocalDisplayNames } =
+    useBatchGetLocals(localNames);
+
+  const sourceDisplayNames = useMemo(
+    () => ({ ...mirrorDisplayNames, ...localDisplayNames }),
+    [mirrorDisplayNames, localDisplayNames],
+  );
+
+  const isLoadingDisplayNames =
+    isLoadingMirrorDisplayNames || isLoadingLocalDisplayNames;
+
   const {
     value: isRemoveModalOpen,
     setTrue: openRemoveModal,
@@ -175,7 +214,14 @@ const TargetDetails: FC<TargetDetailsProps> = ({ target }) => {
 
         {!isGettingPublications && publications.length > 0 && (
           <Blocks.Item title="Used In" titleClassName="p-text--small-caps">
-            <AssociatedPublicationsList publications={publications} />
+            {isLoadingDisplayNames ? (
+              <LoadingState />
+            ) : (
+              <AssociatedPublicationsList
+                publications={publications}
+                sourceDisplayNames={sourceDisplayNames}
+              />
+            )}
           </Blocks.Item>
         )}
       </Blocks>

--- a/src/features/publication-targets/index.ts
+++ b/src/features/publication-targets/index.ts
@@ -10,5 +10,6 @@ export {
   useCreatePublicationTarget,
   useEditPublicationTarget,
   useRemovePublicationTarget,
+  useBatchGetPublicationTargets,
 } from "./api";
 export { default as NoPublicationTargetsModal } from "./components/NoPublicationTargetsModal";

--- a/src/features/publications/api/index.ts
+++ b/src/features/publications/api/index.ts
@@ -1,4 +1,4 @@
-export * from "./useBatchGetPublicationTargets";
+export { useBatchGetPublicationTargets } from "@/features/publication-targets";
 export * from "./useGetPublication";
 export * from "./useGetPublications";
 export * from "./usePublishPublication";

--- a/src/features/publications/components/AssociatedPublicationsList/AssociatedPublicationsList.test.tsx
+++ b/src/features/publications/components/AssociatedPublicationsList/AssociatedPublicationsList.test.tsx
@@ -354,4 +354,73 @@ describe("AssociatedPublicationsList", () => {
       expect(screen.getByText(firstPub.source)).toBeInTheDocument();
     });
   });
+
+  describe("sourceDisplayNames prop", () => {
+    it("renders display names when sourceDisplayNames is provided", () => {
+      const [firstPub] = publications;
+      if (!firstPub) throw new Error("Missing mock publication");
+
+      const sourceDisplayNames = {
+        [firstPub.source]: "My Friendly Mirror Name",
+      };
+
+      renderWithProviders(
+        <AssociatedPublicationsList
+          publications={[firstPub]}
+          sourceDisplayNames={sourceDisplayNames}
+        />,
+      );
+
+      expect(screen.getByText("My Friendly Mirror Name")).toBeInTheDocument();
+      expect(screen.queryByText(firstPub.source)).not.toBeInTheDocument();
+    });
+
+    it("falls back to raw source name when displayName not in lookup", () => {
+      const [firstPub] = publications;
+      if (!firstPub) throw new Error("Missing mock publication");
+
+      renderWithProviders(
+        <AssociatedPublicationsList
+          publications={[firstPub]}
+          sourceDisplayNames={{}}
+        />,
+      );
+
+      expect(screen.getByText(firstPub.source)).toBeInTheDocument();
+    });
+
+    it("renders display names for local repositories", () => {
+      const localPub: Publication = {
+        name: "publications/local-pub-id",
+        publicationId: "local-pub-id",
+        displayName: "Local Publication",
+        label: "local",
+        publicationTarget: "publicationTargets/test",
+        source: "locals/some-local-uuid",
+        distribution: "jammy",
+        origin: "",
+        architectures: [],
+        acquireByHash: false,
+        butAutomaticUpgrades: false,
+        notAutomatic: false,
+        multiDist: false,
+        skipBz2: false,
+        skipContents: false,
+        publishTime: new Date("March 12, 2026"),
+      };
+
+      const sourceDisplayNames = {
+        "locals/some-local-uuid": "My Custom Local Repo",
+      };
+
+      renderWithProviders(
+        <AssociatedPublicationsList
+          publications={[localPub]}
+          sourceDisplayNames={sourceDisplayNames}
+        />,
+      );
+
+      expect(screen.getByText("My Custom Local Repo")).toBeInTheDocument();
+    });
+  });
 });

--- a/src/features/publications/components/AssociatedPublicationsList/AssociatedPublicationsList.tsx
+++ b/src/features/publications/components/AssociatedPublicationsList/AssociatedPublicationsList.tsx
@@ -18,6 +18,7 @@ interface AssociatedPublicationsListProps {
   readonly pageSize?: number;
   readonly openInNewTab?: boolean;
   readonly showSources?: boolean;
+  readonly sourceDisplayNames?: Record<string, string>;
 }
 
 const AssociatedPublicationsList: FC<AssociatedPublicationsListProps> = ({
@@ -25,6 +26,7 @@ const AssociatedPublicationsList: FC<AssociatedPublicationsListProps> = ({
   pageSize = 10,
   openInNewTab = false,
   showSources = true,
+  sourceDisplayNames = {},
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -60,17 +62,23 @@ const AssociatedPublicationsList: FC<AssociatedPublicationsListProps> = ({
                 },
               }: CellProps<Publication>): ReactNode => {
                 const sourceType = getSourceType(source);
+                const displayName = sourceDisplayNames[source];
                 let content: ReactNode;
                 if (sourceType === "Mirror") {
                   content = (
                     <MirrorLink
                       mirrorName={source}
+                      displayName={displayName}
                       openInNewTab={openInNewTab}
                     />
                   );
                 } else if (sourceType === "Local repository") {
                   content = (
-                    <LocalLink localName={source} openInNewTab={openInNewTab} />
+                    <LocalLink
+                      localName={source}
+                      displayName={displayName}
+                      openInNewTab={openInNewTab}
+                    />
                   );
                 } else {
                   content = source;
@@ -78,7 +86,9 @@ const AssociatedPublicationsList: FC<AssociatedPublicationsListProps> = ({
                 return openInNewTab ? (
                   content
                 ) : (
-                  <TooltipCell message={source ?? ""}>{content}</TooltipCell>
+                  <TooltipCell message={displayName ?? source ?? ""}>
+                    {content}
+                  </TooltipCell>
                 );
               },
             },
@@ -102,7 +112,7 @@ const AssociatedPublicationsList: FC<AssociatedPublicationsListProps> = ({
           ),
       },
     ],
-    [openInNewTab, showSources],
+    [openInNewTab, showSources, sourceDisplayNames],
   );
 
   const pagedData =

--- a/src/features/publications/components/AssociatedPublicationsList/AssociatedPublicationsList.tsx
+++ b/src/features/publications/components/AssociatedPublicationsList/AssociatedPublicationsList.tsx
@@ -13,6 +13,8 @@ import MirrorLink from "./MirrorLink/MirrorLink";
 import LocalLink from "./LocalLink/LocalLink";
 import { getSourceType } from "@/features/publications";
 
+const EMPTY_SOURCE_DISPLAY_NAMES: Record<string, string> = {};
+
 interface AssociatedPublicationsListProps {
   readonly publications: Publication[];
   readonly pageSize?: number;
@@ -26,7 +28,7 @@ const AssociatedPublicationsList: FC<AssociatedPublicationsListProps> = ({
   pageSize = 10,
   openInNewTab = false,
   showSources = true,
-  sourceDisplayNames = {},
+  sourceDisplayNames = EMPTY_SOURCE_DISPLAY_NAMES,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 

--- a/src/features/publications/components/AssociatedPublicationsList/LocalLink/LocalLink.tsx
+++ b/src/features/publications/components/AssociatedPublicationsList/LocalLink/LocalLink.tsx
@@ -4,10 +4,15 @@ import type { FC } from "react";
 
 interface LocalLinkProps {
   readonly localName: string;
+  readonly displayName?: string;
   readonly openInNewTab?: boolean;
 }
 
-const LocalLink: FC<LocalLinkProps> = ({ localName, openInNewTab = false }) => (
+const LocalLink: FC<LocalLinkProps> = ({
+  localName,
+  displayName,
+  openInNewTab = false,
+}) => (
   <StaticLink
     to={ROUTES.repositories.localRepositories({
       sidePath: ["view"],
@@ -15,7 +20,7 @@ const LocalLink: FC<LocalLinkProps> = ({ localName, openInNewTab = false }) => (
     })}
     target={openInNewTab ? "_blank" : undefined}
   >
-    {localName}
+    {displayName ?? localName}
   </StaticLink>
 );
 

--- a/src/features/publications/components/AssociatedPublicationsList/MirrorLink/MirrorLink.tsx
+++ b/src/features/publications/components/AssociatedPublicationsList/MirrorLink/MirrorLink.tsx
@@ -4,11 +4,13 @@ import type { FC } from "react";
 
 interface MirrorLinkProps {
   readonly mirrorName: string;
+  readonly displayName?: string;
   readonly openInNewTab?: boolean;
 }
 
 const MirrorLink: FC<MirrorLinkProps> = ({
   mirrorName,
+  displayName,
   openInNewTab = false,
 }) => (
   <StaticLink
@@ -18,7 +20,7 @@ const MirrorLink: FC<MirrorLinkProps> = ({
     })}
     target={openInNewTab ? "_blank" : undefined}
   >
-    {mirrorName}
+    {displayName ?? mirrorName}
   </StaticLink>
 );
 

--- a/src/features/publications/components/PublicationDetails/PublicationDetails.tsx
+++ b/src/features/publications/components/PublicationDetails/PublicationDetails.tsx
@@ -10,6 +10,7 @@ import { getSourceType } from "../../helpers";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import moment from "moment";
 import usePageParams from "@/hooks/usePageParams/usePageParams";
+import { NO_DATA_TEXT } from "@/components/layout/NoData/constants";
 
 interface PublicationDetailsProps {
   readonly publication: Publication;
@@ -89,9 +90,13 @@ const PublicationDetails = ({
 
             <InfoGrid.Item
               label="Date published"
-              value={moment(publication.publishTime).format(
-                DISPLAY_DATE_TIME_FORMAT,
-              )}
+              value={
+                publication.publishTime
+                  ? moment(publication.publishTime).format(
+                      DISPLAY_DATE_TIME_FORMAT,
+                    )
+                  : NO_DATA_TEXT
+              }
             />
           </InfoGrid>
         </Blocks.Item>

--- a/src/features/publications/components/PublicationsList/PublicationsList.tsx
+++ b/src/features/publications/components/PublicationsList/PublicationsList.tsx
@@ -16,7 +16,7 @@ import type { Publication } from "@canonical/landscape-openapi";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import moment from "moment";
 import { ROUTES } from "@/libs/routes";
-import { NO_DATA_TEXT } from "@/components/layout/NoData";
+import { NO_DATA_TEXT } from "@/components/layout/NoData/constants";
 
 interface PublicationsListProps {
   readonly publications: Publication[];

--- a/src/features/publications/components/PublicationsList/PublicationsList.tsx
+++ b/src/features/publications/components/PublicationsList/PublicationsList.tsx
@@ -16,6 +16,7 @@ import type { Publication } from "@canonical/landscape-openapi";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import moment from "moment";
 import { ROUTES } from "@/libs/routes";
+import { NO_DATA_TEXT } from "@/components/layout/NoData";
 
 interface PublicationsListProps {
   readonly publications: Publication[];
@@ -92,11 +93,11 @@ const PublicationsList: FC<PublicationsListProps> = ({
       },
       {
         accessor: "publishTime",
-        Header: "Publish date",
+        Header: "Date published",
         Cell: ({ row: { original } }: CellProps<Publication>) =>
           original.publishTime
             ? moment(original.publishTime).format(DISPLAY_DATE_TIME_FORMAT)
-            : "unknown",
+            : NO_DATA_TEXT,
       },
       {
         ...LIST_ACTIONS_COLUMN_PROPS,


### PR DESCRIPTION
## Summary

- use batchGet for publication targets rendering associated publications
- use publication and source display names everywhere possible
- standard missing dates for publication.publishTime to use NO_DATA_TEXT

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [X] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [X] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [X] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [X] **UI verified** — I have verified the changes locally.
- [X] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
