### PR TITLE
fix: keyboard a11y and arrow-key navigation for saved-searches dropdown

### DIFF
--- a/.changeset/twelve-suns-sing.md
+++ b/.changeset/twelve-suns-sing.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Keyboard a11y and arrow-key navigation for saved-searches dropdown

--- a/src/features/saved-searches/components/SavedSearchList/SavedSearchList.module.scss
+++ b/src/features/saved-searches/components/SavedSearchList/SavedSearchList.module.scss
@@ -32,6 +32,10 @@
   }
 }
 
+.activeItem {
+  background-color: $colors--theme--background-neutral-default;
+}
+
 .list li:last-child .listItem {
   border-bottom: none !important;
 }

--- a/src/features/saved-searches/components/SavedSearchList/SavedSearchList.tsx
+++ b/src/features/saved-searches/components/SavedSearchList/SavedSearchList.tsx
@@ -2,7 +2,7 @@ import LoadingState from "@/components/layout/LoadingState";
 import useSidePanel from "@/hooks/useSidePanel";
 import { Button, Col, Row, Tooltip } from "@canonical/react-components";
 import classNames from "classnames";
-import { Suspense, type FC } from "react";
+import { Suspense, useEffect, type FC } from "react";
 import type { SavedSearch } from "../../types";
 import ManageSavedSearchesSidePanel from "../ManageSavedSeachesSidePanel";
 import classes from "./SavedSearchList.module.scss";
