### PR TITLE
Mirrors improvements

### DIFF
--- a/.changeset/proud-ducks-ask.md
+++ b/.changeset/proud-ducks-ask.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+mirror fixes

--- a/src/features/mirrors/api/useCreateMirror.ts
+++ b/src/features/mirrors/api/useCreateMirror.ts
@@ -4,11 +4,12 @@ import type {
   CreateMirrorError,
   CreateMirrorResponse,
 } from "@canonical/landscape-openapi";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { AxiosError, AxiosResponse } from "axios";
 
 export function useCreateMirror() {
   const authFetchDebArchive = useFetchDebArchive();
+  const queryClient = useQueryClient();
 
   return useMutation<
     AxiosResponse<CreateMirrorResponse>,
@@ -17,5 +18,7 @@ export function useCreateMirror() {
   >({
     mutationKey: ["mirrors"],
     mutationFn: async (params) => authFetchDebArchive.post("mirrors", params),
+    onSuccess: async () =>
+      queryClient.invalidateQueries({ queryKey: ["mirrors"] }),
   });
 }

--- a/src/features/mirrors/api/useDeleteMirror.ts
+++ b/src/features/mirrors/api/useDeleteMirror.ts
@@ -4,24 +4,23 @@ import type {
   DeleteMirrorError,
   DeleteMirrorResponse,
 } from "@canonical/landscape-openapi";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { AxiosError, AxiosResponse } from "axios";
-
-export interface UseDeleteMirrorVariables {
-  mirrorName: DeleteMirrorData["path"]["name_1"];
-  params?: DeleteMirrorData["query"];
-}
-
-export function useDeleteMirror() {
+export function useDeleteMirror(name: DeleteMirrorData["path"]["name_1"]) {
   const authFetchDebArchive = useFetchDebArchive();
+  const queryClient = useQueryClient();
 
   return useMutation<
     AxiosResponse<DeleteMirrorResponse>,
     AxiosError<DeleteMirrorError>,
-    UseDeleteMirrorVariables
+    DeleteMirrorData["query"]
   >({
     mutationKey: ["mirrors"],
-    mutationFn: async ({ mirrorName, params }) =>
-      authFetchDebArchive.delete(mirrorName, { params }),
+    mutationFn: async (params) => authFetchDebArchive.delete(name, { params }),
+    onSuccess: async () => {
+      queryClient.invalidateQueries({
+        queryKey: ["mirrors"]
+      });
+    },
   });
 }

--- a/src/features/mirrors/api/useGetMirror.ts
+++ b/src/features/mirrors/api/useGetMirror.ts
@@ -24,7 +24,7 @@ export function useGetMirror(
     AxiosResponse<GetMirrorResponse>,
     AxiosError<GetMirrorError>
   >({
-    queryKey: ["mirrors", mirrorName],
+    queryKey: ["mirror", mirrorName],
     queryFn: async () => authFetchDebArchive.get(mirrorName),
     ...options,
   });

--- a/src/features/mirrors/api/useSyncMirror.ts
+++ b/src/features/mirrors/api/useSyncMirror.ts
@@ -7,21 +7,16 @@ import type {
 import { useMutation } from "@tanstack/react-query";
 import type { AxiosError, AxiosResponse } from "axios";
 
-export interface UseSyncMirrorVariables {
-  mirrorName: SyncMirrorData["path"]["name"];
-  params?: SyncMirrorData["body"];
-}
-
-export function useSyncMirror() {
+export function useSyncMirror(name: SyncMirrorData["path"]["name"]) {
   const authFetchDebArchive = useFetchDebArchive();
 
   return useMutation<
     AxiosResponse<SyncMirrorResponse>,
     AxiosError<SyncMirrorError>,
-    UseSyncMirrorVariables
+    SyncMirrorData["body"]
   >({
-    mutationKey: ["mirrors"],
-    mutationFn: async ({ mirrorName, params }) =>
-      authFetchDebArchive.post(`${mirrorName}:sync`, params),
+    mutationKey: ["mirror", name, "sync"],
+    mutationFn: async (params) =>
+      authFetchDebArchive.post(`${name}:sync`, params),
   });
 }

--- a/src/features/mirrors/api/useUpdateMirror.ts
+++ b/src/features/mirrors/api/useUpdateMirror.ts
@@ -7,6 +7,10 @@ import type {
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { AxiosError, AxiosResponse } from "axios";
 
+type UpdateMirrorParams = Omit<UpdateMirrorData["body"], "gpgKey"> & {
+  gpgKey: { armor: string | null };
+};
+
 export function useUpdateMirror(name: UpdateMirrorData["path"]["mirror.name"]) {
   const authFetchDebArchive = useFetchDebArchive();
   const queryClient = useQueryClient();
@@ -14,7 +18,7 @@ export function useUpdateMirror(name: UpdateMirrorData["path"]["mirror.name"]) {
   return useMutation<
     AxiosResponse<UpdateMirrorResponse>,
     AxiosError<UpdateMirrorError>,
-    UpdateMirrorData["body"]
+    UpdateMirrorParams
   >({
     mutationKey: ["mirror", name, "update"],
     mutationFn: async (params) => authFetchDebArchive.patch(name, params),

--- a/src/features/mirrors/api/useUpdateMirror.ts
+++ b/src/features/mirrors/api/useUpdateMirror.ts
@@ -4,24 +4,23 @@ import type {
   UpdateMirrorError,
   UpdateMirrorResponse,
 } from "@canonical/landscape-openapi";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { AxiosError, AxiosResponse } from "axios";
 
-export interface UseUpdateMirrorVariables {
-  mirrorName: UpdateMirrorData["path"]["mirror.name"];
-  params: UpdateMirrorData["body"];
-}
-
-export function useUpdateMirror() {
+export function useUpdateMirror(name: UpdateMirrorData["path"]["mirror.name"]) {
   const authFetchDebArchive = useFetchDebArchive();
+  const queryClient = useQueryClient();
 
   return useMutation<
     AxiosResponse<UpdateMirrorResponse>,
     AxiosError<UpdateMirrorError>,
-    UseUpdateMirrorVariables
+    UpdateMirrorData["body"]
   >({
-    mutationKey: ["mirrors"],
-    mutationFn: async ({ mirrorName, params }) =>
-      authFetchDebArchive.patch(mirrorName, params),
+    mutationKey: ["mirror", name, "update"],
+    mutationFn: async (params) => authFetchDebArchive.patch(name, params),
+    onSuccess: async () => {
+      queryClient.invalidateQueries({ queryKey: ["mirrors"] });
+      queryClient.invalidateQueries({ queryKey: ["mirror", name] });
+    },
   });
 }

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
@@ -103,12 +103,11 @@ const AddMirrorForm: FC = () => {
           downloadInstaller: values.downloadInstallerFiles,
           downloadSources: values.downloadSources,
           downloadUdebs: values.downloadUdebPackages,
-          gpgKey:
-            values.verificationGpgKey === undefined
-              ? undefined
-              : {
-                  armor: values.verificationGpgKey,
-                },
+          gpgKey: values.verificationGpgKey
+            ? {
+                armor: values.verificationGpgKey,
+              }
+            : undefined,
         });
 
         close();

--- a/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.test.tsx
+++ b/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.test.tsx
@@ -97,7 +97,7 @@ describe("EditMirrorForm", () => {
     await user.click(screen.getByRole("button", { name: "Save changes" }));
 
     expect(mockUpdateMirror).toHaveBeenCalledExactlyOnceWith(
-      expect.objectContaining({ params: expect.objectContaining(params) }),
+      expect.objectContaining(params),
     );
   });
 });

--- a/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
+++ b/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
@@ -60,9 +60,7 @@ const EditMirrorForm: FC = () => {
           downloadUdebs: values.downloadUdebPackages,
           downloadSources: values.downloadSources,
           downloadInstaller: values.downloadInstallerFiles,
-          gpgKey: values.verificationGpgKey
-            ? { armor: values.verificationGpgKey }
-            : undefined,
+          gpgKey: { armor: values.verificationGpgKey || null },
         });
 
         close();

--- a/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
+++ b/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
@@ -34,7 +34,7 @@ const EditMirrorForm: FC = () => {
   const { name, popSidePath, createPageParamsSetter } = usePageParams();
 
   const mirror = useGetMirror(name).data.data;
-  const updateMirror = useUpdateMirror().mutateAsync;
+  const updateMirror = useUpdateMirror(name).mutateAsync;
 
   const close = createPageParamsSetter({ sidePath: [], name: "" });
 
@@ -54,18 +54,15 @@ const EditMirrorForm: FC = () => {
     onSubmit: async (values) => {
       try {
         await updateMirror({
-          mirrorName: name,
-          params: {
-            displayName: values.name,
-            archiveRoot: mirror.archiveRoot,
-            components: mirror.components,
-            downloadUdebs: values.downloadUdebPackages,
-            downloadSources: values.downloadSources,
-            downloadInstaller: values.downloadInstallerFiles,
-            gpgKey: values.verificationGpgKey
-              ? { armor: values.verificationGpgKey }
-              : undefined,
-          },
+          displayName: values.name,
+          archiveRoot: mirror.archiveRoot,
+          components: mirror.components,
+          downloadUdebs: values.downloadUdebPackages,
+          downloadSources: values.downloadSources,
+          downloadInstaller: values.downloadInstallerFiles,
+          gpgKey: values.verificationGpgKey
+            ? { armor: values.verificationGpgKey }
+            : undefined,
         });
 
         close();

--- a/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
+++ b/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
@@ -62,10 +62,9 @@ const EditMirrorForm: FC = () => {
             downloadUdebs: values.downloadUdebPackages,
             downloadSources: values.downloadSources,
             downloadInstaller: values.downloadInstallerFiles,
-            gpgKey:
-              values.verificationGpgKey === undefined
-                ? undefined
-                : { armor: values.verificationGpgKey },
+            gpgKey: values.verificationGpgKey
+              ? { armor: values.verificationGpgKey }
+              : undefined,
           },
         });
 

--- a/src/features/mirrors/components/MirrorPackagesCount/MirrorPackagesCount.tsx
+++ b/src/features/mirrors/components/MirrorPackagesCount/MirrorPackagesCount.tsx
@@ -9,9 +9,13 @@ interface MirrorPackagesCount {
 }
 
 const MirrorPackagesCount: FC<MirrorPackagesCount> = ({ mirrorName }) => {
-  const { data, isLoading, isError } = useListMirrorPackages(mirrorName, {
-    pageSize: 1000,
-  });
+  const { data, isLoading, isError } = useListMirrorPackages(
+    mirrorName,
+    {
+      pageSize: 1000,
+    },
+    { refetchOnMount: false },
+  );
 
   if (isLoading) return <Spinner />;
   if (isError || !data) return <NoData />;

--- a/src/features/mirrors/components/MirrorPublicationsLink/MirrorPublicationsLinks.tsx
+++ b/src/features/mirrors/components/MirrorPublicationsLink/MirrorPublicationsLinks.tsx
@@ -11,10 +11,13 @@ interface MirrorPublicationsLinkProps {
 const MirrorPublicationsLink: FC<MirrorPublicationsLinkProps> = ({
   mirrorName,
 }) => {
-  const { data } = useListPublications({
-    filter: `source="${mirrorName}"`,
-    pageSize: 1000,
-  });
+  const { data } = useListPublications(
+    {
+      filter: `source="${mirrorName}"`,
+      pageSize: 1000,
+    },
+    { refetchOnMount: false },
+  );
 
   if (!data.data.publications?.length) {
     return "0 publications";

--- a/src/features/mirrors/components/MirrorsList/MirrorsList.tsx
+++ b/src/features/mirrors/components/MirrorsList/MirrorsList.tsx
@@ -55,7 +55,7 @@ const MirrorsList: FC<MirrorsListProps> = ({ mirrors, emptyMsg }) => {
       {
         Header: "Packages",
         Cell: ({ row: { original: mirror } }: CellProps<Mirror>) =>
-          mirror.name !== undefined ? (
+          mirror.name ? (
             <MirrorPackagesCount mirrorName={mirror.name} />
           ) : (
             <NoData />
@@ -64,7 +64,7 @@ const MirrorsList: FC<MirrorsListProps> = ({ mirrors, emptyMsg }) => {
       {
         Header: "Publications",
         Cell: ({ row: { original: mirror } }: CellProps<Mirror>) =>
-          mirror.name !== undefined ? (
+          mirror.name ? (
             <Suspense fallback={<Spinner />}>
               <MirrorPublicationsLink mirrorName={mirror.name} />
             </Suspense>
@@ -76,7 +76,7 @@ const MirrorsList: FC<MirrorsListProps> = ({ mirrors, emptyMsg }) => {
         ...LIST_ACTIONS_COLUMN_PROPS,
         accessor: undefined,
         Cell: ({ row: { original: mirror } }: CellProps<Mirror>) =>
-          mirror.name !== undefined ? (
+          mirror.name ? (
             <Suspense fallback={<Spinner />}>
               <MirrorActions
                 mirrorDisplayName={mirror.displayName}

--- a/src/features/mirrors/components/RemoveMirrorModal/RemoveMirrorModal.test.tsx
+++ b/src/features/mirrors/components/RemoveMirrorModal/RemoveMirrorModal.test.tsx
@@ -86,8 +86,6 @@ describe("RemoveMirrorModal", () => {
     );
     await user.click(screen.getByRole("button", { name: /remove mirror/i }));
 
-    expect(mockDeleteMirror).toHaveBeenCalledWith(
-      expect.objectContaining({ mirrorName: props.mirrorName }),
-    );
+    expect(mockDeleteMirror).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/mirrors/components/RemoveMirrorModal/RemoveMirrorModal.tsx
+++ b/src/features/mirrors/components/RemoveMirrorModal/RemoveMirrorModal.tsx
@@ -29,16 +29,13 @@ const RemoveMirrorModal: FC<RemoveMirrorModalProps> = ({
   const { publications } = useGetPublicationsBySource(mirrorName);
 
   const { mutateAsync: deleteMirror, isPending: isDeletingMirror } =
-    useDeleteMirror();
+    useDeleteMirror(mirrorName);
 
   const tryRemoveMirror = async () => {
     try {
-      await deleteMirror({
-        mirrorName,
-      });
+      await deleteMirror({});
 
       setPageParams({ sidePath: [], name: "" });
-      close();
 
       notify.success({
         title: `You have successfully removed ${mirrorDisplayName}.`,
@@ -46,6 +43,8 @@ const RemoveMirrorModal: FC<RemoveMirrorModalProps> = ({
       });
     } catch (error) {
       debug(error);
+    } finally {
+      close();
     }
   };
 

--- a/src/features/mirrors/components/UpdateMirrorModal/UpdateMirrorModal.test.tsx
+++ b/src/features/mirrors/components/UpdateMirrorModal/UpdateMirrorModal.test.tsx
@@ -41,8 +41,6 @@ describe("UpdateMirrorModal", () => {
 
     await user.click(screen.getByRole("button", { name: /update mirror/i }));
 
-    expect(mockSyncMirror).toHaveBeenCalledWith(
-      expect.objectContaining({ mirrorName: props.mirrorName }),
-    );
+    expect(mockSyncMirror).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/mirrors/components/UpdateMirrorModal/UpdateMirrorModal.tsx
+++ b/src/features/mirrors/components/UpdateMirrorModal/UpdateMirrorModal.tsx
@@ -24,7 +24,7 @@ const UpdateMirrorModal: FC<UpdateMirrorModalProps> = ({
   const { setPageParams } = usePageParams();
 
   const { mutateAsync: syncMirror, isPending: isSyncingMirror } =
-    useSyncMirror();
+    useSyncMirror(mirrorName);
 
   const { value: ignoreChecksums, toggle: toggleIgnoreChecksums } =
     useBoolean();
@@ -41,13 +41,10 @@ const UpdateMirrorModal: FC<UpdateMirrorModalProps> = ({
   const tryUpdateMirror = async () => {
     try {
       await syncMirror({
-        mirrorName,
-        params: {
-          ignoreChecksums,
-          ignoreSignatures,
-          forceUpdate,
-          skipExistingPackages,
-        },
+        ignoreChecksums,
+        ignoreSignatures,
+        forceUpdate,
+        skipExistingPackages,
       });
 
       setPageParams({ sidePath: [], name: "" });

--- a/src/tests/server/handlers/mirrors.ts
+++ b/src/tests/server/handlers/mirrors.ts
@@ -1,6 +1,6 @@
 import { API_URL_DEB_ARCHIVE } from "@/constants";
 import { getEndpointStatus } from "@/tests/controllers/controller";
-import { mirrors } from "@/tests/mocks/mirrors";
+import { mirrors as mockMirrors } from "@/tests/mocks/mirrors";
 import type { StrictResponse } from "msw";
 import { delay, http, HttpResponse } from "msw";
 import { ENDPOINT_STATUS_API_ERROR } from "./_constants";
@@ -12,11 +12,15 @@ import type {
   CreateMirrorResponse,
   SyncMirrorResponse,
   BatchGetMirrorsResponse,
+  MirrorWritable,
+  Mirror,
 } from "@canonical/landscape-openapi";
 import {
   getDebArchivePaginatedResponse,
   getDebArchivePaginationParams,
 } from "./_helpers";
+
+const mirrors = [...(mockMirrors as Mirror[])];
 
 const getMirrorsResponse = (requestUrl: string) => {
   const { pageSize, pageToken } = getDebArchivePaginationParams(requestUrl);
@@ -70,10 +74,23 @@ export default [
     return getMirrorsResponse(request.url);
   }),
 
-  http.post(`${API_URL_DEB_ARCHIVE}mirrors`, async () => {
-    await delay();
-    return HttpResponse.json<CreateMirrorResponse>();
-  }),
+  http.post<never, MirrorWritable>(
+    `${API_URL_DEB_ARCHIVE}mirrors`,
+    async ({ request }) => {
+      await delay();
+
+      const requestBody = await request.json();
+      const mirrorId = requestBody.displayName.toLowerCase();
+
+      mirrors.push({
+        name: `mirrors/${mirrorId}`,
+        mirrorId,
+        ...requestBody,
+      });
+
+      return HttpResponse.json<CreateMirrorResponse>();
+    },
+  ),
 
   http.get(`${API_URL_DEB_ARCHIVE}mirrors/:mirrorId`, async ({ params }) => {
     await delay();
@@ -87,26 +104,64 @@ export default [
     }
   }),
 
-  http.get(`${API_URL_DEB_ARCHIVE}mirrors/:mirrorId/packages`, async () => {
+  http.get(
+    `${API_URL_DEB_ARCHIVE}mirrors/:mirrorId/packages`,
+    async ({ params }) => {
+      await delay();
+
+      const mirror = mirrors.find(
+        ({ mirrorId }) => mirrorId === params.mirrorId,
+      );
+
+      if (!mirror) {
+        return new HttpResponse(null, { status: 404 });
+      } else {
+        return HttpResponse.json<ListMirrorPackagesResponse>({
+          mirrorPackages: ["package-1", "package-2", "package-3"],
+        });
+      }
+    },
+  ),
+
+  http.patch(`${API_URL_DEB_ARCHIVE}mirrors/:mirrorId`, async ({ params }) => {
     await delay();
 
-    return HttpResponse.json<ListMirrorPackagesResponse>({
-      mirrorPackages: ["package-1", "package-2", "package-3"],
-    });
+    const mirror = mirrors.find(({ mirrorId }) => mirrorId === params.mirrorId);
+
+    if (!mirror) {
+      return new HttpResponse(null, { status: 404 });
+    } else {
+      return HttpResponse.json<UpdateMirrorResponse>();
+    }
   }),
 
-  http.patch(`${API_URL_DEB_ARCHIVE}mirrors/:mirrorId`, async () => {
+  http.delete(`${API_URL_DEB_ARCHIVE}mirrors/:mirrorId`, async ({ params }) => {
     await delay();
-    return HttpResponse.json<UpdateMirrorResponse>();
+
+    const mirror = mirrors.find(({ mirrorId }) => mirrorId === params.mirrorId);
+
+    if (!mirror) {
+      return new HttpResponse(null, { status: 404 });
+    } else {
+      mirrors.splice(mirrors.indexOf(mirror), 1);
+      return HttpResponse.json<DeleteMirrorResponse>(mirror);
+    }
   }),
 
-  http.delete(`${API_URL_DEB_ARCHIVE}mirrors/:mirrorId`, async () => {
-    await delay();
-    return HttpResponse.json<DeleteMirrorResponse>();
-  }),
+  http.post(
+    `${API_URL_DEB_ARCHIVE}mirrors/:mirrorId\\:sync`,
+    async ({ params }) => {
+      await delay();
 
-  http.post(`${API_URL_DEB_ARCHIVE}mirrors/:mirrorId\\:sync`, async () => {
-    await delay();
-    return HttpResponse.json<SyncMirrorResponse>();
-  }),
+      const mirror = mirrors.find(
+        ({ mirrorId }) => mirrorId === params.mirrorId,
+      );
+
+      if (!mirror) {
+        return new HttpResponse(null, { status: 404 });
+      } else {
+        return HttpResponse.json<SyncMirrorResponse>();
+      }
+    },
+  ),
 ];


### PR DESCRIPTION
## Summary

Summarize the changes made in this pull request. Include any relevant context or background information that would help reviewers understand the purpose and scope of the changes.

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
