### PR TITLE
Mirror package filter

### DIFF
--- a/.changeset/new-walls-accept.md
+++ b/.changeset/new-walls-accept.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": minor
+---
+
+Add mirror package filter options

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.module.scss
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.module.scss
@@ -1,3 +1,13 @@
+.wrapper {
+  align-items: flex-start;
+  display: flex;
+  flex-basis: 30rem;
+}
+
+.formContainer {
+  flex: 1;
+}
+
 .heading {
   margin-top: 1.5rem;
 }

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.module.scss
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.module.scss
@@ -1,0 +1,3 @@
+.heading {
+  margin-top: 1.5rem;
+}

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
@@ -30,6 +30,7 @@ import { UBUNTU_SNAPSHOTS_HOST } from "../../constants";
 import ReadOnlyField from "@/components/form/ReadOnlyField";
 import { isArchiveInfoValid } from "../../helpers";
 import * as Yup from "yup";
+import classes from "./AddMirrorForm.module.scss";
 
 const AddMirrorForm: FC = () => {
   const debug = useDebug();
@@ -103,6 +104,10 @@ const AddMirrorForm: FC = () => {
           downloadInstaller: values.downloadInstallerFiles,
           downloadSources: values.downloadSources,
           downloadUdebs: values.downloadUdebPackages,
+          filter: values.packageFilter,
+          filterWithDeps: values.packageFilter
+            ? values.includeDependencies
+            : undefined,
           gpgKey: values.verificationGpgKey
             ? {
                 armor: values.verificationGpgKey,
@@ -360,7 +365,23 @@ const AddMirrorForm: FC = () => {
                   <Icon name={ICONS.help} />
                 </Tooltip>
               </div>
-              <p>Download options:</p>
+              <p className={classes.heading}>Filter options:</p>
+              <Input
+                type="text"
+                label="Package filter"
+                {...formik.getFieldProps("packageFilter")}
+              />
+              <CheckboxInput
+                label="Include dependencies in filter"
+                {...formik.getFieldProps("includeDependencies")}
+                checked={
+                  !!formik.values.packageFilter &&
+                  formik.values.includeDependencies
+                }
+                disabled={!formik.values.packageFilter}
+                inline
+              />
+              <p className={classes.heading}>Download options:</p>
               <CheckboxInput
                 label="Download .udeb packages "
                 {...formik.getFieldProps("downloadUdebPackages")}

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
@@ -31,6 +31,7 @@ import ReadOnlyField from "@/components/form/ReadOnlyField";
 import { isArchiveInfoValid } from "../../helpers";
 import * as Yup from "yup";
 import classes from "./AddMirrorForm.module.scss";
+import MirrorFilterHelpButton from "../MirrorFilterHelpButton";
 
 const AddMirrorForm: FC = () => {
   const debug = useDebug();
@@ -366,11 +367,16 @@ const AddMirrorForm: FC = () => {
                 </Tooltip>
               </div>
               <p className={classes.heading}>Filter options:</p>
-              <Input
-                type="text"
-                label="Package filter"
-                {...formik.getFieldProps("packageFilter")}
-              />
+              <div className={classes.wrapper}>
+                <div className={classes.formContainer}>
+                  <Input
+                    type="text"
+                    label="Package filter"
+                    {...formik.getFieldProps("packageFilter")}
+                  />
+                </div>
+                <MirrorFilterHelpButton />
+              </div>
               <CheckboxInput
                 label="Include dependencies in filter"
                 {...formik.getFieldProps("includeDependencies")}

--- a/src/features/mirrors/components/AddMirrorForm/helpers.ts
+++ b/src/features/mirrors/components/AddMirrorForm/helpers.ts
@@ -95,6 +95,8 @@ export function getInitialBaseValues(
     downloadUdebPackages: false,
     downloadSources: false,
     downloadInstallerFiles: false,
+    packageFilter: "",
+    includeDependencies: false,
   };
 }
 

--- a/src/features/mirrors/components/AddMirrorForm/types.ts
+++ b/src/features/mirrors/components/AddMirrorForm/types.ts
@@ -13,6 +13,8 @@ export interface BaseFormProps {
   snapshotDate?: string;
   proService?: string;
   verificationGpgKey?: string;
+  packageFilter?: string;
+  includeDependencies?: boolean;
 }
 
 export interface UbuntuArchiveFormProps extends BaseFormProps {

--- a/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.module.scss
+++ b/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.module.scss
@@ -1,3 +1,13 @@
+.wrapper {
+  align-items: flex-start;
+  display: flex;
+  flex-basis: 30rem;
+}
+
+.formContainer {
+  flex: 1;
+}
+
 .heading {
   margin-top: 1.5rem;
 }

--- a/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.module.scss
+++ b/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.module.scss
@@ -1,0 +1,3 @@
+.heading {
+  margin-top: 1.5rem;
+}

--- a/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
+++ b/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
@@ -45,8 +45,8 @@ const EditMirrorForm: FC = () => {
       downloadSources: !!mirror.downloadSources,
       downloadInstallerFiles: !!mirror.downloadInstaller,
       verificationGpgKey: mirror.gpgKey?.armor,
-      packageFilter: undefined,
-      includeDependencies: false,
+      packageFilter: mirror.filter,
+      includeDependencies: mirror.filterWithDeps,
     },
 
     validationSchema: Yup.object().shape({
@@ -64,7 +64,7 @@ const EditMirrorForm: FC = () => {
           downloadSources: values.downloadSources,
           downloadInstaller: values.downloadInstallerFiles,
           gpgKey: { armor: values.verificationGpgKey || null },
-          filter: values.packageFilter || undefined,
+          filter: values.packageFilter,
           filterWithDeps: values.packageFilter
             ? values.includeDependencies
             : undefined,

--- a/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
+++ b/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
@@ -27,6 +27,7 @@ import {
 import ReadOnlyField from "@/components/form/ReadOnlyField";
 import * as Yup from "yup";
 import { NO_DATA_TEXT } from "@/components/layout/NoData";
+import classes from "./EditMirrorForm.module.scss";
 
 const EditMirrorForm: FC = () => {
   const debug = useDebug();
@@ -133,7 +134,23 @@ const EditMirrorForm: FC = () => {
                   <Icon name={ICONS.help} />
                 </Tooltip>
               </div>
-              <p>Download options:</p>
+              <p className={classes.heading}>Filter options:</p>
+              {/* <Input
+                type="text"
+                label="Package filter"
+                {...formik.getFieldProps("packageFilter")}
+              />
+              <CheckboxInput
+                label="Include dependencies in filter"
+                {...formik.getFieldProps("includeDependencies")}
+                checked={
+                  !!formik.values.packageFilter &&
+                  formik.values.includeDependencies
+                }
+                disabled={!formik.values.packageFilter}
+                inline
+              /> */}
+              <p className={classes.heading}>Download options:</p>
               <CheckboxInput
                 label="Download .udeb packages "
                 {...formik.getFieldProps("downloadUdebPackages")}

--- a/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
+++ b/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
@@ -45,6 +45,8 @@ const EditMirrorForm: FC = () => {
       downloadSources: !!mirror.downloadSources,
       downloadInstallerFiles: !!mirror.downloadInstaller,
       verificationGpgKey: mirror.gpgKey?.armor,
+      packageFilter: undefined,
+      includeDependencies: false,
     },
 
     validationSchema: Yup.object().shape({
@@ -62,6 +64,10 @@ const EditMirrorForm: FC = () => {
           downloadSources: values.downloadSources,
           downloadInstaller: values.downloadInstallerFiles,
           gpgKey: { armor: values.verificationGpgKey || null },
+          filter: values.packageFilter || undefined,
+          filterWithDeps: values.packageFilter
+            ? values.includeDependencies
+            : undefined,
         });
 
         closeSidePanel();
@@ -135,7 +141,7 @@ const EditMirrorForm: FC = () => {
                 </Tooltip>
               </div>
               <p className={classes.heading}>Filter options:</p>
-              {/* <Input
+              <Input
                 type="text"
                 label="Package filter"
                 {...formik.getFieldProps("packageFilter")}
@@ -149,7 +155,7 @@ const EditMirrorForm: FC = () => {
                 }
                 disabled={!formik.values.packageFilter}
                 inline
-              /> */}
+              />
               <p className={classes.heading}>Download options:</p>
               <CheckboxInput
                 label="Download .udeb packages "

--- a/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
+++ b/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
@@ -28,6 +28,7 @@ import ReadOnlyField from "@/components/form/ReadOnlyField";
 import * as Yup from "yup";
 import { NO_DATA_TEXT } from "@/components/layout/NoData";
 import classes from "./EditMirrorForm.module.scss";
+import MirrorFilterHelpButton from "../MirrorFilterHelpButton";
 
 const EditMirrorForm: FC = () => {
   const debug = useDebug();
@@ -141,11 +142,16 @@ const EditMirrorForm: FC = () => {
                 </Tooltip>
               </div>
               <p className={classes.heading}>Filter options:</p>
-              <Input
-                type="text"
-                label="Package filter"
-                {...formik.getFieldProps("packageFilter")}
-              />
+              <div className={classes.wrapper}>
+                <div className={classes.formContainer}>
+                  <Input
+                    type="text"
+                    label="Package filter"
+                    {...formik.getFieldProps("packageFilter")}
+                  />
+                </div>
+                <MirrorFilterHelpButton />
+              </div>
               <CheckboxInput
                 label="Include dependencies in filter"
                 {...formik.getFieldProps("includeDependencies")}

--- a/src/features/mirrors/components/EditMirrorForm/types.ts
+++ b/src/features/mirrors/components/EditMirrorForm/types.ts
@@ -5,4 +5,6 @@ export interface FormProps {
   downloadSources: boolean;
   downloadInstallerFiles: boolean;
   verificationGpgKey?: string;
+  packageFilter?: string;
+  includeDependencies?: boolean;
 }

--- a/src/features/mirrors/components/MirrorDetails/MirrorDetails.tsx
+++ b/src/features/mirrors/components/MirrorDetails/MirrorDetails.tsx
@@ -185,6 +185,18 @@ const MirrorDetails: FC = () => {
                   value={boolToLabel(mirror.preserveSignatures)}
                 />
                 <InfoGrid.Item
+                  label="Package filter"
+                  value={mirror.filter}
+                  large
+                />
+                {mirror.filter && (
+                  <InfoGrid.Item
+                    label="Include dependencies in filter"
+                    value={boolToLabel(mirror.filterWithDeps)}
+                    large
+                  />
+                )}
+                <InfoGrid.Item
                   label="Download .udeb"
                   value={boolToLabel(mirror.downloadUdebs)}
                 />

--- a/src/features/mirrors/components/MirrorFilterHelpButton/MirrorFilterHelpButton.module.scss
+++ b/src/features/mirrors/components/MirrorFilterHelpButton/MirrorFilterHelpButton.module.scss
@@ -33,7 +33,14 @@
 }
 
 .modal {
-  table {
-    width: 60rem;
+  p {
+    max-width: 60rem;
   }
+}
+
+.tableWrapper {
+  max-height: 55vh;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  width: 100%;
 }

--- a/src/features/mirrors/components/MirrorFilterHelpButton/MirrorFilterHelpButton.module.scss
+++ b/src/features/mirrors/components/MirrorFilterHelpButton/MirrorFilterHelpButton.module.scss
@@ -1,0 +1,39 @@
+@import "vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/settings_spacing";
+
+.helpButton {
+  margin-top: 2.5rem;
+
+  &,
+  &:active,
+  &:focus,
+  &:hover {
+    background-color: $colors--theme--background-inputs;
+    border-bottom: $input-border-thickness solid
+      $colors--theme--border-high-contrast;
+    border-left: 0;
+    border-right: 0;
+    padding-left: calc($sph--large + $sph--x-small);
+    padding-right: calc($sph--large + $sph--x-small);
+    position: relative;
+  }
+
+  &::before {
+    border-left: 1px solid $color-mid-light;
+    bottom: 2px;
+    content: "";
+    left: 0;
+    position: absolute;
+    top: 2px;
+  }
+}
+
+.term {
+  width: 30%;
+}
+
+.modal {
+  table {
+    width: 60rem;
+  }
+}

--- a/src/features/mirrors/components/MirrorFilterHelpButton/MirrorFilterHelpButton.tsx
+++ b/src/features/mirrors/components/MirrorFilterHelpButton/MirrorFilterHelpButton.tsx
@@ -12,6 +12,7 @@ import { useBoolean } from "usehooks-ts";
 import type { Column } from "react-table";
 import type { Term } from "./types";
 import { PACKAGE_FILTER_HELP_DATA } from "./constants";
+import { createPortal } from "react-dom";
 
 const MirrorFilterHelpButton: FC = () => {
   const {
@@ -47,29 +48,34 @@ const MirrorFilterHelpButton: FC = () => {
       >
         <Icon name={ICONS.help} />
       </Button>
-      {isModalOpen && (
-        <Modal
-          title="Package query syntax"
-          close={closeModal}
-          className={classes.modal}
-        >
-          <p>
-            Available search terms for use in package queries. If multiple terms
-            are separated by <code>|</code> (OR), any of the conditions will
-            match. Terms separated by <code>,</code> (AND) must all match. When
-            a term is preceded by <code>!</code> (NOT), the condition must not
-            match. Use parentheses <code>()</code> to group terms. Values
-            containing spaces or ambiguous characters must be quoted with{" "}
-            <code>&apos;</code> or <code>&quot;</code> (escape inner quotes with{" "}
-            <code>\</code>).
-          </p>
-          <ModularTable
-            className="u-no-margin--bottom"
-            columns={columns}
-            data={PACKAGE_FILTER_HELP_DATA}
-          />
-        </Modal>
-      )}
+      {isModalOpen &&
+        createPortal(
+          <Modal
+            title="Package query syntax"
+            close={closeModal}
+            className={classes.modal}
+          >
+            <p>
+              Available search terms for use in package queries. If multiple
+              terms are separated by <code>|</code> (OR), any of the conditions
+              will match. Terms separated by <code>,</code> (AND) must all
+              match. When a term is preceded by <code>!</code> (NOT), the
+              condition must not match. Use parentheses <code>()</code> to group
+              terms. Values containing spaces or ambiguous characters must be
+              quoted with <code>&apos;</code> or <code>&quot;</code> (escape
+              inner quotes with <code>\</code>).
+            </p>
+            <div className={classes.tableWrapper}>
+              <ModularTable
+                className="u-no-margin--bottom"
+                columns={columns}
+                data={PACKAGE_FILTER_HELP_DATA}
+                style={{ minWidth: "60rem" }}
+              />
+            </div>
+          </Modal>,
+          document.body,
+        )}
     </>
   );
 };

--- a/src/features/mirrors/components/MirrorFilterHelpButton/MirrorFilterHelpButton.tsx
+++ b/src/features/mirrors/components/MirrorFilterHelpButton/MirrorFilterHelpButton.tsx
@@ -1,0 +1,77 @@
+import {
+  Button,
+  Icon,
+  ICONS,
+  Modal,
+  ModularTable,
+} from "@canonical/react-components";
+import classNames from "classnames";
+import { useMemo, type FC } from "react";
+import classes from "./MirrorFilterHelpButton.module.scss";
+import { useBoolean } from "usehooks-ts";
+import type { Column } from "react-table";
+import type { Term } from "./types";
+import { PACKAGE_FILTER_HELP_DATA } from "./constants";
+
+const MirrorFilterHelpButton: FC = () => {
+  const {
+    value: isModalOpen,
+    setTrue: openModal,
+    setFalse: closeModal,
+  } = useBoolean();
+
+  const columns = useMemo<Column<Term>[]>(
+    () => [
+      {
+        Header: "Term",
+        accessor: "term",
+        className: classes.term,
+      },
+      {
+        Header: "Description",
+        accessor: "description",
+      },
+    ],
+    [],
+  );
+
+  return (
+    <>
+      <Button
+        type="button"
+        appearance="base"
+        hasIcon
+        className={classNames("u-no-margin--bottom", classes.helpButton)}
+        onClick={openModal}
+        aria-label="Help"
+      >
+        <Icon name={ICONS.help} />
+      </Button>
+      {isModalOpen && (
+        <Modal
+          title="Package query syntax"
+          close={closeModal}
+          className={classes.modal}
+        >
+          <p>
+            Available search terms for use in package queries. If multiple terms
+            are separated by <code>|</code> (OR), any of the conditions will
+            match. Terms separated by <code>,</code> (AND) must all match. When
+            a term is preceded by <code>!</code> (NOT), the condition must not
+            match. Use parentheses <code>()</code> to group terms. Values
+            containing spaces or ambiguous characters must be quoted with{" "}
+            <code>&apos;</code> or <code>&quot;</code> (escape inner quotes with{" "}
+            <code>\</code>).
+          </p>
+          <ModularTable
+            className="u-no-margin--bottom"
+            columns={columns}
+            data={PACKAGE_FILTER_HELP_DATA}
+          />
+        </Modal>
+      )}
+    </>
+  );
+};
+
+export default MirrorFilterHelpButton;

--- a/src/features/mirrors/components/MirrorFilterHelpButton/constants.tsx
+++ b/src/features/mirrors/components/MirrorFilterHelpButton/constants.tsx
@@ -1,0 +1,211 @@
+import type { Term } from "./types";
+
+export const PACKAGE_FILTER_HELP_DATA: Term[] = [
+  {
+    term: <code>name_version_arch</code>,
+    description: (
+      <>
+        Direct reference to exactly one package (e.g.{" "}
+        <code>libmysqlclient18_5.5.35-rel33.0-611.squeeze_amd64</code>).
+      </>
+    ),
+  },
+  {
+    term: <code>{"<package>"}</code>,
+    description: (
+      <>
+        Matches the named package at any version/architecture (including
+        source), and packages that <code>Provide:</code> it.
+      </>
+    ),
+  },
+  {
+    term: <code>{"<package> (<op> <version>)"}</code>,
+    description: (
+      <>
+        Dependency condition with version constraint (e.g.{" "}
+        <code>mysql-client ({">"}= 3.6)</code>).
+      </>
+    ),
+  },
+  {
+    term: <code>{"<package> {<arch>}"}</code>,
+    description: (
+      <>
+        Dependency condition limited to an architecture (e.g.{" "}
+        <code>mysql-client {"{i386}"}</code>). A package whose own architecture
+        is <code>all</code> matches any queried architecture except{" "}
+        <code>source</code>.
+      </>
+    ),
+  },
+  {
+    term: <code>{"<package> (<op> <version>) {<arch>}"}</code>,
+    description: "Combined version and architecture condition.",
+  },
+  {
+    term: <code>{"<field> (<op> <value>)"}</code>,
+    description: (
+      <>
+        Match against a package field (e.g. <code>Priority (optional)</code>,{" "}
+        <code>Name (~ .*-dev)</code>).
+      </>
+    ),
+  },
+  {
+    term: <i>Debian control fields</i>,
+    description: (
+      <>
+        All standard control fields are supported <b>except</b>{" "}
+        <code>Filename</code>, <code>MD5sum</code>, <code>SHA1</code>,{" "}
+        <code>SHA256</code>, <code>Size</code>, <code>Files</code>,{" "}
+        <code>Checksums-SHA1</code>, <code>Checksums-SHA256</code>.
+      </>
+    ),
+  },
+  {
+    term: <code>$Source</code>,
+    description: "Name of the source package (for binary packages).",
+  },
+  {
+    term: <code>$SourceVersion</code>,
+    description: "Version of the source package.",
+  },
+  {
+    term: <code>$Architecture</code>,
+    description: (
+      <>
+        Architecture for binary packages; <code>source</code> for source
+        packages. With <code>=</code>, a package of architecture{" "}
+        <code>any</code> matches every architecture except <code>source</code>.
+      </>
+    ),
+  },
+  {
+    term: <code>$Version</code>,
+    description: (
+      <>
+        Same value as <code>Version</code>, but comparisons use Debian version
+        precedence rules.
+      </>
+    ),
+  },
+  {
+    term: <code>$PackageType</code>,
+    description: (
+      <>
+        <code>deb</code> for binary packages, <code>udeb</code> for{" "}
+        <code>.udeb</code> packages, <code>source</code> for source packages.
+      </>
+    ),
+  },
+  {
+    term: <code>=</code>,
+    description: "Strict match. Default operator if none is given.",
+  },
+  {
+    term: (
+      <>
+        {" "}
+        <code>{">="}</code> <code>{"<="}</code> <code>{">>"}</code>{" "}
+        <code>{"<<"}</code>
+      </>
+    ),
+    description: (
+      <>
+        Comparison operators. Lexicographical for most fields; Debian version
+        rules for package versions. <code>{">>"}</code> is strictly greater,{" "}
+        <code>{"<<"}</code> is strictly less.
+      </>
+    ),
+  },
+  {
+    term: <code>%</code>,
+    description: (
+      <>
+        Shell-style pattern matching. Supports <code>[^]</code>, <code>?</code>,{" "}
+        <code>*</code> (e.g. <code>$Version (% 3.5-*)</code>).
+      </>
+    ),
+  },
+  {
+    term: <code>~</code>,
+    description: (
+      <>
+        Regular expression matching (e.g. <code>Name (~ .*-dev)</code>).
+      </>
+    ),
+  },
+  {
+    term: <code>,</code>,
+    description: "Logical AND — combines terms; all must match.",
+  },
+  {
+    term: <code>|</code>,
+    description: "Logical OR — combines terms; any may match.",
+  },
+  {
+    term: <code>!</code>,
+    description: "Logical NOT — negates the following term.",
+  },
+  {
+    term: <code>( ... )</code>,
+    description: "Grouping to control operator precedence.",
+  },
+  {
+    term: <code>mysql-client</code>,
+    description: (
+      <>
+        Example: matches <code>mysql-client</code> at any version/architecture
+        (including source), plus packages that Provide it.
+      </>
+    ),
+  },
+  {
+    term: <code>mysql-client ({">"}= 3.6)</code>,
+    description: (
+      <>
+        Example: <code>mysql-client</code> at version ≥ 3.6.
+      </>
+    ),
+  },
+  {
+    term: <code>mysql-client {"{i386}"}</code>,
+    description: (
+      <>
+        Example: <code>mysql-client</code> on the i386 architecture.
+      </>
+    ),
+  },
+  {
+    term: <code>$Source (nginx)</code>,
+    description: (
+      <>
+        Example: all binary packages built from source package{" "}
+        <code>nginx</code>.
+      </>
+    ),
+  },
+  {
+    term: <code>!Name (~ .*-dev), mail-transport, $Version ({">="} 3.5)</code>,
+    description: (
+      <>
+        Example: provides <code>mail-transport</code>, name does not end in{" "}
+        <code>-dev</code>, version ≥ 3.5.
+      </>
+    ),
+  },
+  {
+    term: <code>Name</code>,
+    description: 'Example: matches every package (i.e. "name is not empty").',
+  },
+  {
+    term: <code>Name (% http-*) | $Source (webserver)</code>,
+    description: (
+      <>
+        Example: name matches <code>http-*</code> OR built from source{" "}
+        <code>webserver</code>.
+      </>
+    ),
+  },
+];

--- a/src/features/mirrors/components/MirrorFilterHelpButton/index.ts
+++ b/src/features/mirrors/components/MirrorFilterHelpButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MirrorFilterHelpButton";

--- a/src/features/mirrors/components/MirrorFilterHelpButton/types.ts
+++ b/src/features/mirrors/components/MirrorFilterHelpButton/types.ts
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+
+export interface Term extends Record<string, unknown> {
+  term: ReactNode;
+  description: ReactNode;
+}


### PR DESCRIPTION
## Summary

Add mirror package filter options

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [ ] Patch (fix)
- [x] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
