### PR TITLE
Mirror packages tab [LNDENG-4392]

### DIFF
--- a/.changeset/old-lamps-stop.md
+++ b/.changeset/old-lamps-stop.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": minor
+---
+
+Add mirror packages tab

--- a/src/features/mirrors/components/MirrorDetails/MirrorDetails.module.scss
+++ b/src/features/mirrors/components/MirrorDetails/MirrorDetails.module.scss
@@ -1,0 +1,5 @@
+@import "vanilla-framework/scss/settings_spacing";
+
+.marginBottom {
+  margin-bottom: $spv--x-large;
+}

--- a/src/features/mirrors/components/MirrorDetails/MirrorDetails.tsx
+++ b/src/features/mirrors/components/MirrorDetails/MirrorDetails.tsx
@@ -1,6 +1,6 @@
-import type { FC } from "react";
+import { useState, type FC } from "react";
 import SidePanel from "@/components/layout/SidePanel/SidePanel";
-import { Button, Icon, ICONS } from "@canonical/react-components";
+import { Button, Icon, ICONS, Tabs } from "@canonical/react-components";
 import Blocks from "@/components/layout/Blocks";
 import InfoGrid from "@/components/layout/InfoGrid";
 import { useGetMirror, useListPublicationTargets } from "../../api";
@@ -18,6 +18,8 @@ import {
   AssociatedPublicationsList,
   useGetPublicationsBySource,
 } from "@/features/publications";
+import classes from "./MirrorDetails.module.scss";
+import MirrorPackagesList from "../MirrorPackagesList";
 
 const MirrorDetails: FC = () => {
   const { name, createSidePathPusher, sidePath, setPageParams } =
@@ -39,6 +41,8 @@ const MirrorDetails: FC = () => {
     setFalse: closeNoPublicationTargetsModal,
   } = useBoolean();
 
+  const [tabId, setTabId] = useState<"details" | "packages">("details");
+
   const mirror = useGetMirror(name).data.data;
 
   const { publications } = useGetPublicationsBySource(name);
@@ -56,6 +60,25 @@ const MirrorDetails: FC = () => {
       openNoPublicationTargetsModal();
     }
   };