@@ -16,6 +16,8 @@ interface SavedSearchListProps {
   readonly savedSearches: SavedSearch[];
   readonly onManageSearches: () => void;
   readonly onSavedSearchRemove: () => void;
+  readonly activeIndex?: number | null;
+  readonly itemIdPrefix?: string;
 }
 
 const SavedSearchList: FC<SavedSearchListProps> = ({
@@ -23,9 +25,22 @@ const SavedSearchList: FC<SavedSearchListProps> = ({
   savedSearches,
   onManageSearches,
   onSavedSearchRemove,
+  activeIndex = null,
+  itemIdPrefix,
 }) => {
   const { setSidePanelContent } = useSidePanel();
   const isLargeScreen = useMediaQuery(`(min-width: ${BREAKPOINT_PX["lg"]}px)`);
+
+  // aria-activedescendant doesn't move DOM focus, so scroll the active item ourselves.
+  useEffect(() => {
+    if (activeIndex === null || !itemIdPrefix) {
+      return;
+    }
+    const activeItem = document.getElementById(
+      `${itemIdPrefix}-${activeIndex}`,
+    );
+    activeItem?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, itemIdPrefix]);
 
   if (!savedSearches.length) {
     return null;
@@ -63,12 +78,20 @@ const SavedSearchList: FC<SavedSearchListProps> = ({
           classes.list,
         )}
       >
-        {savedSearches.map((savedSearch) => (
+        {savedSearches.map((savedSearch, index) => (
           <li key={savedSearch.name}>
-            <div className={classes.listItem}>
+            <div
+              className={classNames(classes.listItem, {
+                [classes.activeItem]: index === activeIndex,
+              })}
+            >
               <Button
                 type="button"
                 appearance="base"
+                id={
+                  itemIdPrefix ? `${itemIdPrefix}-${index}` : undefined
+                }
+                aria-selected={index === activeIndex || undefined}
                 className={classes.search}
                 onClick={() => {
                   onSavedSearchClick(savedSearch);

--- a/src/features/saved-searches/components/SearchBoxWithSavedSearches/SearchBoxWithSavedSearches.module.scss
+++ b/src/features/saved-searches/components/SearchBoxWithSavedSearches/SearchBoxWithSavedSearches.module.scss
@@ -1,3 +1,4 @@
+@import "vanilla-framework/scss/settings_colors";
 @import "vanilla-framework/scss/settings_placeholders";
 @import "vanilla-framework/scss/settings_spacing";
 
@@ -29,5 +30,19 @@
 
   :global(.p-search-box__input) {
     border-bottom: 0;
+  }
+}
+
+.keyboardHint {
+  border-top: 1px solid $colors--theme--border-default;
+  padding: $spv--small $sph--large;
+
+  kbd {
+    background-color: $colors--theme--background-neutral-default;
+    border: 1px solid $colors--theme--border-default;
+    border-radius: 0.125rem;
+    font-family: inherit;
+    font-size: 0.75em;
+    padding: 0 0.25rem;
   }
 }

--- a/src/features/saved-searches/components/SearchBoxWithSavedSearches/SearchBoxWithSavedSearches.test.tsx
+++ b/src/features/saved-searches/components/SearchBoxWithSavedSearches/SearchBoxWithSavedSearches.test.tsx
@@ -429,4 +429,370 @@ describe("SearchBoxWithSavedSearches", () => {
     const searchBox = screen.getByRole("searchbox");
     expect(searchBox).toHaveValue("existing-query");
   });
+
+  describe("keyboard accessibility", () => {
+    it("should open the dropdown when the search box receives keyboard focus", async () => {
+      renderWithProviders(
+        <div>
+          <button>Before</button>
+          <SearchBoxWithSavedSearches {...defaultProps} />
+        </div>,
+      );
+
+      const beforeButton = screen.getByRole("button", { name: "Before" });
+      beforeButton.focus();
+      expect(screen.queryByText("Saved searches")).not.toBeInTheDocument();
+
+      await user.tab();
+
+      expect(screen.getByRole("searchbox")).toHaveFocus();
+      expect(await screen.findByText("Saved searches")).toBeInTheDocument();
+    });
+
+    it("should expose aria-expanded and aria-controls linking the input to the dropdown panel", async () => {
+      renderWithProviders(<SearchBoxWithSavedSearches {...defaultProps} />);
+
+      const searchBox = screen.getByRole("searchbox");
+      expect(searchBox).toHaveAttribute("aria-expanded", "false");
+      expect(searchBox).not.toHaveAttribute("aria-controls");
+
+      await user.click(searchBox);
+      await screen.findByText("Saved searches");
+
+      expect(searchBox).toHaveAttribute("aria-expanded", "true");
+      const controlsId = searchBox.getAttribute("aria-controls");
+      expect(controlsId).toBeTruthy();
+
+      const panel = screen.getByRole("group", { name: "Saved searches" });
+      expect(panel).toHaveAttribute("id", controlsId);
+    });
+
+    it("should keep the dropdown open while focus moves between focusable items inside it", async () => {
+      renderWithProviders(<SearchBoxWithSavedSearches {...defaultProps} />);
+
+      const searchBox = screen.getByRole("searchbox");
+      await user.click(searchBox);
+
+      await screen.findByText("Saved searches");
+
+      const manageButton = screen.getByRole("button", { name: "Manage" });
+      manageButton.focus();
+      expect(manageButton).toHaveFocus();
+
+      // After focus moves to a button inside the panel, the dropdown must remain visible.
+      expect(screen.getByText("Saved searches")).toBeInTheDocument();
+    });
+
+    it("should close the dropdown when keyboard focus moves to an element outside the component", async () => {
+      renderWithProviders(
+        <div>
+          <SearchBoxWithSavedSearches {...defaultProps} />
+          <button>After</button>
+        </div>,
+      );
+
+      const searchBox = screen.getByRole("searchbox");
+      await user.click(searchBox);
+
+      await screen.findByText("Saved searches");
+
+      const afterButton = screen.getByRole("button", { name: "After" });
+      afterButton.focus();
+
+      await waitFor(() => {
+        expect(screen.queryByText("Saved searches")).not.toBeInTheDocument();
+      });
+    });
+
+    it("should close the dropdown and return focus to the search box when Escape is pressed inside the panel", async () => {
+      renderWithProviders(<SearchBoxWithSavedSearches {...defaultProps} />);
+
+      const searchBox = screen.getByRole("searchbox");
+      await user.click(searchBox);
+
+      await screen.findByText("Saved searches");
+
+      const manageButton = screen.getByRole("button", { name: "Manage" });
+      manageButton.focus();
+      expect(manageButton).toHaveFocus();
+
+      await user.keyboard("{Escape}");
+
+      expect(screen.queryByText("Saved searches")).not.toBeInTheDocument();
+      expect(searchBox).toHaveFocus();
+    });
+
+    it("should not re-open the dropdown when focus is restored to the search box on Escape", async () => {
+      renderWithProviders(<SearchBoxWithSavedSearches {...defaultProps} />);
+
+      const searchBox = screen.getByRole("searchbox");
+      await user.click(searchBox);
+
+      await screen.findByText("Saved searches");
+
+      const manageButton = screen.getByRole("button", { name: "Manage" });
+      manageButton.focus();
+
+      await user.keyboard("{Escape}");
+
+      expect(searchBox).toHaveFocus();
+      expect(screen.queryByText("Saved searches")).not.toBeInTheDocument();
+    });
+
+    it("should keep the dropdown open while focus is on the help button inside the search container", async () => {
+      renderWithProviders(<SearchBoxWithSavedSearches {...defaultProps} />);
+
+      const searchBox = screen.getByRole("searchbox");
+      await user.click(searchBox);
+
+      await screen.findByText("Saved searches");
+
+      const helpButton = screen.getByRole("button", { name: "Search help" });
+      helpButton.focus();
+      expect(helpButton).toHaveFocus();
+      expect(screen.getByText("Saved searches")).toBeInTheDocument();
+    });
+
+    it("should keep the dropdown open while a modal opened from inside it has focus", async () => {
+      renderWithProviders(<SearchBoxWithSavedSearches {...defaultProps} />);
+
+      const searchBox = screen.getByRole("searchbox");
+      await user.click(searchBox);
+
+      await screen.findByText("Saved searches");
+
+      const [firstSearch] = savedSearches;
+      const removeButton = screen.getByRole("button", {
+        name: `Remove ${firstSearch.title} saved search`,
+      });
+      await user.click(removeButton);
+
+      const modal = screen.getByRole("dialog");
+      expect(modal).toBeInTheDocument();
+      expect(screen.getByText("Saved searches")).toBeInTheDocument();
+    });
+
+    it("should re-open the dropdown when the search box is clicked after Escape closed it", async () => {
+      renderWithProviders(<SearchBoxWithSavedSearches {...defaultProps} />);
+
+      const searchBox = screen.getByRole("searchbox");
+      await user.click(searchBox);
+
+      await screen.findByText("Saved searches");
+
+      await user.keyboard("{Escape}");
+      expect(screen.queryByText("Saved searches")).not.toBeInTheDocument();
+
+      await user.click(searchBox);
+      expect(await screen.findByText("Saved searches")).toBeInTheDocument();
+    });
+
+    it("should highlight the first saved search when ArrowDown is pressed", async () => {
+      renderWithProviders(<SearchBoxWithSavedSearches {...defaultProps} />);
+
+      const searchBox = screen.getByRole("searchbox");
+      await user.click(searchBox);
+
+      await screen.findByText("Saved searches");
+
+      expect(searchBox).not.toHaveAttribute("aria-activedescendant");
+
+      await user.keyboard("{ArrowDown}");
+
+      const activeId = searchBox.getAttribute("aria-activedescendant");
+      expect(activeId).toBeTruthy();
+
+      const [firstSearch] = savedSearches;
+      assert(firstSearch);
+      const activeButton = document.getElementById(activeId ?? "");
+      assert(activeButton);
+      expect(activeButton).toHaveAttribute("aria-selected", "true");
+      expect(activeButton).toHaveTextContent(firstSearch.title);
+    });
+
+    it("should move highlight down through items and clamp at the last one", async () => {
+      renderWithProviders(<SearchBoxWithSavedSearches {...defaultProps} />);
+
+      const searchBox = screen.getByRole("searchbox");
+      await user.click(searchBox);
+
+      await screen.findByText("Saved searches");
+
+      // Press ArrowDown more times than there are items so we exercise the clamp.
+      for (let i = 0; i < savedSearches.length + 2; i += 1) {
+        await user.keyboard("{ArrowDown}");
+      }
+
+      const lastSearch = savedSearches.at(-1);
+      assert(lastSearch);
+      const activeId = searchBox.getAttribute("aria-activedescendant");
+      const activeButton = document.getElementById(activeId ?? "");
+      assert(activeButton);
+      expect(activeButton).toHaveTextContent(lastSearch.title);
+    });
+
+    it("should highlight the last saved search when ArrowUp is pressed with no current selection", async () => {
+      renderWithProviders(<SearchBoxWithSavedSearches {...defaultProps} />);
+
+      const searchBox = screen.getByRole("searchbox");
+      await user.click(searchBox);
+
+      await screen.findByText("Saved searches");
+
+      await user.keyboard("{ArrowUp}");
+
+      const lastSearch = savedSearches.at(-1);
+      assert(lastSearch);
+      const activeId = searchBox.getAttribute("aria-activedescendant");
+      const activeButton = document.getElementById(activeId ?? "");
+      assert(activeButton);
+      expect(activeButton).toHaveTextContent(lastSearch.title);
+    });
+
+    it("should clamp ArrowUp at the first item", async () => {
+      renderWithProviders(<SearchBoxWithSavedSearches {...defaultProps} />);
+
+      const searchBox = screen.getByRole("searchbox");
+      await user.click(searchBox);
+
+      await screen.findByText("Saved searches");
+
+      await user.keyboard("{ArrowDown}");
+      await user.keyboard("{ArrowUp}");
+      await user.keyboard("{ArrowUp}");
+
+      const [firstSearch] = savedSearches;
+      assert(firstSearch);
+      const activeId = searchBox.getAttribute("aria-activedescendant");
+      const activeButton = document.getElementById(activeId ?? "");
+      assert(activeButton);
+      expect(activeButton).toHaveTextContent(firstSearch.title);
+    });
+
+    it("should jump to the first item with Home and the last with End", async () => {
+      renderWithProviders(<SearchBoxWithSavedSearches {...defaultProps} />);
+
+      const searchBox = screen.getByRole("searchbox");
+      await user.click(searchBox);
+
+      await screen.findByText("Saved searches");
+
+      const [firstSearch] = savedSearches;
+      const lastSearch = savedSearches.at(-1);
+      assert(firstSearch);
+      assert(lastSearch);
+
+      await user.keyboard("{End}");
+      let activeId = searchBox.getAttribute("aria-activedescendant");
+      expect(document.getElementById(activeId ?? "")).toHaveTextContent(
+        lastSearch.title,
+      );
+
+      await user.keyboard("{Home}");
+      activeId = searchBox.getAttribute("aria-activedescendant");
+      expect(document.getElementById(activeId ?? "")).toHaveTextContent(
+        firstSearch.title,
+      );
+    });
+
+    it("should apply the highlighted saved search when Enter is pressed", async () => {
+      const onChange = vi.fn();
+      renderWithProviders(
+        <SearchBoxWithSavedSearches {...defaultProps} onChange={onChange} />,
+      );
+
+      const searchBox = screen.getByRole("searchbox");
+      await user.click(searchBox);
+
+      await screen.findByText("Saved searches");
+
+      const [, secondSearch] = savedSearches;
+      assert(secondSearch);
+
+      await user.keyboard("{ArrowDown}{ArrowDown}");
+      await user.keyboard("{Enter}");
+
+      expect(onChange).toHaveBeenCalled();
+      expect(searchBox).toHaveValue(`search:${secondSearch.name}`);
+    });
+
+    it("should fall back to plain search on Enter when no item is highlighted", async () => {
+      const onChange = vi.fn();
+      renderWithProviders(
+        <SearchBoxWithSavedSearches {...defaultProps} onChange={onChange} />,
+      );
+
+      const searchBox = screen.getByRole("searchbox");
+      await user.click(searchBox);
+      await user.type(searchBox, "free-text-query");
+
+      await user.keyboard("{Enter}");
+
+      expect(onChange).toHaveBeenCalled();
+      expect(searchBox).toHaveValue("free-text-query");
+    });
+
+    it("should reset the highlight when the input text changes", async () => {
+      renderWithProviders(<SearchBoxWithSavedSearches {...defaultProps} />);
+
+      const searchBox = screen.getByRole("searchbox");
+      await user.click(searchBox);
+
+      await screen.findByText("Saved searches");
+
+      await user.keyboard("{ArrowDown}");
+      expect(searchBox).toHaveAttribute("aria-activedescendant");
+
+      await user.type(searchBox, "x");
+
+      expect(searchBox).not.toHaveAttribute("aria-activedescendant");
+    });
+
+    it("should scroll the highlighted item into view when navigating with the arrow keys", async () => {
+      const scrollIntoViewSpy = vi
+        .spyOn(Element.prototype, "scrollIntoView")
+        .mockImplementation(() => undefined);
+
+      try {
+        renderWithProviders(<SearchBoxWithSavedSearches {...defaultProps} />);
+
+        const searchBox = screen.getByRole("searchbox");
+        await user.click(searchBox);
+
+        await screen.findByText("Saved searches");
+
+        scrollIntoViewSpy.mockClear();
+
+        await user.keyboard("{ArrowDown}");
+
+        const activeId = searchBox.getAttribute("aria-activedescendant");
+        const activeItem = document.getElementById(activeId ?? "");
+        assert(activeItem);
+
+        const scrollCalls = scrollIntoViewSpy.mock.instances.filter(
+          (instance) => instance === activeItem,
+        );
+        expect(scrollCalls.length).toBeGreaterThan(0);
+        expect(scrollIntoViewSpy).toHaveBeenLastCalledWith({
+          block: "nearest",
+        });
+      } finally {
+        scrollIntoViewSpy.mockRestore();
+      }
+    });
+
+    it("should render a muted helper hint describing keyboard shortcuts", async () => {
+      renderWithProviders(<SearchBoxWithSavedSearches {...defaultProps} />);
+
+      const searchBox = screen.getByRole("searchbox");
+      await user.click(searchBox);
+
+      await screen.findByText("Saved searches");
+
+      const hint = screen.getByText(/to navigate/i);
+      expect(hint).toBeInTheDocument();
+      expect(hint).toHaveTextContent("Enter");
+      expect(hint).toHaveTextContent("Esc");
+    });
+  });
 });

--- a/src/features/saved-searches/components/SearchBoxWithSavedSearches/SearchBoxWithSavedSearches.tsx
+++ b/src/features/saved-searches/components/SearchBoxWithSavedSearches/SearchBoxWithSavedSearches.tsx
@@ -2,8 +2,8 @@ import LoadingState from "@/components/layout/LoadingState";
 import usePageParams from "@/hooks/usePageParams";
 import { Form, SearchBox } from "@canonical/react-components";
 import classNames from "classnames";
-import type { FC, KeyboardEvent } from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import type { FC, FocusEvent, KeyboardEvent } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useOnClickOutside } from "usehooks-ts";
 import { useGetSavedSearches } from "../../api";
 import type { SavedSearch } from "../../types";
@@ -18,6 +18,13 @@ interface SearchBoxWithSavedSearchesProps {
   readonly onChange?: () => void;
 }
 
+const SAVED_SEARCHES_PANEL_LABEL = "Saved searches";
+
+const isInsideModalPortal = (node: Node): boolean => {
+  const portalElement = document.querySelector(".p-modal");
+  return Boolean(portalElement?.contains(node));
+};
+
 const SearchBoxWithSavedSearches: FC<SearchBoxWithSavedSearchesProps> = ({
   onHelpButtonClick,
   onChange,
@@ -30,16 +37,50 @@ const SearchBoxWithSavedSearches: FC<SearchBoxWithSavedSearchesProps> = ({
 
   const containerRef = useRef<HTMLDivElement>(null);
   const chipsContainerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const suppressFocusOpenRef = useRef(false);
+  const panelId = useId();
+  const itemIdPrefix = `${panelId}-item`;
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  const closeDropdown = () => {
+    setShowDropdown(false);
+    setActiveIndex(null);
+  };
 
   const handleDropdownClose = (event: MouseEvent | TouchEvent | FocusEvent) => {
-    const portalElement = document.querySelector(".p-modal");
-    if (portalElement && portalElement.contains(event.target as Node)) {
+    if (isInsideModalPortal(event.target as Node)) {
       return;
     }
-    setShowDropdown(false);
+    closeDropdown();
   };
 
   useOnClickOutside(containerRef, handleDropdownClose);
+
+  const handleContainerBlur = (event: FocusEvent<HTMLDivElement>) => {
+    const next = event.relatedTarget as Node | null;
+    if (next && containerRef.current?.contains(next)) {
+      return;
+    }
+    if (next && isInsideModalPortal(next)) {
+      return;
+    }
+    closeDropdown();
+  };
+
+  const handleContainerKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape" && showDropdown) {
+      event.stopPropagation();
+      closeDropdown();
+      if (
+        inputRef.current &&
+        document.activeElement !== inputRef.current
+      ) {
+        suppressFocusOpenRef.current = true;
+        inputRef.current.focus();
+      }
+    }
+  };
 
   useEffect(() => {
     setInputText(query);
@@ -54,6 +95,12 @@ const SearchBoxWithSavedSearches: FC<SearchBoxWithSavedSearchesProps> = ({
       }),
     [savedSearches, inputText, query],
   );
+
+  // Clamp during render so a removed saved search doesn't leave a stale highlight.
+  const effectiveActiveIndex =
+    activeIndex !== null && activeIndex < filteredSearches.length
+      ? activeIndex
+      : null;
 
   const handleSearch = () => {
     const nextQuery = inputText.trim();
@@ -83,22 +130,69 @@ const SearchBoxWithSavedSearches: FC<SearchBoxWithSavedSearchesProps> = ({
     const { key } = event;
 
     if (showDropdown) {
-      if (key === "Escape") {
-        setShowDropdown(false);
+      if (key === "Enter") {
+        const highlighted =
+          effectiveActiveIndex !== null
+            ? filteredSearches[effectiveActiveIndex]
+            : undefined;
+        if (highlighted) {
+          handleSavedSearchClick(highlighted);
+        } else {
+          handleSearch();
+        }
       }
+    } else if (key === "Enter") {
+      setShowDropdown(true);
+    }
+  };
 
-      if (key === "Enter") {
-        handleSearch();
-      }
-    } else {
-      if (key === "Enter") {
+  const handleArrowKeysOnSearchBox = (
+    event: KeyboardEvent<HTMLInputElement>,
+  ) => {
+    const itemCount = filteredSearches.length;
+
+    if (event.key === "ArrowDown") {
+      if (!showDropdown) {
         setShowDropdown(true);
+        return;
       }
+      if (itemCount === 0) {
+        return;
+      }
+      event.preventDefault();
+      setActiveIndex((current) => {
+        if (current === null) {
+          return 0;
+        }
+        return Math.min(current + 1, itemCount - 1);
+      });
+    } else if (event.key === "ArrowUp") {
+      if (!showDropdown || itemCount === 0) {
+        return;
+      }
+      event.preventDefault();
+      setActiveIndex((current) => {
+        if (current === null) {
+          return itemCount - 1;
+        }
+        return Math.max(current - 1, 0);
+      });
+    } else if (event.key === "Home" && showDropdown && itemCount > 0) {
+      event.preventDefault();
+      setActiveIndex(0);
+    } else if (event.key === "End" && showDropdown && itemCount > 0) {
+      event.preventDefault();
+      setActiveIndex(itemCount - 1);
     }
   };
 
   return (
-    <div className="p-search-and-filter" ref={containerRef}>
+    <div
+      className="p-search-and-filter"
+      ref={containerRef}
+      onBlur={handleContainerBlur}
+      onKeyDown={handleContainerKeyDown}
+    >
       <div
         className={classNames(
           "p-search-and-filter__search-container",
@@ -119,16 +213,26 @@ const SearchBoxWithSavedSearches: FC<SearchBoxWithSavedSearchesProps> = ({
         >
           <div className={classes.searchBoxContainer}>
             <SearchBox
+              ref={inputRef}
               externallyControlled
               shouldRefocusAfterReset
               autocomplete="off"
               className={classes.input}
               value={inputText}
+              aria-expanded={showDropdown}
+              aria-controls={showDropdown ? panelId : undefined}
+              aria-activedescendant={
+                showDropdown && effectiveActiveIndex !== null
+                  ? `${itemIdPrefix}-${effectiveActiveIndex}`
+                  : undefined
+              }
               onChange={(inputValue) => {
                 setInputText(inputValue);
+                setActiveIndex(null);
               }}
               onClear={() => {
                 setInputText("");
+                setActiveIndex(null);
                 setPageParams({ query: "" });
                 onChange?.();
               }}
@@ -136,6 +240,14 @@ const SearchBoxWithSavedSearches: FC<SearchBoxWithSavedSearchesProps> = ({
               onClick={() => {
                 setShowDropdown(true);
               }}
+              onFocus={() => {
+                if (suppressFocusOpenRef.current) {
+                  suppressFocusOpenRef.current = false;
+                  return;
+                }
+                setShowDropdown(true);
+              }}
+              onKeyDown={handleArrowKeysOnSearchBox}
               onKeyUp={handleKeysOnSearchBox}
             />
           </div>
@@ -144,7 +256,12 @@ const SearchBoxWithSavedSearches: FC<SearchBoxWithSavedSearchesProps> = ({
       </div>
       {showDropdown && isLoadingSavedSearches && <LoadingState />}
       {showDropdown && !isLoadingSavedSearches && (
-        <div className="p-search-and-filter__panel">
+        <div
+          id={panelId}
+          role="group"
+          aria-label={SAVED_SEARCHES_PANEL_LABEL}
+          className="p-search-and-filter__panel"
+        >
           <SearchPrompt
             onSearchSave={() => {
               setInputText("");
@@ -154,14 +271,25 @@ const SearchBoxWithSavedSearches: FC<SearchBoxWithSavedSearchesProps> = ({
 
           <SavedSearchList
             onSavedSearchClick={handleSavedSearchClick}
-            onManageSearches={() => {
-              setShowDropdown(false);
-            }}
+            onManageSearches={closeDropdown}
             onSavedSearchRemove={() => {
               setShowDropdown(true);
             }}
             savedSearches={filteredSearches}
+            activeIndex={effectiveActiveIndex}
+            itemIdPrefix={itemIdPrefix}
           />
+          {filteredSearches.length > 0 && (
+            <p
+              className={classNames(
+                "p-text--small u-text--muted u-no-margin--bottom",
+                classes.keyboardHint,
+              )}
+            >
+              Use <kbd>↑</kbd> <kbd>↓</kbd> to navigate, <kbd>Enter</kbd> to
+              select, <kbd>Esc</kbd> to close
+            </p>
+          )}
         </div>
       )}
     </div>

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -35,6 +35,14 @@ HTMLCanvasElement.prototype.getContext = (() => {
 
 document.queryCommandSupported = vi.fn(() => true);
 
+// jsdom does not implement Element.prototype.scrollIntoView; polyfill as a
+// no-op so components that call it during tests (e.g. for keyboard nav) work.
+if (typeof Element.prototype.scrollIntoView !== "function") {
+  Element.prototype.scrollIntoView = function scrollIntoView() {
+    /* no-op */
+  };
+}
+
 if (typeof globalThis.ProgressEvent === "undefined") {
   class TestProgressEvent extends Event implements ProgressEvent<EventTarget> {
     lengthComputable = false;


### PR DESCRIPTION
## Summary

Open the dropdown on focus (not just mouse click), expose aria-expanded / aria-controls / aria-activedescendant on the input, label the panel as a group, restore focus to the input on Escape, and let users navigate the list with ↑/↓/Home/End and apply with Enter. Active item scrolls into view, and a muted helper hint describes the shortcuts.

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
