### PR TITLE
Fix: Edit Local not refetching (+ sidepanels closing issue)

### DIFF
--- a/.changeset/happy-places-juggle.md
+++ b/.changeset/happy-places-juggle.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Fix edit local repository not refetching issue and some pages' side panels leaving behind name path param after closing

--- a/src/features/local-repositories/api/useUpdateLocalRepository.ts
+++ b/src/features/local-repositories/api/useUpdateLocalRepository.ts
@@ -19,8 +19,10 @@ export const useUpdateLocalRepository = () => {
     mutationKey: ["local", "update"],
     mutationFn: async ({ name, ...local }) =>
       authFetchDebArchive.patch(name, local),
-    onSuccess: async () =>
-      queryClient.invalidateQueries({ queryKey: ["locals"] }),
+    onSuccess: async (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["locals"] });
+      queryClient.invalidateQueries({ queryKey: ["local", variables.name] });
+    },
   });
 
   return {

--- a/src/features/local-repositories/components/AddLocalRepositorySidePanel/AddLocalRepositorySidePanel.tsx
+++ b/src/features/local-repositories/components/AddLocalRepositorySidePanel/AddLocalRepositorySidePanel.tsx
@@ -18,13 +18,8 @@ import Blocks from "@/components/layout/Blocks";
 const AddLocalRepositorySidePanel: FC = () => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { createPageParamsSetter } = usePageParams();
+  const { closeSidePanel } = usePageParams();
   const { createRepository, isCreatingRepository } = useCreateLocalRepository();
-
-  const closeSidePanel = createPageParamsSetter({
-    sidePath: [],
-    name: "",
-  });
 
   const handleSubmit = async (values: AddLocalRepositoryFormValues) => {
     const valuesforCreation = {

--- a/src/features/local-repositories/components/EditLocalRepositorySidePanel/EditLocalRepositoryForm/EditLocalRepositoryForm.tsx
+++ b/src/features/local-repositories/components/EditLocalRepositorySidePanel/EditLocalRepositoryForm/EditLocalRepositoryForm.tsx
@@ -24,13 +24,8 @@ const EditLocalRepositoryForm: FC<EditLocalRepositoryFormProps> = ({
 }) => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { popSidePath, createPageParamsSetter } = usePageParams();
+  const { popSidePathUntilClear, closeSidePanel } = usePageParams();
   const { updateRepository, isUpdatingRepository } = useUpdateLocalRepository();
-
-  const closeSidePanel = createPageParamsSetter({
-    sidePath: [],
-    name: "",
-  });
 
   const handleSubmit = async (values: EditLocalRepositoryFormValues) => {
     const localToUpdate = {
@@ -102,7 +97,7 @@ const EditLocalRepositoryForm: FC<EditLocalRepositoryFormProps> = ({
       <SidePanelFormButtons
         submitButtonLoading={formik.isSubmitting || isUpdatingRepository}
         submitButtonText="Save changes"
-        onCancel={popSidePath}
+        onCancel={popSidePathUntilClear}
       />
     </Form>
   );

--- a/src/features/local-repositories/components/ImportRepositoryPackagesSidePanel/ImportRepositoryPackagesSidePanel.tsx
+++ b/src/features/local-repositories/components/ImportRepositoryPackagesSidePanel/ImportRepositoryPackagesSidePanel.tsx
@@ -26,15 +26,11 @@ const POLL_INTERVAL = 2000;
 const ImportRepositoryPackagesSidePanel: FC = () => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { popSidePath, name, createPageParamsSetter } = usePageParams();
+  const { popSidePathUntilClear, name, closeSidePanel } = usePageParams();
   const { repository, isGettingRepository } = useGetPageLocalRepository();
 
   const { importRepositoryPackages, isImportingRepositoryPackages } =
     useImportRepositoryPackages();
-  const closeSidePanel = createPageParamsSetter({
-    sidePath: [],
-    name: "",
-  });
 
   const repositoryName = `locals/${name}`;
   const [operationName, setOperationName] = useState<string>("");
@@ -163,7 +159,7 @@ const ImportRepositoryPackagesSidePanel: FC = () => {
             submitButtonDisabled={!canImport}
             submitButtonLoading={formik.isSubmitting}
             submitButtonText={`Import ${packagesCount}`}
-            onCancel={popSidePath}
+            onCancel={popSidePathUntilClear}
           />
         </Form>
       </SidePanel.Content>

--- a/src/features/local-repositories/components/PublishLocalRepositorySidePanel/components/PublishRepositoryExistingForm/PublishRepositoryExistingForm.tsx
+++ b/src/features/local-repositories/components/PublishLocalRepositorySidePanel/components/PublishRepositoryExistingForm/PublishRepositoryExistingForm.tsx
@@ -35,14 +35,9 @@ const PublishRepositoryExistingForm: FC<PublishRepositoryExistingFormProps> = ({
 }) => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { popSidePath, createPageParamsSetter } = usePageParams();
+  const { popSidePathUntilClear, closeSidePanel } = usePageParams();
   const { publishPublication, isPublishingPublication } =
     usePublishPublication();
-
-  const closeSidePanel = createPageParamsSetter({
-    sidePath: [],
-    name: "",
-  });
 
   const handleSubmit = async (values: { name: string }) => {
     try {
@@ -194,7 +189,7 @@ const PublishRepositoryExistingForm: FC<PublishRepositoryExistingFormProps> = ({
       <SidePanelFormButtons
         submitButtonLoading={formik.isSubmitting || isPublishingPublication}
         submitButtonText="Publish repository"
-        onCancel={popSidePath}
+        onCancel={popSidePathUntilClear}
       />
     </Form>
   );

--- a/src/features/local-repositories/components/PublishLocalRepositorySidePanel/components/PublishRepositoryNewForm/PublishRepositoryNewForm.tsx
+++ b/src/features/local-repositories/components/PublishLocalRepositorySidePanel/components/PublishRepositoryNewForm/PublishRepositoryNewForm.tsx
@@ -38,17 +38,12 @@ const PublishRepositoryNewForm: FC<PublishRepositoryNewFormProps> = ({
 }) => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { popSidePath, createPageParamsSetter } = usePageParams();
+  const { popSidePathUntilClear, closeSidePanel } = usePageParams();
   const { publicationTargets, isGettingPublicationTargets } =
     useGetPublicationTargets();
   const { createPublication, isCreatingPublication } = useCreatePublication();
   const { publishPublication, isPublishingPublication } =
     usePublishPublication();
-
-  const closeSidePanel = createPageParamsSetter({
-    sidePath: [],
-    name: "",
-  });
 
   const handleSubmit = async (values: PublishRepositoryNewFormValues) => {
     const valuesforCreation = {
@@ -230,7 +225,7 @@ const PublishRepositoryNewForm: FC<PublishRepositoryNewFormProps> = ({
           isPublishingPublication
         }
         submitButtonText="Publish repository"
-        onCancel={popSidePath}
+        onCancel={popSidePathUntilClear}
       />
     </Form>
   );

--- a/src/features/local-repositories/components/RemoveLocalRepositoryModal/RemoveLocalRepositoryModal.tsx
+++ b/src/features/local-repositories/components/RemoveLocalRepositoryModal/RemoveLocalRepositoryModal.tsx
@@ -24,7 +24,7 @@ const RemoveLocalRepositoryModal: FC<RemoveLocalRepositoryModalProps> = ({
 }) => {
   const { notify } = useNotify();
   const debug = useDebug();
-  const { setPageParams } = usePageParams();
+  const { closeSidePanel } = usePageParams();
   const { removeRepository, isRemovingRepository } = useRemoveLocalRepository();
   const { publications, isGettingPublications } = useGetPublicationsBySource(
     repository.name,
@@ -57,7 +57,7 @@ const RemoveLocalRepositoryModal: FC<RemoveLocalRepositoryModalProps> = ({
     try {
       await removeRepository({ name: repository.name ?? "" });
 
-      setPageParams({ sidePath: [], name: "" });
+      closeSidePanel();
 
       notify.success({
         title: `You have successfully removed ${repository.displayName}`,

--- a/src/features/mirrors/api/useDeleteMirror.ts
+++ b/src/features/mirrors/api/useDeleteMirror.ts
@@ -19,7 +19,7 @@ export function useDeleteMirror(name: DeleteMirrorData["path"]["name_1"]) {
     mutationFn: async (params) => authFetchDebArchive.delete(name, { params }),
     onSuccess: async () => {
       queryClient.invalidateQueries({
-        queryKey: ["mirrors"]
+        queryKey: ["mirrors"],
       });
     },
   });

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
@@ -34,12 +34,11 @@ import * as Yup from "yup";
 const AddMirrorForm: FC = () => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { createPageParamsSetter } = usePageParams();
+  const { closeSidePanel } = usePageParams();
 
   const ubuntuArchiveQuery = useGetUbuntuArchiveInfo();
   const ubuntuEsmQuery = useGetUbuntuEsmInfo();
   const createMirror = useCreateMirror().mutateAsync;
-  const close = createPageParamsSetter({ sidePath: [] });
 
   const ubuntuArchiveInfo = ubuntuArchiveQuery.data?.data;
   const ubuntuEsmInfo = ubuntuEsmQuery.data?.data.results ?? [];
@@ -110,7 +109,7 @@ const AddMirrorForm: FC = () => {
             : undefined,
         });
 
-        close();
+        closeSidePanel();
 
         notify.success({
           title: `You have successfully added ${values.name}.`,
@@ -381,7 +380,7 @@ const AddMirrorForm: FC = () => {
           <SidePanelFormButtons
             submitButtonLoading={formik.isSubmitting}
             submitButtonText="Add mirror"
-            onCancel={close}
+            onCancel={closeSidePanel}
           />
         </Form>
       </SidePanel.Content>

--- a/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
+++ b/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
@@ -31,12 +31,10 @@ import { NO_DATA_TEXT } from "@/components/layout/NoData";
 const EditMirrorForm: FC = () => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { name, popSidePath, createPageParamsSetter } = usePageParams();
+  const { name, popSidePathUntilClear, closeSidePanel } = usePageParams();
 
   const mirror = useGetMirror(name).data.data;
   const updateMirror = useUpdateMirror(name).mutateAsync;
-
-  const close = createPageParamsSetter({ sidePath: [], name: "" });
 
   const formik = useFormik<FormProps>({
     initialValues: {
@@ -63,7 +61,7 @@ const EditMirrorForm: FC = () => {
           gpgKey: { armor: values.verificationGpgKey || null },
         });
 
-        close();
+        closeSidePanel();
 
         notify.success({
           title: `You have successfully edited ${mirror.displayName}.`,
@@ -163,7 +161,7 @@ const EditMirrorForm: FC = () => {
           <SidePanelFormButtons
             submitButtonLoading={formik.isSubmitting}
             submitButtonText="Save changes"
-            onCancel={popSidePath}
+            onCancel={popSidePathUntilClear}
           />
         </Form>
       </SidePanel.Content>

--- a/src/features/mirrors/components/PublishMirrorForm/components/PublishMirrorExistingForm/PublishMirrorExistingForm.tsx
+++ b/src/features/mirrors/components/PublishMirrorForm/components/PublishMirrorExistingForm/PublishMirrorExistingForm.tsx
@@ -33,15 +33,10 @@ const PublishMirrorExistingForm: FC<PublishMirrorExistingFormProps> = ({
 }) => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { popSidePath, createPageParamsSetter } = usePageParams();
+  const { popSidePathUntilClear, closeSidePanel } = usePageParams();
 
   const { publishPublication, isPublishingPublication } =
     usePublishPublication();
-
-  const close = createPageParamsSetter({
-    sidePath: [],
-    name: "",
-  });
 
   const formik = useFormik({
     initialValues: { publicationName: publications[0]?.name ?? "" },
@@ -53,7 +48,7 @@ const PublishMirrorExistingForm: FC<PublishMirrorExistingFormProps> = ({
           body: { forceCleanup: true, forceOverwrite: true },
         });
 
-        close();
+        closeSidePanel();
 
         notify.success({
           title: `You have marked ${mirror.displayName} to be published.`,
@@ -193,7 +188,7 @@ const PublishMirrorExistingForm: FC<PublishMirrorExistingFormProps> = ({
         submitButtonDisabled={!formik.isValid}
         submitButtonLoading={formik.isSubmitting || isPublishingPublication}
         submitButtonText="Publish mirror"
-        onCancel={popSidePath}
+        onCancel={popSidePathUntilClear}
       />
     </Form>
   );

--- a/src/features/mirrors/components/PublishMirrorForm/components/PublishMirrorNewForm/PublishMirrorNewForm.tsx
+++ b/src/features/mirrors/components/PublishMirrorForm/components/PublishMirrorNewForm/PublishMirrorNewForm.tsx
@@ -36,16 +36,11 @@ const PublishMirrorNewForm: FC<PublishMirrorNewFormProps> = ({
 }) => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { popSidePath, createPageParamsSetter } = usePageParams();
+  const { popSidePathUntilClear, closeSidePanel } = usePageParams();
 
   const { createPublication, isCreatingPublication } = useCreatePublication();
   const { publishPublication, isPublishingPublication } =
     usePublishPublication();
-
-  const close = createPageParamsSetter({
-    sidePath: [],
-    name: "",
-  });
 
   const formik = useFormik({
     initialValues: {
@@ -85,7 +80,7 @@ const PublishMirrorNewForm: FC<PublishMirrorNewFormProps> = ({
           body: { forceCleanup: true, forceOverwrite: true },
         });
 
-        close();
+        closeSidePanel();
 
         notify.success({
           title: `You have marked ${mirror.displayName} to be published.`,
@@ -233,7 +228,7 @@ const PublishMirrorNewForm: FC<PublishMirrorNewFormProps> = ({
           isPublishingPublication
         }
         submitButtonText="Publish mirror"
-        onCancel={popSidePath}
+        onCancel={popSidePathUntilClear}
       />
     </Form>
   );

--- a/src/features/mirrors/components/RemoveMirrorModal/RemoveMirrorModal.tsx
+++ b/src/features/mirrors/components/RemoveMirrorModal/RemoveMirrorModal.tsx
@@ -24,7 +24,7 @@ const RemoveMirrorModal: FC<RemoveMirrorModalProps> = ({
 }) => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { setPageParams } = usePageParams();
+  const { closeSidePanel } = usePageParams();
 
   const { publications } = useGetPublicationsBySource(mirrorName);
 
@@ -35,7 +35,7 @@ const RemoveMirrorModal: FC<RemoveMirrorModalProps> = ({
     try {
       await deleteMirror({});
 
-      setPageParams({ sidePath: [], name: "" });
+      closeSidePanel();
 
       notify.success({
         title: `You have successfully removed ${mirrorDisplayName}.`,

--- a/src/features/mirrors/components/UpdateMirrorModal/UpdateMirrorModal.tsx
+++ b/src/features/mirrors/components/UpdateMirrorModal/UpdateMirrorModal.tsx
@@ -21,7 +21,7 @@ const UpdateMirrorModal: FC<UpdateMirrorModalProps> = ({
 }) => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { setPageParams } = usePageParams();
+  const { closeSidePanel } = usePageParams();
 
   const { mutateAsync: syncMirror, isPending: isSyncingMirror } =
     useSyncMirror(mirrorName);
@@ -47,7 +47,7 @@ const UpdateMirrorModal: FC<UpdateMirrorModalProps> = ({
         skipExistingPackages,
       });
 
-      setPageParams({ sidePath: [], name: "" });
+      closeSidePanel();
       close();
 
       notify.success({

--- a/src/features/publication-targets/components/AddPublicationTargetForm/AddPublicationTargetForm.tsx
+++ b/src/features/publication-targets/components/AddPublicationTargetForm/AddPublicationTargetForm.tsx
@@ -96,8 +96,7 @@ const buildFilesystemPayload = (values: FilesystemFormValues) => ({
 
 const AddPublicationTargetForm: FC = () => {
   const debug = useDebug();
-  const { createPageParamsSetter } = usePageParams();
-  const closeForm = createPageParamsSetter({ sidePath: [], name: "" });
+  const { closeSidePanel } = usePageParams();
   const { notify } = useNotify();
   const { createPublicationTargetQuery } = useCreatePublicationTarget();
 
@@ -125,7 +124,7 @@ const AddPublicationTargetForm: FC = () => {
           });
         }
 
-        closeForm();
+        closeSidePanel();
 
         notify.success({
           title: "Publication target created",
@@ -170,7 +169,7 @@ const AddPublicationTargetForm: FC = () => {
       <SidePanelFormButtons
         submitButtonDisabled={formik.isSubmitting}
         submitButtonText="Add publication target"
-        onCancel={closeForm}
+        onCancel={closeSidePanel}
       />
     </Form>
   );

--- a/src/features/publication-targets/components/EditTargetForm/EditTargetForm.tsx
+++ b/src/features/publication-targets/components/EditTargetForm/EditTargetForm.tsx
@@ -129,8 +129,7 @@ const buildFilesystemPayload = (values: EditTargetFormValues) => ({
 
 const EditTargetForm: FC<EditTargetFormProps> = ({ target }) => {
   const debug = useDebug();
-  const { createPageParamsSetter, popSidePath } = usePageParams();
-  const closeForm = createPageParamsSetter({ sidePath: [], name: "" });
+  const { closeSidePanel, popSidePathUntilClear } = usePageParams();
   const { notify } = useNotify();
   const { editPublicationTargetQuery } = useEditPublicationTarget();
   const { mutateAsync: editTarget } = editPublicationTargetQuery;
@@ -162,7 +161,7 @@ const EditTargetForm: FC<EditTargetFormProps> = ({ target }) => {
           });
         }
 
-        closeForm();
+        closeSidePanel();
 
         notify.success({
           title: "Publication target edited",
@@ -356,7 +355,7 @@ const EditTargetForm: FC<EditTargetFormProps> = ({ target }) => {
       <SidePanelFormButtons
         submitButtonDisabled={formik.isSubmitting}
         submitButtonText="Save changes"
-        onCancel={popSidePath}
+        onCancel={popSidePathUntilClear}
       />
     </Form>
   );

--- a/src/features/publication-targets/components/RemoveTargetForm/RemoveTargetModal.tsx
+++ b/src/features/publication-targets/components/RemoveTargetForm/RemoveTargetModal.tsx
@@ -25,7 +25,7 @@ const RemoveTargetModal: FC<RemoveTargetModalProps> = ({
 }) => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { setPageParams } = usePageParams();
+  const { closeSidePanel } = usePageParams();
   const { removePublicationTargetQuery } = useRemovePublicationTarget();
   const { mutateAsync: removeTarget, isPending: isRemoving } =
     removePublicationTargetQuery;
@@ -39,7 +39,7 @@ const RemoveTargetModal: FC<RemoveTargetModalProps> = ({
     try {
       if (!target.name) return;
 
-      setPageParams({ sidePath: [], name: "" });
+      closeSidePanel();
       await removeTarget({ name: target.name });
 
       notify.success({

--- a/src/features/publications/api/useUpdatePublication.ts
+++ b/src/features/publications/api/useUpdatePublication.ts
@@ -27,8 +27,12 @@ export default function useUpdatePublication() {
         `publications/${encodeURIComponent(publicationName)}`,
         body,
       ),
-    onSuccess: async () =>
-      queryClient.invalidateQueries({ queryKey: ["publications"] }),
+    onSuccess: async (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["publications"] });
+      queryClient.invalidateQueries({
+        queryKey: ["publication", variables.publicationName],
+      });
+    },
   });
 
   return {

--- a/src/features/publications/components/AddPublicationForm/AddPublicationForm.tsx
+++ b/src/features/publications/components/AddPublicationForm/AddPublicationForm.tsx
@@ -40,8 +40,7 @@ import type { FormProps, SelectableSource } from "./types";
 const AddPublicationForm: FC = () => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { createPageParamsSetter } = usePageParams();
-  const closePanel = createPageParamsSetter({ sidePath: [], name: "" });
+  const { closeSidePanel } = usePageParams();
   const { data: mirrorsData } = useListMirrors();
   const { repositories: locals, isGettingRepositories: isGettingLocals } =
     useGetLocalRepositories();
@@ -57,7 +56,7 @@ const AddPublicationForm: FC = () => {
         const payload = getPublicationPayload(values);
         await createPublication(payload);
 
-        closePanel();
+        closeSidePanel();
 
         notify.success({
           title: "Publication created",
@@ -383,7 +382,7 @@ const AddPublicationForm: FC = () => {
       <SidePanelFormButtons
         submitButtonDisabled={formik.isSubmitting || isCreatingPublication}
         submitButtonText="Add publication"
-        onCancel={closePanel}
+        onCancel={closeSidePanel}
       />
     </Form>
   );

--- a/src/features/publications/components/AssociatedPublicationsList/AssociatedPublicationsList.test.tsx
+++ b/src/features/publications/components/AssociatedPublicationsList/AssociatedPublicationsList.test.tsx
@@ -220,11 +220,12 @@ describe("AssociatedPublicationsList", () => {
   });
 
   describe("edge cases", () => {
-    it("renders without error with empty publications array", () => {
+    it("renders empty message with empty publications array", () => {
       renderWithProviders(<AssociatedPublicationsList publications={[]} />);
 
-      // Table should render but with no data rows
-      expect(screen.getByText("Publication")).toBeInTheDocument();
+      expect(
+        screen.getByText("No associated publications were found."),
+      ).toBeInTheDocument();
     });
 
     it("renders single publication correctly", () => {

--- a/src/features/publications/components/AssociatedPublicationsList/AssociatedPublicationsList.tsx
+++ b/src/features/publications/components/AssociatedPublicationsList/AssociatedPublicationsList.tsx
@@ -130,6 +130,7 @@ const AssociatedPublicationsList: FC<AssociatedPublicationsListProps> = ({
       <ModularTable
         columns={columns as Column<Record<string, unknown>>[]}
         data={pagedData as unknown as Record<string, unknown>[]}
+        emptyMsg="No associated publications were found."
       />
       <ModalTablePagination
         current={currentPage}

--- a/src/features/publications/components/PublicationDetails/PublicationDetails.tsx
+++ b/src/features/publications/components/PublicationDetails/PublicationDetails.tsx
@@ -9,7 +9,6 @@ import RepublishPublicationModal from "../RepublishPublicationModal";
 import { getSourceType } from "../../helpers";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import moment from "moment";
-import usePageParams from "@/hooks/usePageParams/usePageParams";
 import { NO_DATA_TEXT } from "@/components/layout/NoData/constants";
 
 interface PublicationDetailsProps {
@@ -23,8 +22,6 @@ const PublicationDetails = ({
   sourceDisplayName,
   publicationTargetDisplayName,
 }: PublicationDetailsProps) => {
-  const { closeSidePanel } = usePageParams();
-
   const {
     value: isRemoveModalOpen,
     setTrue: openRemoveModal,
@@ -147,19 +144,13 @@ const PublicationDetails = ({
 
       <RepublishPublicationModal
         isOpen={isRepublishModalOpen}
-        close={() => {
-          closeRepublishModal();
-          closeSidePanel();
-        }}
+        close={closeRepublishModal}
         publication={publication}
       />
 
       <RemovePublicationModal
         isOpen={isRemoveModalOpen}
-        close={() => {
-          closeRemoveModal();
-          closeSidePanel();
-        }}
+        close={closeRemoveModal}
         publication={publication}
       />
     </>

--- a/src/features/publications/components/PublicationDetails/PublicationDetails.tsx
+++ b/src/features/publications/components/PublicationDetails/PublicationDetails.tsx
@@ -23,8 +23,7 @@ const PublicationDetails = ({
   sourceDisplayName,
   publicationTargetDisplayName,
 }: PublicationDetailsProps) => {
-  const { createPageParamsSetter } = usePageParams();
-  const closePanel = createPageParamsSetter({ sidePath: [], name: "" });
+  const { closeSidePanel } = usePageParams();
 
   const {
     value: isRemoveModalOpen,
@@ -150,7 +149,7 @@ const PublicationDetails = ({
         isOpen={isRepublishModalOpen}
         close={() => {
           closeRepublishModal();
-          closePanel();
+          closeSidePanel();
         }}
         publication={publication}
       />
@@ -159,7 +158,7 @@ const PublicationDetails = ({
         isOpen={isRemoveModalOpen}
         close={() => {
           closeRemoveModal();
-          closePanel();
+          closeSidePanel();
         }}
         publication={publication}
       />

--- a/src/features/publications/components/RemovePublicationModal/RemovePublicationModal.tsx
+++ b/src/features/publications/components/RemovePublicationModal/RemovePublicationModal.tsx
@@ -5,6 +5,7 @@ import { ConfirmationModal } from "@canonical/react-components";
 import type { FC } from "react";
 import { useDeletePublication } from "../../api";
 import type { Publication } from "@canonical/landscape-openapi";
+import usePageParams from "@/hooks/usePageParams/usePageParams";
 
 interface RemovePublicationModalProps extends Pick<
   TextConfirmationModalProps,
@@ -21,6 +22,7 @@ const RemovePublicationModal: FC<RemovePublicationModalProps> = ({
   const debug = useDebug();
   const { notify } = useNotify();
   const { deletePublication, isRemovingPublication } = useDeletePublication();
+  const { closeSidePanel } = usePageParams();
 
   const handleRemovePublication = async () => {
     try {
@@ -34,6 +36,7 @@ const RemovePublicationModal: FC<RemovePublicationModalProps> = ({
       debug(error);
     } finally {
       close();
+      closeSidePanel();
     }
   };
 

--- a/src/features/publications/components/RepublishPublicationModal/RepublishPublicationModal.tsx
+++ b/src/features/publications/components/RepublishPublicationModal/RepublishPublicationModal.tsx
@@ -4,6 +4,7 @@ import { ConfirmationModal } from "@canonical/react-components";
 import type { FC } from "react";
 import { usePublishPublication } from "../../api";
 import type { Publication } from "@canonical/landscape-openapi";
+import usePageParams from "@/hooks/usePageParams/usePageParams";
 
 interface RepublishPublicationModalProps {
   readonly publication: Publication;
@@ -20,6 +21,7 @@ const RepublishPublicationModal: FC<RepublishPublicationModalProps> = ({
   const { notify } = useNotify();
   const { publishPublication, isPublishingPublication } =
     usePublishPublication();
+  const { closeSidePanel } = usePageParams();
 
   const handleRepublishPublication = async () => {
     try {
@@ -37,6 +39,7 @@ const RepublishPublicationModal: FC<RepublishPublicationModalProps> = ({
       debug(error);
     } finally {
       close();
+      closeSidePanel();
     }
   };
 

--- a/src/features/removal-profiles/components/RemovalProfileRemoveModal/RemovalProfileRemoveModal.tsx
+++ b/src/features/removal-profiles/components/RemovalProfileRemoveModal/RemovalProfileRemoveModal.tsx
@@ -21,7 +21,7 @@ const RemovalProfileRemoveModal: FC<RemovalProfileRemoveModalProps> = ({
 }) => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { setPageParams } = usePageParams();
+  const { closeSidePanel } = usePageParams();
 
   const { removeRemovalProfileQuery } = useRemovalProfiles();
   const { mutateAsync: removeRemovalProfile, isPending: isRemoving } =
@@ -31,7 +31,7 @@ const RemovalProfileRemoveModal: FC<RemovalProfileRemoveModalProps> = ({
     try {
       await removeRemovalProfile({ name: removalProfile.name });
 
-      setPageParams({ sidePath: [], name: "" });
+      closeSidePanel();
 
       notify.success({
         title: "Removal profile removed",

--- a/src/features/repository-profiles/components/RepositoryProfileAddSidePanel/RepositoryProfileAddSidePanel.test.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileAddSidePanel/RepositoryProfileAddSidePanel.test.tsx
@@ -132,19 +132,6 @@ describe("RepositoryProfileAddSidePanel", () => {
     expect(screen.getByText("my-source")).toBeInTheDocument();
   });
 
-  it("renders 'Edit repository profile' title when sidePath starts with 'edit'", () => {
-    renderPanel("edit");
-
-    expect(screen.getByText("Edit repository profile")).toBeInTheDocument();
-  });
-
-  it("renders 'Edit repository profile' as breadcrumb prefix on edit-source step", () => {
-    renderPanel("edit,edit-source");
-
-    expect(screen.getByText("Edit repository profile")).toBeInTheDocument();
-    expect(screen.getByText(/Edit source/i)).toBeInTheDocument();
-  });
-
   it("edit source pre-populates form fields with existing source values", async () => {
     renderPanel("add,add-source");
 

--- a/src/features/repository-profiles/components/RepositoryProfileAddSidePanel/RepositoryProfileAddSidePanel.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileAddSidePanel/RepositoryProfileAddSidePanel.tsx
@@ -7,13 +7,8 @@ import RepositoryProfileForm from "../RepositoryProfileForm";
 import RepositoryProfileSourceForm from "../RepositoryProfileSourceForm";
 
 const RepositoryProfileAddSidePanel: FC = () => {
-  const {
-    sidePath,
-    lastSidePathSegment,
-    popSidePath,
-    createSidePathPusher,
-    createPageParamsSetter,
-  } = usePageParams();
+  const { lastSidePathSegment, popSidePath, createSidePathPusher } =
+    usePageParams();
 
   const [aptSources, setAptSources] = useState<APTSource[]>([]);
   const [sourceToEdit, setSourceToEdit] = useState<APTSource | null>(null);
@@ -22,11 +17,7 @@ const RepositoryProfileAddSidePanel: FC = () => {
     lastSidePathSegment === "add-source" ||
     lastSidePathSegment === "edit-source";
 
-  const panelTitle =
-    sidePath[0] === "add"
-      ? "Add repository profile"
-      : "Edit repository profile";
-  const closePanel = createPageParamsSetter({ sidePath: [], name: "" });
+  const panelTitle = "Add repository profile";
 
   const handleSourceSuccess = (source: APTSource) => {
     if (lastSidePathSegment === "add-source") {
@@ -67,7 +58,6 @@ const RepositoryProfileAddSidePanel: FC = () => {
             action="add"
             aptSources={aptSources}
             onAptSourcesChange={setAptSources}
-            onClose={closePanel}
             onAddSourceClick={createSidePathPusher("add-source")}
             onEditSourceClick={(source) => {
               setSourceToEdit(source);

--- a/src/features/repository-profiles/components/RepositoryProfileDetails/RepositoryProfileDetails.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileDetails/RepositoryProfileDetails.tsx
@@ -154,6 +154,7 @@ const RepositoryProfileDetails: FC = () => {
         confirmButtonLoading={isRemoving}
         onConfirm={handleRemoveProfile}
         close={closeModal}
+        renderInPortal
       >
         <p>
           This will remove &quot;{profile.title}&quot; profile. This action is{" "}

--- a/src/features/repository-profiles/components/RepositoryProfileEditForm/RepositoryProfileEditForm.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileEditForm/RepositoryProfileEditForm.tsx
@@ -8,19 +8,9 @@ import RepositoryProfileForm from "../RepositoryProfileForm";
 import RepositoryProfileSourceForm from "../RepositoryProfileSourceForm";
 
 const RepositoryProfileEditForm: FC = () => {
-  const {
-    name,
-    lastSidePathSegment,
-    popSidePath,
-    createSidePathPusher,
-    createPageParamsSetter,
-  } = usePageParams();
+  const { name, lastSidePathSegment, popSidePath, createSidePathPusher } =
+    usePageParams();
   const { data: profile } = useGetRepositoryProfile(name);
-
-  const closeSidePanel = createPageParamsSetter({
-    sidePath: [],
-    name: "",
-  });
 
   const [aptSources, setAptSources] = useState<APTSource[]>(
     profile.apt_sources ?? [],
@@ -73,7 +63,6 @@ const RepositoryProfileEditForm: FC = () => {
             profile={profile}
             aptSources={aptSources}
             onAptSourcesChange={setAptSources}
-            onClose={closeSidePanel}
             onAddSourceClick={createSidePathPusher("add-source")}
             onEditSourceClick={(source) => {
               setSourceToEdit(source);

--- a/src/features/repository-profiles/components/RepositoryProfileEditForm/RepositoryProfileEditForm.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileEditForm/RepositoryProfileEditForm.tsx
@@ -8,9 +8,19 @@ import RepositoryProfileForm from "../RepositoryProfileForm";
 import RepositoryProfileSourceForm from "../RepositoryProfileSourceForm";
 
 const RepositoryProfileEditForm: FC = () => {
-  const { name, lastSidePathSegment, popSidePath, createSidePathPusher } =
-    usePageParams();
+  const {
+    name,
+    lastSidePathSegment,
+    popSidePath,
+    createSidePathPusher,
+    createPageParamsSetter,
+  } = usePageParams();
   const { data: profile } = useGetRepositoryProfile(name);
+
+  const closeSidePanel = createPageParamsSetter({
+    sidePath: [],
+    name: "",
+  });
 
   const [aptSources, setAptSources] = useState<APTSource[]>(
     profile.apt_sources ?? [],
@@ -63,7 +73,7 @@ const RepositoryProfileEditForm: FC = () => {
             profile={profile}
             aptSources={aptSources}
             onAptSourcesChange={setAptSources}
-            onClose={popSidePath}
+            onClose={closeSidePanel}
             onAddSourceClick={createSidePathPusher("add-source")}
             onEditSourceClick={(source) => {
               setSourceToEdit(source);

--- a/src/features/repository-profiles/components/RepositoryProfileForm/RepositoryProfileForm.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileForm/RepositoryProfileForm.tsx
@@ -16,13 +16,13 @@ import type { APTSource } from "../../types";
 import useDebug from "@/hooks/useDebug";
 import useNotify from "@/hooks/useNotify";
 import useRoles from "@/hooks/useRoles";
-import useSidePanel from "@/hooks/useSidePanel";
 import { CTA_INFO, INITIAL_VALUES } from "./constants";
 import { getValidationSchema } from "./helpers";
 import { getFormikError } from "@/utils/formikErrors";
 import { AppErrorBoundary } from "@/components/layout/AppErrorBoundary";
 import Blocks from "@/components/layout/Blocks/Blocks";
 import classes from "./RepositoryProfileForm.module.scss";
+import usePageParams from "@/hooks/usePageParams";
 
 type RepositoryProfileFormProps =
   | {
@@ -31,7 +31,6 @@ type RepositoryProfileFormProps =
       onAptSourcesChange: (sources: APTSource[]) => void;
       onAddSourceClick: () => void;
       onEditSourceClick: (source: APTSource) => void;
-      onClose?: () => void;
     }
   | {
       action: "edit";
@@ -40,15 +39,12 @@ type RepositoryProfileFormProps =
       onAptSourcesChange: (sources: APTSource[]) => void;
       onAddSourceClick: () => void;
       onEditSourceClick: (source: APTSource) => void;
-      onClose?: () => void;
-      hasBackButton?: boolean;
-      onBackButtonPress?: () => void;
     };
 
 const RepositoryProfileForm: FC<RepositoryProfileFormProps> = (props) => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { closeSidePanel } = useSidePanel();
+  const { popSidePathUntilClear, closeSidePanel } = usePageParams();
 
   const { getAccessGroupQuery } = useRoles();
   const { createRepositoryProfileQuery, editRepositoryProfileQuery } =
@@ -79,7 +75,7 @@ const RepositoryProfileForm: FC<RepositoryProfileFormProps> = (props) => {
           ...valuesToSubmit,
           apt_sources: values.apt_sources,
         });
-        (props.onClose ?? closeSidePanel)();
+        closeSidePanel();
         notify.success({
           title: "Repository profile created",
           message: `Repository profile "${values.title}" created successfully`,
@@ -100,7 +96,7 @@ const RepositoryProfileForm: FC<RepositoryProfileFormProps> = (props) => {
             )
             .map((s) => s.id),
         });
-        (props.onClose ?? closeSidePanel)();
+        closeSidePanel();
         notify.success({
           title: `You have successfully edited ${values.title}`,
           message: `The repository profile details have been updated.`,
@@ -197,13 +193,7 @@ const RepositoryProfileForm: FC<RepositoryProfileFormProps> = (props) => {
         submitButtonDisabled={formik.isSubmitting}
         submitButtonText={CTA_INFO[props.action].label}
         submitButtonAriaLabel={CTA_INFO[props.action].ariaLabel}
-        onCancel={props.action === "edit" ? props.onClose : undefined}
-        hasBackButton={
-          props.action === "edit" ? props.hasBackButton : undefined
-        }
-        onBackButtonPress={
-          props.action === "edit" ? props.onBackButtonPress : undefined
-        }
+        onCancel={popSidePathUntilClear}
       />
     </Form>
   );

--- a/src/features/repository-profiles/components/RepositoryProfileListActions/RepositoryProfileListActions.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileListActions/RepositoryProfileListActions.tsx
@@ -99,6 +99,7 @@ const RepositoryProfileListActions: FC<RepositoryProfileListActionsProps> = ({
         confirmButtonLoading={isRemoving}
         onConfirm={handleRemoveProfile}
         close={closeModal}
+        renderInPortal
       >
         <p>
           This will remove &quot;{profile.title}&quot; profile. This action is{" "}

--- a/src/hooks/usePageParams/usePageParams.ts
+++ b/src/hooks/usePageParams/usePageParams.ts
@@ -10,6 +10,7 @@ interface UsePageParamsReturnType extends PageParams {
   createSidePathPusher: (value: string) => () => void;
   createPageParamsSetter: (newParams: Partial<PageParams>) => () => void;
   popSidePathUntilClear: () => void;
+  closeSidePanel: () => void;
 }
 
 const usePageParams = (): UsePageParamsReturnType => {
@@ -75,13 +76,13 @@ const usePageParams = (): UsePageParamsReturnType => {
     });
   };
 
+  const closeSidePanel = createPageParamsSetter({
+    sidePath: [],
+    name: "",
+  });
+
   const popSidePathUntilClear =
-    parsedSearchParams.sidePath.length > 1
-      ? popSidePath
-      : createPageParamsSetter({
-          sidePath: [],
-          name: "",
-        });
+    parsedSearchParams.sidePath.length > 1 ? popSidePath : closeSidePanel;
 
   return {
     ...parsedSearchParams,
@@ -91,6 +92,7 @@ const usePageParams = (): UsePageParamsReturnType => {
     createSidePathPusher,
     createPageParamsSetter,
     popSidePathUntilClear,
+    closeSidePanel,
   };
 };
 

--- a/src/hooks/usePageParams/usePageParams.ts
+++ b/src/hooks/usePageParams/usePageParams.ts
@@ -9,6 +9,7 @@ interface UsePageParamsReturnType extends PageParams {
   popSidePath: () => void;
   createSidePathPusher: (value: string) => () => void;
   createPageParamsSetter: (newParams: Partial<PageParams>) => () => void;
+  popSidePathUntilClear: () => void;
 }
 
 const usePageParams = (): UsePageParamsReturnType => {
@@ -74,6 +75,14 @@ const usePageParams = (): UsePageParamsReturnType => {
     });
   };
 
+  const popSidePathUntilClear =
+    parsedSearchParams.sidePath.length > 1
+      ? popSidePath
+      : createPageParamsSetter({
+          sidePath: [],
+          name: "",
+        });
+
   return {
     ...parsedSearchParams,
     setPageParams,
@@ -81,6 +90,7 @@ const usePageParams = (): UsePageParamsReturnType => {
     popSidePath,
     createSidePathPusher,
     createPageParamsSetter,
+    popSidePathUntilClear,
   };
 };
 

--- a/src/pages/dashboard/repositories/local-repositories/LocalRepositoriesPage.test.tsx
+++ b/src/pages/dashboard/repositories/local-repositories/LocalRepositoriesPage.test.tsx
@@ -1,0 +1,95 @@
+import { expectLoadingState, setScreenSize } from "@/tests/helpers";
+import { renderWithProviders } from "@/tests/render";
+import { screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import LocalRepositoriesPage from "./LocalRepositoriesPage";
+import userEvent from "@testing-library/user-event";
+
+describe("LocalRepositoriesPage", () => {
+  it("renders the title and add button", async () => {
+    renderWithProviders(<LocalRepositoriesPage />);
+
+    await expectLoadingState();
+
+    expect(
+      screen.getByRole("heading", { name: /local repositories/i }),
+    ).toBeInTheDocument();
+
+    expect(
+      await screen.findByRole("button", { name: /add local repository/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the add form side panel when add button is clicked", async () => {
+    renderWithProviders(<LocalRepositoriesPage />);
+
+    await expectLoadingState();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add local repository" }),
+    );
+
+    expect(
+      await within(screen.getByLabelText("Side panel")).findByRole("button", {
+        name: /add repository/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the edit form side panel when sidePath=edit is in the URL", async () => {
+    renderWithProviders(
+      <LocalRepositoriesPage />,
+      undefined,
+      "/?sidePath=edit&name=aaaa-bbbb-cccc",
+    );
+
+    expect(
+      await within(screen.getByLabelText("Side panel")).findByRole("button", {
+        name: /save changes/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the view form side panel when sidePath=view is in the URL", async () => {
+    setScreenSize("xxl");
+
+    renderWithProviders(
+      <LocalRepositoriesPage />,
+      undefined,
+      "/?sidePath=view&name=aaaa-bbbb-cccc",
+    );
+
+    expect(
+      await within(screen.getByLabelText("Side panel")).findByRole("button", {
+        name: /remove/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the import packages form side panel when sidePath=import-packages is in the URL", async () => {
+    renderWithProviders(
+      <LocalRepositoriesPage />,
+      undefined,
+      "/?sidePath=import-packages&name=aaaa-bbbb-cccc",
+    );
+
+    expect(
+      await within(screen.getByLabelText("Side panel")).findByRole("button", {
+        name: /import packages/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the publish form side panel when sidePath=publish is in the URL", async () => {
+    renderWithProviders(
+      <LocalRepositoriesPage />,
+      undefined,
+      "/?sidePath=publish&name=aaaa-bbbb-cccc",
+    );
+
+    expect(
+      await within(screen.getByLabelText("Side panel")).findByRole("button", {
+        name: /publish repository/i,
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/repositories/local-repositories/LocalRepositoriesPage.tsx
+++ b/src/pages/dashboard/repositories/local-repositories/LocalRepositoriesPage.tsx
@@ -43,7 +43,7 @@ const PublishLocalRepositorySidePanel = lazy(async () =>
 );
 
 const LocalRepositoriesPage: FC = () => {
-  const { search, lastSidePathSegment, sidePath, popSidePath } =
+  const { search, lastSidePathSegment, sidePath, createPageParamsSetter } =
     usePageParams();
 
   const { repositories, isGettingRepositories } =
@@ -74,7 +74,10 @@ const LocalRepositoriesPage: FC = () => {
         />
       </PageContent>
 
-      <SidePanel onClose={popSidePath} isOpen={!!sidePath.length}>
+      <SidePanel
+        onClose={createPageParamsSetter({ sidePath: [], name: "" })}
+        isOpen={!!sidePath.length}
+      >
         {lastSidePathSegment === "add" && (
           <SidePanel.Suspense key="add">
             <AddLocalRepositorySidePanel />

--- a/src/pages/dashboard/repositories/local-repositories/LocalRepositoriesPage.tsx
+++ b/src/pages/dashboard/repositories/local-repositories/LocalRepositoriesPage.tsx
@@ -43,7 +43,7 @@ const PublishLocalRepositorySidePanel = lazy(async () =>
 );
 
 const LocalRepositoriesPage: FC = () => {
-  const { search, lastSidePathSegment, sidePath, createPageParamsSetter } =
+  const { search, lastSidePathSegment, sidePath, popSidePathUntilClear } =
     usePageParams();
 
   const { repositories, isGettingRepositories } =
@@ -74,10 +74,7 @@ const LocalRepositoriesPage: FC = () => {
         />
       </PageContent>
 
-      <SidePanel
-        onClose={createPageParamsSetter({ sidePath: [], name: "" })}
-        isOpen={!!sidePath.length}
-      >
+      <SidePanel onClose={popSidePathUntilClear} isOpen={!!sidePath.length}>
         {lastSidePathSegment === "add" && (
           <SidePanel.Suspense key="add">
             <AddLocalRepositorySidePanel />

--- a/src/pages/dashboard/repositories/mirrors/MirrorsPage.test.tsx
+++ b/src/pages/dashboard/repositories/mirrors/MirrorsPage.test.tsx
@@ -1,9 +1,12 @@
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import userEvent from "@testing-library/user-event";
-import { PATHS, ROUTES } from "@/libs/routes";
 import { setEndpointStatus } from "@/tests/controllers/controller";
-import { resetScreenSize, setScreenSize } from "@/tests/helpers";
+import {
+  expectLoadingState,
+  resetScreenSize,
+  setScreenSize,
+} from "@/tests/helpers";
 import { renderWithProviders } from "@/tests/render";
 import MirrorsPage from "./MirrorsPage";
 import { Suspense } from "react";
@@ -57,9 +60,6 @@ describe("MirrorsPage", () => {
       <Suspense fallback={<LoadingState />}>
         <MirrorsPage />
       </Suspense>,
-      undefined,
-      ROUTES.repositories.mirrors(),
-      `/${PATHS.repositories.root}/${PATHS.repositories.mirrors}`,
     );
 
     await screen.findByRole("heading", { name: "Mirrors" });
@@ -67,6 +67,62 @@ describe("MirrorsPage", () => {
 
     expect(
       await screen.findByRole("heading", { name: "Add mirror" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the edit form side panel when sidePath=edit is in the URL", async () => {
+    renderWithProviders(
+      <Suspense fallback={<LoadingState />}>
+        <MirrorsPage />
+      </Suspense>,
+      undefined,
+      "/?sidePath=edit&name=mirrors/ubuntu-archive-mirror",
+    );
+
+    await expectLoadingState();
+
+    expect(
+      await within(screen.getByLabelText("Side panel")).findByRole("button", {
+        name: /save changes/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the view form side panel when sidePath=view is in the URL", async () => {
+    setScreenSize("xxl");
+
+    renderWithProviders(
+      <Suspense fallback={<LoadingState />}>
+        <MirrorsPage />
+      </Suspense>,
+      undefined,
+      "/?sidePath=view&name=mirrors/ubuntu-archive-mirror",
+    );
+
+    await expectLoadingState();
+
+    expect(
+      await within(screen.getByLabelText("Side panel")).findByRole("button", {
+        name: /remove/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the publish form side panel when sidePath=publish is in the URL", async () => {
+    renderWithProviders(
+      <Suspense fallback={<LoadingState />}>
+        <MirrorsPage />
+      </Suspense>,
+      undefined,
+      "/?sidePath=publish&name=mirrors/ubuntu-archive-mirror",
+    );
+
+    await expectLoadingState();
+
+    expect(
+      await within(screen.getByLabelText("Side panel")).findByRole("button", {
+        name: /publish mirror/i,
+      }),
     ).toBeInTheDocument();
   });
 });

--- a/src/pages/dashboard/repositories/mirrors/MirrorsPage.tsx
+++ b/src/pages/dashboard/repositories/mirrors/MirrorsPage.tsx
@@ -36,13 +36,8 @@ const PublishMirrorForm = lazy(async () =>
 );
 
 const MirrorsPage: FC = () => {
-  const {
-    search,
-    sidePath,
-    lastSidePathSegment,
-    popSidePath,
-    createPageParamsSetter,
-  } = usePageParams();
+  const { search, sidePath, lastSidePathSegment, createPageParamsSetter } =
+    usePageParams();
 
   useSetDynamicFilterValidation("sidePath", ["add", "edit", "publish", "view"]);
 
@@ -99,7 +94,10 @@ const MirrorsPage: FC = () => {
     <PageMain>
       <PageHeader title="Mirrors" actions={actions} />
       <PageContent hasTable={hasTable}>{children}</PageContent>
-      <SidePanel onClose={popSidePath} isOpen={!!sidePath.length}>
+      <SidePanel
+        onClose={createPageParamsSetter({ sidePath: [], name: "" })}
+        isOpen={!!sidePath.length}
+      >
         {lastSidePathSegment === "add" && (
           <SidePanel.Suspense key="add">
             <AddMirrorForm />

--- a/src/pages/dashboard/repositories/mirrors/MirrorsPage.tsx
+++ b/src/pages/dashboard/repositories/mirrors/MirrorsPage.tsx
@@ -36,8 +36,13 @@ const PublishMirrorForm = lazy(async () =>
 );
 
 const MirrorsPage: FC = () => {
-  const { search, sidePath, lastSidePathSegment, createPageParamsSetter } =
-    usePageParams();
+  const {
+    search,
+    sidePath,
+    lastSidePathSegment,
+    popSidePathUntilClear,
+    createPageParamsSetter,
+  } = usePageParams();
 
   useSetDynamicFilterValidation("sidePath", ["add", "edit", "publish", "view"]);
 
@@ -94,10 +99,7 @@ const MirrorsPage: FC = () => {
     <PageMain>
       <PageHeader title="Mirrors" actions={actions} />
       <PageContent hasTable={hasTable}>{children}</PageContent>
-      <SidePanel
-        onClose={createPageParamsSetter({ sidePath: [], name: "" })}
-        isOpen={!!sidePath.length}
-      >
+      <SidePanel onClose={popSidePathUntilClear} isOpen={!!sidePath.length}>
         {lastSidePathSegment === "add" && (
           <SidePanel.Suspense key="add">
             <AddMirrorForm />

--- a/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.test.tsx
+++ b/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.test.tsx
@@ -1,8 +1,9 @@
-import { expectLoadingState } from "@/tests/helpers";
+import { expectLoadingState, setScreenSize } from "@/tests/helpers";
 import { renderWithProviders } from "@/tests/render";
 import { screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import PublicationTargetsPage from "./PublicationTargetsPage";
+import userEvent from "@testing-library/user-event";
 
 describe("PublicationTargetsPage", () => {
   it("renders the page title", () => {
@@ -21,18 +22,51 @@ describe("PublicationTargetsPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders the add form side panel when sidePath=add is in the URL", async () => {
+  it("renders the add form side panel when add button is clicked", async () => {
+    renderWithProviders(<PublicationTargetsPage />);
+
+    await expectLoadingState();
+    await userEvent.click(
+      screen.getByRole("button", { name: /add publication target/i }),
+    );
+
+    expect(
+      await within(screen.getByLabelText("Side panel")).findByRole("button", {
+        name: /add publication target/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the edit form side panel when sidePath=edit is in the URL", async () => {
     renderWithProviders(
       <PublicationTargetsPage />,
       undefined,
-      "/?sidePath=add",
+      "/?sidePath=edit&name=aaaaaaaa-0000-0000-0000-000000000001",
     );
 
     await expectLoadingState();
 
     expect(
-      within(screen.getByLabelText("Side panel")).getByRole("button", {
-        name: /add publication target/i,
+      await within(screen.getByLabelText("Side panel")).findByRole("button", {
+        name: /save changes/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the view form side panel when sidePath=view is in the URL", async () => {
+    setScreenSize("xxl");
+
+    renderWithProviders(
+      <PublicationTargetsPage />,
+      undefined,
+      "/?sidePath=view&name=aaaaaaaa-0000-0000-0000-000000000001",
+    );
+
+    await expectLoadingState();
+
+    expect(
+      await within(screen.getByLabelText("Side panel")).findByRole("button", {
+        name: /remove/i,
       }),
     ).toBeInTheDocument();
   });

--- a/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.tsx
+++ b/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.tsx
@@ -13,6 +13,7 @@ import {
   useGetPublicationTargets,
 } from "@/features/publication-targets";
 import { lazy, type FC } from "react";
+import LoadingState from "@/components/layout/LoadingState";
 
 const AddPublicationTargetForm = lazy(async () =>
   import("@/features/publication-targets").then((module) => ({
@@ -27,21 +28,14 @@ const EditTargetForm = lazy(async () =>
 );
 
 const PublicationTargetsPage: FC = () => {
-  const { lastSidePathSegment, name, popSidePath } = usePageParams();
+  const { lastSidePathSegment, name, createPageParamsSetter } = usePageParams();
   const { publicationTargets, count, isGettingPublicationTargets } =
     useGetPublicationTargets();
 
   useSetDynamicFilterValidation("sidePath", ["view", "add", "edit"]);
 
   if (isGettingPublicationTargets) {
-    return (
-      <PageMain>
-        <PageHeader title="Publication targets" />
-        <PageContent>
-          <div>Loading publication targets...</div>
-        </PageContent>
-      </PageMain>
-    );
+    return <LoadingState />;
   }
 
   const viewTarget = publicationTargets.find(
@@ -93,8 +87,7 @@ const PublicationTargetsPage: FC = () => {
       <PageContent hasTable={hasTable}>{children}</PageContent>
 
       <SidePanel
-        // onClose={createPageParamsSetter({ sidePath: [], name: "" })}
-        onClose={popSidePath}
+        onClose={createPageParamsSetter({ sidePath: [], name: "" })}
         isOpen={
           lastSidePathSegment === "add" ||
           (!!lastSidePathSegment && !!viewTarget)

--- a/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.tsx
+++ b/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.tsx
@@ -28,7 +28,7 @@ const EditTargetForm = lazy(async () =>
 );
 
 const PublicationTargetsPage: FC = () => {
-  const { lastSidePathSegment, name, createPageParamsSetter } = usePageParams();
+  const { lastSidePathSegment, name, popSidePathUntilClear } = usePageParams();
   const { publicationTargets, count, isGettingPublicationTargets } =
     useGetPublicationTargets();
 
@@ -94,7 +94,7 @@ const PublicationTargetsPage: FC = () => {
       <PageContent hasTable={hasTable}>{children}</PageContent>
 
       <SidePanel
-        onClose={createPageParamsSetter({ sidePath: [], name: "" })}
+        onClose={popSidePathUntilClear}
         isOpen={
           lastSidePathSegment === "add" ||
           (!!lastSidePathSegment && !!viewTarget)

--- a/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.tsx
+++ b/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.tsx
@@ -35,7 +35,14 @@ const PublicationTargetsPage: FC = () => {
   useSetDynamicFilterValidation("sidePath", ["view", "add", "edit"]);
 
   if (isGettingPublicationTargets) {
-    return <LoadingState />;
+    return (
+      <PageMain>
+        <PageHeader title="Publication targets" />
+        <PageContent>
+          <LoadingState />
+        </PageContent>
+      </PageMain>
+    );
   }
 
   const viewTarget = publicationTargets.find(

--- a/src/pages/dashboard/repositories/publications/PublicationsPage.test.tsx
+++ b/src/pages/dashboard/repositories/publications/PublicationsPage.test.tsx
@@ -1,0 +1,53 @@
+import { expectLoadingState, setScreenSize } from "@/tests/helpers";
+import { renderWithProviders } from "@/tests/render";
+import { screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import PublicationsPage from "./PublicationsPage";
+import userEvent from "@testing-library/user-event";
+
+describe("PublicationsPage", () => {
+  it("renders the title and add button", async () => {
+    renderWithProviders(<PublicationsPage />);
+
+    await expectLoadingState();
+
+    expect(
+      screen.getByRole("heading", { name: /publications/i }),
+    ).toBeInTheDocument();
+
+    expect(
+      await screen.findByRole("button", { name: /add publication/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the add form side panel when add button is clicked", async () => {
+    renderWithProviders(<PublicationsPage />);
+
+    await expectLoadingState();
+    await userEvent.click(
+      await screen.findByRole("button", { name: /add publication/i }),
+    );
+
+    expect(
+      await within(screen.getByLabelText("Side panel")).findByRole("button", {
+        name: /add publication/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the view form side panel when sidePath=view is in the URL", async () => {
+    setScreenSize("xxl");
+
+    renderWithProviders(
+      <PublicationsPage />,
+      undefined,
+      "/?sidePath=view&name=7b1d5c2f-0c4e-4d8e-8f2f-99d4f2d9a123",
+    );
+
+    expect(
+      await within(screen.getByLabelText("Side panel")).findByRole("button", {
+        name: /republish/i,
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/repositories/publications/PublicationsPage.tsx
+++ b/src/pages/dashboard/repositories/publications/PublicationsPage.tsx
@@ -18,7 +18,7 @@ const PublicationDetailsSidePanel = lazy(async () =>
 );
 
 const PublicationsPage: FC = () => {
-  const { sidePath, lastSidePathSegment, createPageParamsSetter } =
+  const { sidePath, lastSidePathSegment, popSidePathUntilClear } =
     usePageParams();
 
   useSetDynamicFilterValidation("sidePath", ["add", "add-target", "view"]);
@@ -26,10 +26,7 @@ const PublicationsPage: FC = () => {
     <PageMain>
       <PublicationsContainer />
 
-      <SidePanel
-        isOpen={!!sidePath.length}
-        onClose={createPageParamsSetter({ sidePath: [], name: "" })}
-      >
+      <SidePanel isOpen={!!sidePath.length} onClose={popSidePathUntilClear}>
         {lastSidePathSegment === "add" && (
           <SidePanel.Suspense key="add">
             <SidePanel.Header>Add publication</SidePanel.Header>

--- a/src/pages/dashboard/repositories/publications/PublicationsPage.tsx
+++ b/src/pages/dashboard/repositories/publications/PublicationsPage.tsx
@@ -17,12 +17,6 @@ const PublicationDetailsSidePanel = lazy(async () =>
   })),
 );
 
-const AddPublicationTargetForm = lazy(async () =>
-  import("@/features/publication-targets").then((module) => ({
-    default: module.AddPublicationTargetForm,
-  })),
-);
-
 const PublicationsPage: FC = () => {
   const { sidePath, lastSidePathSegment, createPageParamsSetter } =
     usePageParams();
@@ -40,12 +34,6 @@ const PublicationsPage: FC = () => {
           <SidePanel.Suspense key="add">
             <SidePanel.Header>Add publication</SidePanel.Header>
             <AddPublicationForm />
-          </SidePanel.Suspense>
-        )}
-        {lastSidePathSegment === "add-target" && (
-          <SidePanel.Suspense key="add-target">
-            <SidePanel.Header>Add publication target</SidePanel.Header>
-            <AddPublicationTargetForm />
           </SidePanel.Suspense>
         )}
         {lastSidePathSegment === "view" && (

--- a/src/pages/dashboard/repositories/repository-profiles/RepositoryProfilesPage.test.tsx
+++ b/src/pages/dashboard/repositories/repository-profiles/RepositoryProfilesPage.test.tsx
@@ -5,6 +5,9 @@ import { expectLoadingState } from "@/tests/helpers";
 import { screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import RepositoryProfilesPage from "./RepositoryProfilesPage";
+import userEvent from "@testing-library/user-event";
+
+const [profile] = repositoryProfiles;
 
 describe("RepositoryProfilesPage", () => {
   it("renders repository profile list with table and pagination", async () => {
@@ -43,7 +46,6 @@ describe("RepositoryProfilesPage", () => {
   });
 
   it("opens profile details panel when sidePath=view and name are set in URL", async () => {
-    const [profile] = repositoryProfiles;
     renderWithProviders(
       <RepositoryProfilesPage />,
       undefined,
@@ -54,6 +56,37 @@ describe("RepositoryProfilesPage", () => {
     expect(
       await within(screen.getByLabelText("Side panel")).findByRole("heading", {
         name: profile.title,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the add form side panel when add button is clicked", async () => {
+    renderWithProviders(<RepositoryProfilesPage />);
+
+    await expectLoadingState();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add repository profile" }),
+    );
+
+    expect(
+      await within(screen.getByLabelText("Side panel")).findByRole("button", {
+        name: /add a new repository profile/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the edit form side panel when sidePath=edit is in the URL", async () => {
+    renderWithProviders(
+      <RepositoryProfilesPage />,
+      undefined,
+      `/?sidePath=edit&name=${profile.name}`,
+    );
+
+    await expectLoadingState();
+
+    expect(
+      await within(screen.getByLabelText("Side panel")).findByRole("button", {
+        name: /save changes/i,
       }),
     ).toBeInTheDocument();
   });

--- a/src/pages/dashboard/repositories/repository-profiles/RepositoryProfilesPage.tsx
+++ b/src/pages/dashboard/repositories/repository-profiles/RepositoryProfilesPage.tsx
@@ -32,7 +32,7 @@ const RepositoryProfileEditForm = lazy(async () =>
 
 const RepositoryProfilesPage: FC = () => {
   const { getRepositoryProfilesQuery } = useRepositoryProfiles();
-  const { sidePath, lastSidePathSegment, createPageParamsSetter } =
+  const { sidePath, lastSidePathSegment, popSidePathUntilClear } =
     usePageParams();
 
   useSetDynamicFilterValidation("sidePath", [
@@ -68,10 +68,7 @@ const RepositoryProfilesPage: FC = () => {
           }
         />
       </PageContent>
-      <SidePanel
-        onClose={createPageParamsSetter({ sidePath: [], name: "" })}
-        isOpen={!!sidePath.length}
-      >
+      <SidePanel onClose={popSidePathUntilClear} isOpen={!!sidePath.length}>
         {sidePath.includes("add") && (
           <SidePanel.Suspense key="add">
             <RepositoryProfileAddSidePanel />

--- a/src/pages/dashboard/repositories/repository-profiles/RepositoryProfilesPage.tsx
+++ b/src/pages/dashboard/repositories/repository-profiles/RepositoryProfilesPage.tsx
@@ -32,7 +32,8 @@ const RepositoryProfileEditForm = lazy(async () =>
 
 const RepositoryProfilesPage: FC = () => {
   const { getRepositoryProfilesQuery } = useRepositoryProfiles();
-  const { sidePath, lastSidePathSegment, popSidePath } = usePageParams();
+  const { sidePath, lastSidePathSegment, createPageParamsSetter } =
+    usePageParams();
 
   useSetDynamicFilterValidation("sidePath", [
     "add",
@@ -67,7 +68,10 @@ const RepositoryProfilesPage: FC = () => {
           }
         />
       </PageContent>
-      <SidePanel onClose={popSidePath} isOpen={!!sidePath.length}>
+      <SidePanel
+        onClose={createPageParamsSetter({ sidePath: [], name: "" })}
+        isOpen={!!sidePath.length}
+      >
         {sidePath.includes("add") && (
           <SidePanel.Suspense key="add">
             <RepositoryProfileAddSidePanel />

--- a/src/tests/server/handlers/publicationTargets.ts
+++ b/src/tests/server/handlers/publicationTargets.ts
@@ -1,8 +1,11 @@
 import { API_URL_DEB_ARCHIVE } from "@/constants";
 import { getEndpointStatus } from "@/tests/controllers/controller";
 import { publicationTargets } from "@/tests/mocks/publicationTargets";
-import type { PublicationTarget } from "@canonical/landscape-openapi";
-import { http, HttpResponse } from "msw";
+import type {
+  PublicationTarget,
+  BatchGetPublicationTargetsResponse,
+} from "@canonical/landscape-openapi";
+import { http, HttpResponse, type StrictResponse } from "msw";
 import { ENDPOINT_STATUS_API_ERROR } from "./_constants";
 import {
   getDebArchivePaginatedResponse,
@@ -21,6 +24,17 @@ const getPublicationTargetsResponse = (requestUrl: string) => {
     publicationTargets: paginatedData,
     nextPageToken,
   });
+};
+
+const getBatchPublicationTargetsResponse = async (
+  request: Request,
+): Promise<StrictResponse<BatchGetPublicationTargetsResponse>> => {
+  const body = (await request.json()) as { names?: string[] };
+  const requestedNames = body.names ?? [];
+  const matched = publicationTargets.filter(({ name }) =>
+    name ? requestedNames.includes(name) : false,
+  );
+  return HttpResponse.json({ publicationTargets: matched });
 };
 
 export default [
@@ -67,6 +81,13 @@ export default [
       } as PublicationTarget;
       publicationTargets[idx] = updated;
       return HttpResponse.json(updated);
+    },
+  ),
+
+  http.post(
+    `${API_URL_DEB_ARCHIVE}publicationTargets:batchGet`,
+    async ({ request }) => {
+      return getBatchPublicationTargetsResponse(request);
     },
   ),
 

--- a/src/tests/server/handlers/publications.ts
+++ b/src/tests/server/handlers/publications.ts
@@ -1,7 +1,6 @@
 import { API_URL_DEB_ARCHIVE } from "@/constants";
 import { getEndpointStatus } from "@/tests/controllers/controller";
 import { publications } from "@/tests/mocks/publications";
-import { publicationTargets } from "@/tests/mocks/publicationTargets";
 import type { StrictResponse } from "msw";
 import { delay, http, HttpResponse } from "msw";
 import {
@@ -10,7 +9,6 @@ import {
 } from "./_helpers";
 import { ENDPOINT_STATUS_API_ERROR } from "./_constants";
 import type {
-  BatchGetPublicationTargetsResponse,
   Publication,
   PublishPublicationResponse,
 } from "@canonical/landscape-openapi";
@@ -129,25 +127,7 @@ const getPublishPublicationResponse =
     );
   };
 
-const getBatchPublicationTargetsResponse = async (
-  request: Request,
-): Promise<StrictResponse<BatchGetPublicationTargetsResponse>> => {
-  const body = (await request.json()) as { names?: string[] };
-  const requestedNames = body.names ?? [];
-  const matched = publicationTargets.filter(({ name }) =>
-    name ? requestedNames.includes(name) : false,
-  );
-  return HttpResponse.json({ publicationTargets: matched });
-};
-
 export default [
-  http.post(
-    `${API_URL_DEB_ARCHIVE}publicationTargets:batchGet`,
-    async ({ request }) => {
-      return getBatchPublicationTargetsResponse(request);
-    },
-  ),
-
   http.get(`${API_URL_DEB_ARCHIVE}publications`, async ({ request }) => {
     await delay();
 


### PR DESCRIPTION
## Summary

- added invalidation for singular `Get` queries after edit for `local` and `publication` (even though we don't actually currently use `useUpdatePublication`, but in case we end up using it in the future to avoid this bug reappearing)
- created new function `popSidePathUntilClear` in `usePageParams` which uses `popSidePath` for side panel params until the last sidePanel is fully cleared using `createPageParamsSetter` so that it erases the `name` param, since it was leaving behind this in the url: 
<img width="1112" height="42" alt="image" src="https://github.com/user-attachments/assets/4d2bc742-2ac6-41dd-8097-6e47e0fb8c4b" />
<br/>


- increased test coverage for all repositories related pages 
- added empty message for associated publications table
<img width="655" height="219" alt="image" src="https://github.com/user-attachments/assets/bc58d828-fa36-4bf4-8fae-4390daf42115" />  

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