+
+  const tabs: { label: string; id: "details" | "packages" }[] = [
+    {
+      label: "General details",
+      id: "details",
+    },
+    {
+      label: "Packages",
+      id: "packages",
+    },
+  ];
+
+  const links = tabs.map(({ label, id }) => ({
+    label,
+    active: tabId == id,
+    onClick: () => {
+      setTabId(id);
+    },
+  }));
 
   return (
     <>
@@ -99,80 +122,89 @@ const MirrorDetails: FC = () => {
             <span className="u-text--negative">Remove</span>
           </Button>
         </div>
-        <Blocks>
-          <Blocks.Item title="Details" titleClassName="p-text--small-caps">
-            <InfoGrid dense>
-              <InfoGrid.Item label="Name" value={mirror.displayName} />
-              <InfoGrid.Item
-                label="Source type"
-                value={getSourceType(mirror.archiveRoot)}
+        <Tabs listClassName={classes.marginBottom} links={links} />
+        {tabId === "details" && (
+          <Blocks>
+            <Blocks.Item title="Details" titleClassName="p-text--small-caps">
+              <InfoGrid dense>
+                <InfoGrid.Item label="Name" value={mirror.displayName} />
+                <InfoGrid.Item
+                  label="Source type"
+                  value={getSourceType(mirror.archiveRoot)}
+                />
+                <InfoGrid.Item
+                  label="Source URL"
+                  value={
+                    <a
+                      href={mirror.archiveRoot}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {mirror.archiveRoot}
+                    </a>
+                  }
+                  large
+                />
+                <InfoGrid.Item
+                  label="Last update"
+                  value={
+                    mirror.lastDownloadDate &&
+                    moment(mirror.lastDownloadDate).format(
+                      DISPLAY_DATE_TIME_FORMAT,
+                    )
+                  }
+                />
+                <InfoGrid.Item
+                  label="Packages"
+                  value={
+                    mirror.name && (
+                      <MirrorPackagesCount mirrorName={mirror.name} />
+                    )
+                  }
+                />
+              </InfoGrid>
+            </Blocks.Item>
+            <Blocks.Item title="Contents" titleClassName="p-text--small-caps">
+              <InfoGrid dense>
+                <InfoGrid.Item
+                  label="Distribution"
+                  value={mirror.distribution}
+                />
+                <InfoGrid.Item
+                  label="Components"
+                  value={mirror.components?.join(", ")}
+                  large
+                />
+                <InfoGrid.Item
+                  label="Architectures"
+                  value={mirror.architectures?.join(", ")}
+                  large
+                />
+                <InfoGrid.Item
+                  label="Download .udeb"
+                  value={boolToLabel(mirror.downloadUdebs)}
+                />
+                <InfoGrid.Item
+                  label="Download sources"
+                  value={boolToLabel(mirror.downloadSources)}
+                />
+                <InfoGrid.Item
+                  label="Download installer files"
+                  value={boolToLabel(mirror.downloadInstaller)}
+                />
+              </InfoGrid>
+            </Blocks.Item>
+            <Blocks.Item title="Used in" titleClassName="p-text--small-caps">
+              <AssociatedPublicationsList
+                publications={publications}
+                showSources={false}
               />
-              <InfoGrid.Item
-                label="Source URL"
-                value={
-                  <a
-                    href={mirror.archiveRoot}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {mirror.archiveRoot}
-                  </a>
-                }
-                large
-              />
-              <InfoGrid.Item
-                label="Last update"
-                value={
-                  mirror.lastDownloadDate &&
-                  moment(mirror.lastDownloadDate).format(
-                    DISPLAY_DATE_TIME_FORMAT,
-                  )
-                }
-              />
-              <InfoGrid.Item
-                label="Packages"
-                value={
-                  mirror.name && (
-                    <MirrorPackagesCount mirrorName={mirror.name} />
-                  )
-                }
-              />
-            </InfoGrid>
-          </Blocks.Item>
-          <Blocks.Item title="Contents" titleClassName="p-text--small-caps">
-            <InfoGrid dense>
-              <InfoGrid.Item label="Distribution" value={mirror.distribution} />
-              <InfoGrid.Item
-                label="Components"
-                value={mirror.components?.join(", ")}
-                large
-              />
-              <InfoGrid.Item
-                label="Architectures"
-                value={mirror.architectures?.join(", ")}
-                large
-              />
-              <InfoGrid.Item
-                label="Download .udeb"
-                value={boolToLabel(mirror.downloadUdebs)}
-              />
-              <InfoGrid.Item
-                label="Download sources"
-                value={boolToLabel(mirror.downloadSources)}
-              />
-              <InfoGrid.Item
-                label="Download installer files"
-                value={boolToLabel(mirror.downloadInstaller)}
-              />
-            </InfoGrid>
-          </Blocks.Item>
-          <Blocks.Item title="Used in" titleClassName="p-text--small-caps">
-            <AssociatedPublicationsList
-              publications={publications}
-              showSources={false}
-            />
-          </Blocks.Item>
-        </Blocks>
+            </Blocks.Item>
+          </Blocks>
+        )}
+        {tabId === "packages" && mirror.name && (
+          <MirrorPackagesList mirrorName={mirror.name} />
+        )}
       </SidePanel.Content>
       <UpdateMirrorModal
         isOpen={isUpdateModalOpen}

--- a/src/features/mirrors/components/MirrorPackagesList/MirrorPackagesList.test.tsx
+++ b/src/features/mirrors/components/MirrorPackagesList/MirrorPackagesList.test.tsx
@@ -1,0 +1,21 @@
+import { renderWithProviders } from "@/tests/render";
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import MirrorPackagesList from ".";
+import { mirrors } from "@/tests/mocks/mirrors";
+
+describe("MirrorPackagesList", () => {
+  it("renders table with correct header after loading", async () => {
+    renderWithProviders(<MirrorPackagesList mirrorName={mirrors[0].name} />);
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+
+    expect(
+      await screen.findByRole("columnheader", { name: "Package name" }),
+    ).toBeInTheDocument();
+
+    expect(await screen.findByText("package-1")).toBeInTheDocument();
+    expect(screen.getByText("package-2")).toBeInTheDocument();
+    expect(screen.getByText("package-3")).toBeInTheDocument();
+  });
+});

--- a/src/features/mirrors/components/MirrorPackagesList/MirrorPackagesList.tsx
+++ b/src/features/mirrors/components/MirrorPackagesList/MirrorPackagesList.tsx
@@ -53,7 +53,7 @@ const MirrorPackagesList: FC<MirrorPackagesListProps> = ({ mirrorName }) => {
       <ResponsiveTable
         columns={columns}
         data={pagedPackages}
-        emptyMsg={"No packages associated with this local repository."}
+        emptyMsg={"No packages associated with this mirror."}
         minWidth={320}
       />
       <ModalTablePagination

--- a/src/features/mirrors/components/MirrorPackagesList/MirrorPackagesList.tsx
+++ b/src/features/mirrors/components/MirrorPackagesList/MirrorPackagesList.tsx
@@ -1,0 +1,69 @@
+import { useMemo, type FC } from "react";
+import LoadingState from "@/components/layout/LoadingState";
+import { useListMirrorPackages } from "../../api";
+import { ModalTablePagination } from "@/components/layout/TablePagination";
+import ResponsiveTable from "@/components/layout/ResponsiveTable";
+import { DEFAULT_MODAL_PAGE_SIZE } from "@/constants";
+import type { CellProps, Column } from "react-table";
+import { useCounter } from "usehooks-ts";
+
+interface MirrorPackagesListProps {
+  readonly mirrorName: string;
+}
+
+const MirrorPackagesList: FC<MirrorPackagesListProps> = ({ mirrorName }) => {
+  const { data, isPending, error } = useListMirrorPackages(mirrorName, {
+    pageSize: 1000,
+  });
+
+  const { count: currentPage, increment, decrement } = useCounter(1);
+
+  const columns = useMemo<Column<{ packageName: string }>[]>(
+    () => [
+      {
+        Header: "Package name",
+        Cell: ({
+          row: {
+            original: { packageName },
+          },
+        }: CellProps<{ packageName: string }>) => packageName,
+      },
+    ],
+    [],
+  );
+
+  if (isPending) {
+    return <LoadingState />;
+  }
+
+  if (error) {
+    throw error;
+  }
+
+  const formattedPackages =
+    data.data.mirrorPackages?.map((packageName) => ({ packageName })) || [];
+
+  const pagedPackages = formattedPackages.slice(
+    (currentPage - 1) * DEFAULT_MODAL_PAGE_SIZE,
+    currentPage * DEFAULT_MODAL_PAGE_SIZE,
+  );
+
+  return (
+    <>
+      <ResponsiveTable
+        columns={columns}
+        data={pagedPackages}
+        emptyMsg={"No packages associated with this local repository."}
+        minWidth={320}
+      />
+      <ModalTablePagination
+        current={currentPage}
+        max={Math.ceil(formattedPackages.length / DEFAULT_MODAL_PAGE_SIZE)}
+        onNext={increment}
+        onPrev={decrement}
+      />
+    </>
+  );
+};
+
+export default MirrorPackagesList;

--- a/src/features/mirrors/components/MirrorPackagesList/index.ts
+++ b/src/features/mirrors/components/MirrorPackagesList/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MirrorPackagesList";


### PR DESCRIPTION
## Summary

Add mirror packages tab to details

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [ ] Patch (fix)
- [x] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
