### PR TITLE
Switch profiles side panels to new cancel design

### DIFF
--- a/.changeset/polite-hands-thank.md
+++ b/.changeset/polite-hands-thank.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Fix profiles sidepanels cancel and close behavior to be consistent with new design

--- a/src/components/layout/Blocks/Item/Item.module.scss
+++ b/src/components/layout/Blocks/Item/Item.module.scss
@@ -9,6 +9,12 @@
   }
 }
 
+:global(.p-panel__content) {
+  .item:first-child {
+    padding-top: 0;
+  }
+}
+
 .heading {
   margin: 0 0 $sp-unit * 4;
   padding: 0;

--- a/src/components/layout/SidePanel/Content.tsx
+++ b/src/components/layout/SidePanel/Content.tsx
@@ -5,12 +5,15 @@ import classes from "./SidePanel.module.scss";
 
 const Content: FC<ComponentProps<typeof SidePanel.Content>> = ({
   className,
+  children,
   ...props
 }) => (
   <SidePanel.Content
     className={classNames(classes.content, className)}
     {...props}
-  />
+  >
+    <div className={classes.inner}>{children}</div>
+  </SidePanel.Content>
 );
 
 export default Content;

--- a/src/components/layout/SidePanel/SidePanel.module.scss
+++ b/src/components/layout/SidePanel/SidePanel.module.scss
@@ -1,8 +1,17 @@
+@import "vanilla-framework/scss/settings_spacing";
+
 .content {
   display: flex;
-  flex-direction: column;
-  min-height: 0;
+  flex-grow: 1;
   overflow: visible;
+  padding-bottom: $sp-unit * 4;
+}
+
+.inner {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  max-width: 100%;
 }
 
 .sidePanel {

--- a/src/features/package-profiles/components/PackageProfileAddSidePanel/PackageProfileAddSidePanel.tsx
+++ b/src/features/package-profiles/components/PackageProfileAddSidePanel/PackageProfileAddSidePanel.tsx
@@ -19,7 +19,7 @@ import { INITIAL_VALUES, VALIDATION_SCHEMA } from "./constants";
 const PackageProfileAddSidePanel: FC = () => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { createPageParamsSetter } = usePageParams();
+  const { closeSidePanel } = usePageParams();
   const { getAccessGroupQuery } = useRoles();
   const { createPackageProfileQuery } = usePackageProfiles();
 
@@ -33,8 +33,6 @@ const PackageProfileAddSidePanel: FC = () => {
     })) ?? [];
 
   const { mutateAsync: createPackageProfile } = createPackageProfileQuery;
-
-  const closeSidePanel = createPageParamsSetter({ sidePath: [], name: "" });
 
   const handleSubmit = async (values: AddFormProps) => {
     const valuesToProfileCreation: CreatePackageProfileParams = {

--- a/src/features/package-profiles/components/PackageProfileConstraintsAddSidePanel/components/PackageProfileConstraintsAddForm/PackageProfileConstraintsAddForm.tsx
+++ b/src/features/package-profiles/components/PackageProfileConstraintsAddSidePanel/components/PackageProfileConstraintsAddForm/PackageProfileConstraintsAddForm.tsx
@@ -23,7 +23,7 @@ const PackageProfileConstraintsAddForm: FC<
   const cancel = useContext(CloseContext);
   const debug = useDebug();
   const { notify } = useNotify();
-  const { sidePath, popSidePath } = usePageParams();
+  const { popSidePath } = usePageParams();
   const { addPackageProfileConstraintsQuery } = usePackageProfiles();
 
   const { mutateAsync: addConstraints } = addPackageProfileConstraintsQuery;
@@ -71,8 +71,6 @@ const PackageProfileConstraintsAddForm: FC<
         submitButtonText={`Add ${pluralize(formik.values.constraints.length, "constraint")}`}
         submitButtonAriaLabel={`Add ${pluralize(formik.values.constraints.length, "constraint")} to "${profile.title}" profile`}
         cancelButtonDisabled={formik.isSubmitting}
-        hasBackButton={sidePath.length > 1}
-        onBackButtonPress={popSidePath}
         onCancel={cancel}
       />
     </Form>

--- a/src/features/package-profiles/components/PackageProfileDuplicateSidePanel/components/PackageProfileDuplicateForm/PackageProfileDuplicateForm.tsx
+++ b/src/features/package-profiles/components/PackageProfileDuplicateSidePanel/components/PackageProfileDuplicateForm/PackageProfileDuplicateForm.tsx
@@ -24,7 +24,7 @@ const PackageProfileDuplicateForm: FC<PackageProfileDuplicateFormProps> = ({
   profile,
 }) => {
   const debug = useDebug();
-  const { sidePath, popSidePath, createPageParamsSetter } = usePageParams();
+  const { closeSidePanel, popSidePathUntilClear } = usePageParams();
   const { notify } = useNotify();
   const { getAccessGroupQuery } = useRoles();
   const { copyPackageProfileQuery } = usePackageProfiles();
@@ -38,8 +38,6 @@ const PackageProfileDuplicateForm: FC<PackageProfileDuplicateFormProps> = ({
       label: title,
       value: name,
     })) ?? [];
-
-  const closeSidePanel = createPageParamsSetter({ sidePath: [], name: "" });
 
   const handleSubmit = async (values: DuplicateFormProps) => {
     const valuesToSubmit: CopyPackageProfileParams = {
@@ -111,9 +109,7 @@ const PackageProfileDuplicateForm: FC<PackageProfileDuplicateFormProps> = ({
       <SidePanelFormButtons
         submitButtonLoading={formik.isSubmitting}
         submitButtonText="Duplicate"
-        hasBackButton={sidePath.length > 1}
-        onBackButtonPress={popSidePath}
-        onCancel={closeSidePanel}
+        onCancel={popSidePathUntilClear}
       />
     </Form>
   );

--- a/src/features/package-profiles/components/PackageProfileEditSidePanel/components/PackageProfileEditForm/PackageProfileEditForm.tsx
+++ b/src/features/package-profiles/components/PackageProfileEditSidePanel/components/PackageProfileEditForm/PackageProfileEditForm.tsx
@@ -22,15 +22,13 @@ const PackageProfileEditForm: FC<PackageProfileEditFormProps> = ({
   profile,
 }) => {
   const debug = useDebug();
-  const { sidePath, popSidePath, createPageParamsSetter } = usePageParams();
+  const { closeSidePanel, popSidePathUntilClear } = usePageParams();
   const { notify } = useNotify();
   const { editPackageProfileQuery } = usePackageProfiles();
   const { getAccessGroupQuery } = useRoles();
 
   const { data: accessGroupsData } = getAccessGroupQuery();
   const { mutateAsync: editPackageProfile } = editPackageProfileQuery;
-
-  const closeSidePanel = createPageParamsSetter({ sidePath: [], name: "" });
 
   const handleSubmit = async (values: EditFormProps) => {
     try {
@@ -89,9 +87,7 @@ const PackageProfileEditForm: FC<PackageProfileEditFormProps> = ({
       <SidePanelFormButtons
         submitButtonLoading={formik.isSubmitting}
         submitButtonText="Save changes"
-        hasBackButton={sidePath.length > 1}
-        onBackButtonPress={popSidePath}
-        onCancel={closeSidePanel}
+        onCancel={popSidePathUntilClear}
       />
     </Form>
   );

--- a/src/features/profiles/components/AddProfileButton/AddProfileButton.test.tsx
+++ b/src/features/profiles/components/AddProfileButton/AddProfileButton.test.tsx
@@ -1,6 +1,5 @@
 import { renderWithProviders } from "@/tests/render";
 import { screen } from "@testing-library/react";
-import { within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AddProfileButton from "./AddProfileButton";
@@ -24,7 +23,6 @@ describe("AddProfileButton", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    localStorage.clear();
 
     mockCreatePageParamsSetter.mockReturnValue(openAddSidePanel);
 
@@ -45,42 +43,12 @@ describe("AddProfileButton", () => {
     ).not.toHaveClass("p-button--positive");
   });
 
-  it("opens add side panel for non-WSL type", async () => {
+  it("opens add side panel on click", async () => {
     renderWithProviders(<AddProfileButton />);
 
     await userEvent.click(screen.getByRole("button", { name: /add profile/i }));
 
     expect(openAddSidePanel).toHaveBeenCalledTimes(1);
-  });
-
-  it("opens confirmation modal for WSL when not acknowledged", async () => {
-    renderWithProviders(<AddProfileButton />, undefined, "/profiles/wsl");
-
-    await userEvent.click(screen.getByRole("button", { name: /add profile/i }));
-
-    expect(
-      screen.getByText("WSL profiles is a beta feature"),
-    ).toBeInTheDocument();
-
-    const modal = screen.getByRole("dialog");
-    await userEvent.click(
-      within(modal).getByRole("button", { name: /add WSL profile/i }),
-    );
-
-    expect(openAddSidePanel).toHaveBeenCalledTimes(1);
-  });
-
-  it("skips modal for WSL when already acknowledged", async () => {
-    localStorage.setItem("_landscape_isWslPopupClosed", "true");
-
-    renderWithProviders(<AddProfileButton />, undefined, "/profiles/wsl");
-
-    await userEvent.click(screen.getByRole("button", { name: /add profile/i }));
-
-    expect(openAddSidePanel).toHaveBeenCalledTimes(1);
-    expect(
-      screen.queryByText("WSL profiles is a beta feature"),
-    ).not.toBeInTheDocument();
   });
 
   it("disables button when profile limit is reached", () => {

--- a/src/features/profiles/components/AddProfileButton/AddProfileButton.tsx
+++ b/src/features/profiles/components/AddProfileButton/AddProfileButton.tsx
@@ -1,12 +1,7 @@
-import { Button, ConfirmationModal, Icon } from "@canonical/react-components";
+import { Button, Icon } from "@canonical/react-components";
 import { type FC } from "react";
-import { useLocation } from "react-router";
 import useProfiles from "@/hooks/useProfiles";
 import usePageParams from "@/hooks/usePageParams";
-import { useBoolean } from "usehooks-ts";
-import { PROFILES_PATHS } from "@/libs/routes/profiles";
-
-const LOCAL_STORAGE_ITEM = "_landscape_isWslPopupClosed";
 
 interface AddProfileButtonProps {
   readonly isInsideScriptHeader?: boolean;
@@ -15,8 +10,6 @@ interface AddProfileButtonProps {
 const AddProfileButton: FC<AddProfileButtonProps> = ({
   isInsideScriptHeader = false,
 }) => {
-  const { pathname } = useLocation();
-  const isWsl = pathname.includes(`/${PROFILES_PATHS.wsl}`);
   const { createPageParamsSetter } = usePageParams();
   const { isProfileLimitReached } = useProfiles();
 
@@ -24,62 +17,23 @@ const AddProfileButton: FC<AddProfileButtonProps> = ({
     ? { className: "u-no-margin--bottom" }
     : { appearance: "positive", light: true };
 
-  const { value: isModalRead, setTrue: readModal } = useBoolean(
-    !!localStorage.getItem(LOCAL_STORAGE_ITEM),
-  );
-
-  const {
-    value: isModalOpen,
-    setTrue: openModal,
-    setFalse: closeModal,
-  } = useBoolean();
-
   const openAddSidePanel = createPageParamsSetter({
     sidePath: ["add"],
     name: "",
   });
 
-  const handleClick = () => {
-    if (isWsl && !isModalRead) {
-      openModal();
-    } else {
-      openAddSidePanel();
-    }
-  };
-
-  const handleConfirm = () => {
-    closeModal();
-    openAddSidePanel();
-    localStorage.setItem(LOCAL_STORAGE_ITEM, "true");
-    readModal();
-  };
-
   return (
-    <>
-      <Button
-        type="button"
-        appearance={settings.appearance}
-        className={settings.className}
-        onClick={handleClick}
-        hasIcon
-        disabled={isProfileLimitReached}
-      >
-        <Icon name="plus" light={settings.light} />
-        <span>Add profile</span>
-      </Button>
-
-      {isModalOpen && (
-        <ConfirmationModal
-          close={closeModal}
-          title="WSL profiles is a beta feature"
-          onConfirm={handleConfirm}
-          confirmButtonLabel="Add WSL profile"
-          confirmButtonAppearance="positive"
-        >
-          <p>We are gathering feedback to improve this feature.</p>
-        </ConfirmationModal>
-      )}
-    </>
+    <Button
+      type="button"
+      appearance={settings.appearance}
+      className={settings.className}
+      onClick={openAddSidePanel}
+      hasIcon
+      disabled={isProfileLimitReached}
+    >
+      <Icon name="plus" light={settings.light} />
+      <span>Add profile</span>
+    </Button>
   );
 };
 

--- a/src/features/profiles/hooks/useGetProfileActions.ts
+++ b/src/features/profiles/hooks/useGetProfileActions.ts
@@ -17,6 +17,7 @@ import { useOpenProfileSidePanel } from "./useOpenProfileSidePanel";
 import type { USGProfileMode } from "@/features/usg-profiles";
 import useProfiles from "@/hooks/useProfiles";
 import type { Profile } from "../types";
+import usePageParams from "@/hooks/usePageParams/usePageParams";
 
 interface UseGetProfileActionsProps {
   readonly profile: Profile;
@@ -32,6 +33,7 @@ export const useGetProfileActions = ({
   const openProfileSidePanel = useOpenProfileSidePanel();
   const { runUsgProfile } = useRunUsgProfile();
   const { isProfileLimitReached } = useProfiles();
+  const { closeSidePanel } = usePageParams();
   const debug = useDebug();
   const navigate = useNavigate();
   const { notify } = useNotify();
@@ -50,6 +52,8 @@ export const useGetProfileActions = ({
   const handleRunUsgProfile = async (mode: USGProfileMode) => {
     try {
       const { data: activity } = await runUsgProfile({ id: profile.id });
+
+      closeSidePanel();
 
       const message = getNotificationMessage(mode);
 

--- a/src/features/reboot-profiles/components/RebootProfilesForm/RebootProfilesForm.tsx
+++ b/src/features/reboot-profiles/components/RebootProfilesForm/RebootProfilesForm.tsx
@@ -36,7 +36,7 @@ import type { FormProps, RebootProfilesFormProps } from "./types";
 const RebootProfilesForm: FC<RebootProfilesFormProps> = (props) => {
   const { getAccessGroupQuery } = useRoles();
   const debug = useDebug();
-  const { sidePath, popSidePath, createPageParamsSetter } = usePageParams();
+  const { closeSidePanel, popSidePathUntilClear } = usePageParams();
   const { notify } = useNotify();
 
   const { data: accessGroupsData } = getAccessGroupQuery();
@@ -49,8 +49,6 @@ const RebootProfilesForm: FC<RebootProfilesFormProps> = (props) => {
       label: title,
       value: name,
     })) ?? [];
-
-  const closeSidePanel = createPageParamsSetter({ sidePath: [], name: "" });
 
   const formik = useFormik<FormProps>({
     initialValues: getInitialValues(props),
@@ -240,9 +238,7 @@ const RebootProfilesForm: FC<RebootProfilesFormProps> = (props) => {
             isCreatingRebootProfile ||
             isEditingRebootProfile
           }
-          onCancel={closeSidePanel}
-          hasBackButton={sidePath.length > 1}
-          onBackButtonPress={popSidePath}
+          onCancel={popSidePathUntilClear}
         />
       </Form>
     </FormikProvider>

--- a/src/features/removal-profiles/components/SingleRemovalProfileForm/SingleRemovalProfileForm.tsx
+++ b/src/features/removal-profiles/components/SingleRemovalProfileForm/SingleRemovalProfileForm.tsx
@@ -30,7 +30,7 @@ type SingleRemovalProfileFormProps =
 const SingleRemovalProfileForm: FC<SingleRemovalProfileFormProps> = (props) => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { sidePath, popSidePath, createPageParamsSetter } = usePageParams();
+  const { popSidePathUntilClear, closeSidePanel } = usePageParams();
   const { createRemovalProfileQuery, editRemovalProfileQuery } =
     useRemovalProfiles();
   const { getAccessGroupQuery } = useRoles();
@@ -48,8 +48,6 @@ const SingleRemovalProfileForm: FC<SingleRemovalProfileFormProps> = (props) => {
 
   const { mutateAsync: createRemovalProfile } = createRemovalProfileQuery;
   const { mutateAsync: editRemovalProfile } = editRemovalProfileQuery;
-
-  const closeSidePanel = createPageParamsSetter({ sidePath: [], name: "" });
 
   const handleSubmit = async (values: FormProps) => {
     const valuesToSubmit: CreateRemovalProfileParams = {
@@ -147,9 +145,7 @@ const SingleRemovalProfileForm: FC<SingleRemovalProfileFormProps> = (props) => {
       <SidePanelFormButtons
         submitButtonDisabled={formik.isSubmitting}
         submitButtonText={CTA_LABELS[props.action]}
-        onCancel={closeSidePanel}
-        hasBackButton={sidePath.length > 1}
-        onBackButtonPress={popSidePath}
+        onCancel={popSidePathUntilClear}
       />
     </Form>
   );

--- a/src/features/repository-profiles/components/RepositoryProfileDetails/RepositoryProfileDetails.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileDetails/RepositoryProfileDetails.tsx
@@ -34,10 +34,9 @@ const aptSourceColumns: Column<APTSource>[] = [
 ];
 
 const RepositoryProfileDetails: FC = () => {
-  const { name, createPageParamsSetter, createSidePathPusher } =
+  const { name, closeSidePanel, createSidePathPusher } =
     usePageParams();
   const profile = useGetRepositoryProfile(name).data;
-  const closePanel = createPageParamsSetter({ sidePath: [], name: "" });
   const debug = useDebug();
   const { notify } = useNotify();
 
@@ -77,7 +76,7 @@ const RepositoryProfileDetails: FC = () => {
         message: `Repository profile "${profile.title}" removed successfully`,
       });
 
-      closePanel();
+      closeSidePanel();
     } catch (error) {
       debug(error);
     } finally {

--- a/src/features/repository-profiles/components/RepositoryProfileDetails/RepositoryProfileDetails.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileDetails/RepositoryProfileDetails.tsx
@@ -34,8 +34,7 @@ const aptSourceColumns: Column<APTSource>[] = [
 ];
 
 const RepositoryProfileDetails: FC = () => {
-  const { name, closeSidePanel, createSidePathPusher } =
-    usePageParams();
+  const { name, closeSidePanel, createSidePathPusher } = usePageParams();
   const profile = useGetRepositoryProfile(name).data;
   const debug = useDebug();
   const { notify } = useNotify();

--- a/src/features/script-profiles/components/ScriptProfileForm/ScriptProfileForm.tsx
+++ b/src/features/script-profiles/components/ScriptProfileForm/ScriptProfileForm.tsx
@@ -63,11 +63,9 @@ const ScriptProfileForm: FC<ScriptProfileFormProps> = ({
   submitting = false,
 }) => {
   const debug = useDebug();
-  const { sidePath, popSidePath, createPageParamsSetter } = usePageParams();
+  const { popSidePathUntilClear, closeSidePanel } = usePageParams();
   const { scriptProfileLimits, isGettingScriptProfileLimits } =
     useGetScriptProfileLimits();
-
-  const closeSidePanel = createPageParamsSetter({ sidePath: [], name: "" });
 
   const formik = useFormik<ScriptProfileFormValues>({
     initialValues,
@@ -378,9 +376,7 @@ const ScriptProfileForm: FC<ScriptProfileFormProps> = ({
         }
         submitButtonLoading={submitting}
         submitButtonText={submitButtonText}
-        onCancel={closeSidePanel}
-        hasBackButton={sidePath.length > 1}
-        onBackButtonPress={popSidePath}
+        onCancel={popSidePathUntilClear}
       />
     </Form>
   );

--- a/src/features/script-profiles/components/ScriptProfilesTab/ScriptProfilesTab.tsx
+++ b/src/features/script-profiles/components/ScriptProfilesTab/ScriptProfilesTab.tsx
@@ -112,10 +112,7 @@ const ScriptProfilesTab: FC = () => {
         }
       />
 
-      <SidePanel
-        onClose={popSidePathUntilClear}
-        isOpen={!!sidePath.length}
-      >
+      <SidePanel onClose={popSidePathUntilClear} isOpen={!!sidePath.length}>
         {lastSidePathSegment === "add" && (
           <SidePanel.Suspense key="add">
             <ScriptProfileAddSidePanel />

--- a/src/features/script-profiles/components/ScriptProfilesTab/ScriptProfilesTab.tsx
+++ b/src/features/script-profiles/components/ScriptProfilesTab/ScriptProfilesTab.tsx
@@ -26,7 +26,7 @@ const ScriptProfileEditSidePanel = lazy(
 );
 
 const ScriptProfilesTab: FC = () => {
-  const { sidePath, lastSidePathSegment, createPageParamsSetter } =
+  const { sidePath, lastSidePathSegment, popSidePathUntilClear } =
     usePageParams();
 
   const {
@@ -113,7 +113,7 @@ const ScriptProfilesTab: FC = () => {
       />
 
       <SidePanel
-        onClose={createPageParamsSetter({ sidePath: [], name: "" })}
+        onClose={popSidePathUntilClear}
         isOpen={!!sidePath.length}
       >
         {lastSidePathSegment === "add" && (

--- a/src/features/upgrade-profiles/components/SingleUpgradeProfileForm/SingleUpgradeProfileForm.tsx
+++ b/src/features/upgrade-profiles/components/SingleUpgradeProfileForm/SingleUpgradeProfileForm.tsx
@@ -29,7 +29,7 @@ type SingleUpgradeProfileFormProps =
 const SingleUpgradeProfileForm: FC<SingleUpgradeProfileFormProps> = (props) => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { sidePath, popSidePath, createPageParamsSetter } = usePageParams();
+  const { popSidePathUntilClear, closeSidePanel } = usePageParams();
   const { createUpgradeProfileQuery, editUpgradeProfileQuery } =
     useUpgradeProfiles();
   const { getAccessGroupQuery } = useRoles();
@@ -47,8 +47,6 @@ const SingleUpgradeProfileForm: FC<SingleUpgradeProfileFormProps> = (props) => {
 
   const { mutateAsync: createUpgradeProfile } = createUpgradeProfileQuery;
   const { mutateAsync: editUpgradeProfile } = editUpgradeProfileQuery;
-
-  const closeSidePanel = createPageParamsSetter({ sidePath: [], name: "" });
 
   const handleSubmit = async (values: FormProps) => {
     const valuesToSubmit: CreateUpgradeProfileParams = {
@@ -189,9 +187,7 @@ const SingleUpgradeProfileForm: FC<SingleUpgradeProfileFormProps> = (props) => {
       <SidePanelFormButtons
         submitButtonDisabled={formik.isSubmitting}
         submitButtonText={CTA_LABELS[props.action]}
-        onCancel={closeSidePanel}
-        hasBackButton={sidePath.length > 1}
-        onBackButtonPress={popSidePath}
+        onCancel={popSidePathUntilClear}
       />
     </Form>
   );

--- a/src/features/usg-profiles/components/USGProfileAddSidePanel/USGProfileAddSidePanel.tsx
+++ b/src/features/usg-profiles/components/USGProfileAddSidePanel/USGProfileAddSidePanel.tsx
@@ -21,7 +21,7 @@ const USGProfileAddSidePanel: FC<USGProfileAddSidePanelProps> = ({
   showRetentionNotification,
 }) => {
   const { notify } = useNotify();
-  const { createPageParamsSetter } = usePageParams();
+  const { closeSidePanel } = usePageParams();
 
   const { addUsgProfile, isUsgProfileAdding } = useAddUsgProfile();
 
@@ -104,7 +104,7 @@ const USGProfileAddSidePanel: FC<USGProfileAddSidePanelProps> = ({
           }
           submitButtonLoading={steps[step].isLoading || isUsgProfileAdding}
           submitButtonText={steps[step].submitButtonText}
-          onCancel={createPageParamsSetter({ sidePath: [] })}
+          onCancel={closeSidePanel}
         />
       </SidePanel.Content>
     </>

--- a/src/features/usg-profiles/components/USGProfileDownloadAuditSidePanel/components/USGProfileDownloadAuditForm/USGProfileDownloadAuditForm.tsx
+++ b/src/features/usg-profiles/components/USGProfileDownloadAuditSidePanel/components/USGProfileDownloadAuditForm/USGProfileDownloadAuditForm.tsx
@@ -37,7 +37,7 @@ const USGProfileDownloadAuditForm: FC<USGProfileDownloadAuditFormProps> = ({
   usgProfile,
 }) => {
   const debug = useDebug();
-  const { sidePath, popSidePath, createPageParamsSetter } = usePageParams();
+  const { popSidePathUntilClear } = usePageParams();
 
   const { getUsgProfileReport, isUsgProfileReportLoading } =
     useGetUsgProfileReport();
@@ -309,9 +309,7 @@ const USGProfileDownloadAuditForm: FC<USGProfileDownloadAuditFormProps> = ({
         submitButtonDisabled={!formik.isValid || isUsgProfileReportLoading}
         submitButtonLoading={isUsgProfileReportLoading}
         submitButtonText="Generate CSV"
-        hasBackButton={sidePath.length > 1}
-        onBackButtonPress={popSidePath}
-        onCancel={createPageParamsSetter({ sidePath: [], name: "" })}
+        onCancel={popSidePathUntilClear}
       />
     </>
   );

--- a/src/features/usg-profiles/components/USGProfileDuplicateSidePanel/USGProfileDuplicateSidePanel.tsx
+++ b/src/features/usg-profiles/components/USGProfileDuplicateSidePanel/USGProfileDuplicateSidePanel.tsx
@@ -1,6 +1,5 @@
 import SidePanel from "@/components/layout/SidePanel";
 import useNotify from "@/hooks/useNotify";
-import usePageParams from "@/hooks/usePageParams";
 import type { FC } from "react";
 import { useAddUsgProfile } from "../../api";
 import { useGetPageUsgProfile } from "../../api/useGetPageUsgProfile";
@@ -9,7 +8,6 @@ import USGProfileForm from "../USGProfileForm";
 
 const USGProfileDuplicateSidePanel: FC = () => {
   const { notify } = useNotify();
-  const { sidePath, popSidePath } = usePageParams();
 
   const { usgProfile, isGettingUsgProfile } = useGetPageUsgProfile();
   const { addUsgProfile, isUsgProfileAdding } = useAddUsgProfile();
@@ -49,10 +47,7 @@ const USGProfileDuplicateSidePanel: FC = () => {
           }}
           submitButtonText="Duplicate"
           submitting={isUsgProfileAdding}
-          hasBackButton={sidePath.length > 1}
-          onBackButtonPress={popSidePath}
         />
-        ;
       </SidePanel.Content>
     </>
   );

--- a/src/features/usg-profiles/components/USGProfileEditSidePanel/USGProfileEditSidePanel.tsx
+++ b/src/features/usg-profiles/components/USGProfileEditSidePanel/USGProfileEditSidePanel.tsx
@@ -1,6 +1,5 @@
 import SidePanel from "@/components/layout/SidePanel";
 import useNotify from "@/hooks/useNotify";
-import usePageParams from "@/hooks/usePageParams";
 import type { FC } from "react";
 import { useUpdateUsgProfile } from "../../api";
 import { useGetPageUsgProfile } from "../../api/useGetPageUsgProfile";
@@ -9,7 +8,6 @@ import USGProfileForm from "../USGProfileForm";
 
 const USGProfileEditSidePanel: FC = () => {
   const { notify } = useNotify();
-  const { sidePath, popSidePath } = usePageParams();
 
   const { usgProfile, isGettingUsgProfile } = useGetPageUsgProfile();
   const { updateUsgProfile, isUsgProfileUpdating } = useUpdateUsgProfile();
@@ -47,8 +45,6 @@ const USGProfileEditSidePanel: FC = () => {
           }}
           submitButtonText="Save changes"
           submitting={isUsgProfileUpdating}
-          hasBackButton={sidePath.length > 1}
-          onBackButtonPress={popSidePath}
         />
       </SidePanel.Content>
     </>

--- a/src/features/usg-profiles/components/USGProfileForm/USGProfileForm.tsx
+++ b/src/features/usg-profiles/components/USGProfileForm/USGProfileForm.tsx
@@ -1,6 +1,6 @@
 import SidePanelFormButtons from "@/components/form/SidePanelFormButtons";
 import usePageParams from "@/hooks/usePageParams";
-import type { ComponentProps, ReactNode } from "react";
+import type { ReactNode } from "react";
 import { useState, type FC } from "react";
 import { phrase } from "../../helpers";
 import type { UseUSGProfileFormProps } from "../../hooks/useUsgProfileForm";
@@ -8,13 +8,7 @@ import useUsgProfileForm from "../../hooks/useUsgProfileForm";
 import type { USGProfileFormValues } from "../../types/USGProfileAddFormValues";
 import classes from "./USGProfileForm.module.scss";
 
-interface USGProfileFormProps
-  extends
-    UseUSGProfileFormProps,
-    Pick<
-      ComponentProps<typeof SidePanelFormButtons>,
-      "hasBackButton" | "onBackButtonPress"
-    > {
+interface USGProfileFormProps extends UseUSGProfileFormProps {
   readonly getConfirmationStepDisabled?: (
     values: USGProfileFormValues,
   ) => boolean;
@@ -28,8 +22,6 @@ const USGProfileForm: FC<USGProfileFormProps> = ({
   confirmationStepDescription,
   submitButtonText = "",
   submitting = false,
-  hasBackButton,
-  onBackButtonPress,
   ...props
 }) => {
   const { popSidePathUntilClear } = usePageParams();
@@ -107,8 +99,6 @@ const USGProfileForm: FC<USGProfileFormProps> = ({
         submitButtonDisabled={!formik.isValid || submitting}
         submitButtonLoading={steps.some((step) => step.isLoading) || submitting}
         submitButtonText={submitButtonText}
-        hasBackButton={hasBackButton}
-        onBackButtonPress={onBackButtonPress}
         onCancel={popSidePathUntilClear}
       />
     </>

--- a/src/features/usg-profiles/components/USGProfileForm/USGProfileForm.tsx
+++ b/src/features/usg-profiles/components/USGProfileForm/USGProfileForm.tsx
@@ -32,7 +32,7 @@ const USGProfileForm: FC<USGProfileFormProps> = ({
   onBackButtonPress,
   ...props
 }) => {
-  const { createPageParamsSetter } = usePageParams();
+  const { popSidePathUntilClear } = usePageParams();
 
   const { formik, steps } = useUsgProfileForm(props);
 
@@ -84,7 +84,7 @@ const USGProfileForm: FC<USGProfileFormProps> = ({
           submitButtonDisabled={!!step.isLoading || submitting}
           submitButtonLoading={step.isLoading || submitting}
           submitButtonText={submitButtonText}
-          onCancel={createPageParamsSetter({ sidePath: [], name: "" })}
+          onCancel={popSidePathUntilClear}
         />
       </>
     );
@@ -109,7 +109,7 @@ const USGProfileForm: FC<USGProfileFormProps> = ({
         submitButtonText={submitButtonText}
         hasBackButton={hasBackButton}
         onBackButtonPress={onBackButtonPress}
-        onCancel={createPageParamsSetter({ sidePath: [], name: "" })}
+        onCancel={popSidePathUntilClear}
       />
     </>
   );

--- a/src/features/usg-profiles/components/USGProfileListActions/USGProfileListActions.tsx
+++ b/src/features/usg-profiles/components/USGProfileListActions/USGProfileListActions.tsx
@@ -36,8 +36,6 @@ const USGProfileListActions: FC<USGProfileListActionsProps> = ({ profile }) => {
     try {
       const { data: activity } = await runUsgProfile({ id: profile.id });
 
-      setPageParams({ sidePath: [], name: "" });
-
       const message = getNotificationMessage(profile.mode);
 
       notify.success({

--- a/src/features/usg-profiles/components/USGProfileRunFixSidePanel/USGProfileRunFixSidePanel.tsx
+++ b/src/features/usg-profiles/components/USGProfileRunFixSidePanel/USGProfileRunFixSidePanel.tsx
@@ -18,7 +18,7 @@ const USGProfileRunFixSidePanel: FC = () => {
   const debug = useDebug();
   const navigate = useNavigate();
   const { notify } = useNotify();
-  const { sidePath, popSidePath, createPageParamsSetter } = usePageParams();
+  const { popSidePathUntilClear, closeSidePanel } = usePageParams();
 
   const { usgProfile: profile, isGettingUsgProfile } = useGetPageUsgProfile();
   const { runUsgProfile } = useRunUsgProfile();
@@ -26,8 +26,6 @@ const USGProfileRunFixSidePanel: FC = () => {
   if (isGettingUsgProfile) {
     return <SidePanel.LoadingState />;
   }
-
-  const closeSidePanel = createPageParamsSetter({ sidePath: [], name: "" });
 
   const handleSubmit = async (event: SyntheticEvent) => {
     event.preventDefault();
@@ -138,9 +136,7 @@ const USGProfileRunFixSidePanel: FC = () => {
           <SidePanelFormButtons
             submitButtonDisabled={false}
             submitButtonText="Run"
-            onCancel={closeSidePanel}
-            hasBackButton={sidePath.length > 1}
-            onBackButtonPress={popSidePath}
+            onCancel={popSidePathUntilClear}
           />
         </Form>
       </SidePanel.Content>

--- a/src/features/usg-profiles/hooks/useUsgProfileForm.tsx
+++ b/src/features/usg-profiles/hooks/useUsgProfileForm.tsx
@@ -40,7 +40,7 @@ const useUsgProfileForm = ({
   formMode,
 }: UseUSGProfileFormProps) => {
   const debug = useDebug();
-  const { setPageParams } = usePageParams();
+  const { closeSidePanel } = usePageParams();
   const formik = useFormik<USGProfileFormValues>({
     initialValues,
 
@@ -195,7 +195,7 @@ const useUsgProfileForm = ({
         return;
       }
 
-      setPageParams({ sidePath: [], name: "" });
+      closeSidePanel();
 
       onSuccess(values);
     },

--- a/src/features/wsl-profiles/components/WslProfileAddSidePanel/WslProfileAddSidePanel.tsx
+++ b/src/features/wsl-profiles/components/WslProfileAddSidePanel/WslProfileAddSidePanel.tsx
@@ -22,7 +22,7 @@ import classes from "./WslProfileAddSidePanel.module.scss";
 
 const WslProfileAddSidePanel: FC = () => {
   const debug = useDebug();
-  const { createPageParamsSetter } = usePageParams();
+  const { closeSidePanel } = usePageParams();
   const { notify } = useNotify();
   const { getAccessGroupQuery } = useRoles();
 
@@ -49,8 +49,6 @@ const WslProfileAddSidePanel: FC = () => {
       label: title,
       value: name,
     })) ?? [];
-
-  const closeSidePanel = createPageParamsSetter({ sidePath: [] });
 
   const handleSubmit = async (values: FormProps) => {
     try {

--- a/src/features/wsl-profiles/components/WslProfileEditSidePanel/components/WslProfileEditForm/WslProfileEditForm.tsx
+++ b/src/features/wsl-profiles/components/WslProfileEditSidePanel/components/WslProfileEditForm/WslProfileEditForm.tsx
@@ -28,7 +28,7 @@ interface FormProps {
 
 const WslProfileEditForm: FC<WslProfileEditFormProps> = ({ profile }) => {
   const debug = useDebug();
-  const { sidePath, popSidePath, createPageParamsSetter } = usePageParams();
+  const { popSidePathUntilClear, closeSidePanel } = usePageParams();
   const { notify } = useNotify();
   const { getAccessGroupQuery } = useRoles();
 
@@ -43,8 +43,6 @@ const WslProfileEditForm: FC<WslProfileEditFormProps> = ({ profile }) => {
   const complianceValue = profile.only_landscape_created
     ? "Uninstall non-Landscape instances"
     : "Ignore non-Landscape instances";
-
-  const closeSidePanel = createPageParamsSetter({ sidePath: [], name: "" });
 
   const handleSubmit = async (values: FormProps) => {
     try {
@@ -149,9 +147,7 @@ const WslProfileEditForm: FC<WslProfileEditFormProps> = ({ profile }) => {
       <SidePanelFormButtons
         submitButtonText="Save changes"
         submitButtonDisabled={formik.isSubmitting}
-        onCancel={closeSidePanel}
-        hasBackButton={sidePath.length > 1}
-        onBackButtonPress={popSidePath}
+        onCancel={popSidePathUntilClear}
       />
     </Form>
   );

--- a/src/pages/dashboard/profiles/package-profiles/PackageProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/package-profiles/PackageProfilesPage.tsx
@@ -50,7 +50,7 @@ const PackageProfileEditSidePanel = lazy(async () =>
 
 const PackageProfilesPage: FC = () => {
   const { getPackageProfilesQuery } = usePackageProfiles();
-  const { sidePath, lastSidePathSegment, createPageParamsSetter } =
+  const { sidePath, lastSidePathSegment, popSidePathUntilClear } =
     usePageParams();
 
   const { packageProfile } = useGetPagePackageProfile();
@@ -99,7 +99,7 @@ const PackageProfilesPage: FC = () => {
       </PageContent>
 
       <SidePanel
-        onClose={createPageParamsSetter({ sidePath: [], name: "" })}
+        onClose={popSidePathUntilClear}
         isOpen={!!sidePath.length}
         size={
           lastSidePathSegment === "add" ||

--- a/src/pages/dashboard/profiles/reboot-profiles/RebootProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/reboot-profiles/RebootProfilesPage.tsx
@@ -85,10 +85,7 @@ const RebootProfilesPage: FC = () => {
         />
       </PageContent>
 
-      <SidePanel
-        onClose={popSidePathUntilClear}
-        isOpen={!!sidePath.length}
-      >
+      <SidePanel onClose={popSidePathUntilClear} isOpen={!!sidePath.length}>
         {lastSidePathSegment === "add" && (
           <SidePanel.Suspense key="add">
             <RebootProfileAddSidePanel />

--- a/src/pages/dashboard/profiles/reboot-profiles/RebootProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/reboot-profiles/RebootProfilesPage.tsx
@@ -40,7 +40,7 @@ const RebootProfileEditSidePanel = lazy(async () =>
 const RebootProfilesPage: FC = () => {
   const { rebootProfiles, rebootProfilesCount, isGettingRebootProfiles } =
     useGetRebootProfiles();
-  const { sidePath, lastSidePathSegment, createPageParamsSetter } =
+  const { sidePath, lastSidePathSegment, popSidePathUntilClear } =
     usePageParams();
 
   const { rebootProfile } = useGetPageRebootProfile();
@@ -86,7 +86,7 @@ const RebootProfilesPage: FC = () => {
       </PageContent>
 
       <SidePanel
-        onClose={createPageParamsSetter({ sidePath: [], name: "" })}
+        onClose={popSidePathUntilClear}
         isOpen={!!sidePath.length}
       >
         {lastSidePathSegment === "add" && (

--- a/src/pages/dashboard/profiles/removal-profiles/RemovalProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/removal-profiles/RemovalProfilesPage.tsx
@@ -37,7 +37,7 @@ const RemovalProfilesPage: FC = () => {
     isPending: isGettingRemovalProfiles,
   } = getRemovalProfilesQuery();
 
-  const { sidePath, lastSidePathSegment, createPageParamsSetter } =
+  const { sidePath, lastSidePathSegment, popSidePathUntilClear } =
     usePageParams();
 
   const { removalProfile } = useGetPageRemovalProfile();
@@ -74,7 +74,7 @@ const RemovalProfilesPage: FC = () => {
 
       <SidePanel
         isOpen={!!sidePath.length}
-        onClose={createPageParamsSetter({ sidePath: [], name: "" })}
+        onClose={popSidePathUntilClear}
       >
         {lastSidePathSegment === "add" && (
           <SidePanel.Suspense key="add">

--- a/src/pages/dashboard/profiles/removal-profiles/RemovalProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/removal-profiles/RemovalProfilesPage.tsx
@@ -72,10 +72,7 @@ const RemovalProfilesPage: FC = () => {
         />
       </PageContent>
 
-      <SidePanel
-        isOpen={!!sidePath.length}
-        onClose={popSidePathUntilClear}
-      >
+      <SidePanel isOpen={!!sidePath.length} onClose={popSidePathUntilClear}>
         {lastSidePathSegment === "add" && (
           <SidePanel.Suspense key="add">
             <RemovalProfileAddSidePanel />

--- a/src/pages/dashboard/profiles/upgrade-profiles/UpgradeProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/upgrade-profiles/UpgradeProfilesPage.tsx
@@ -36,7 +36,7 @@ const UpgradeProfilesPage: FC = () => {
   const { data: getUpgradeProfilesResult, isPending } =
     getUpgradeProfilesQuery();
 
-  const { sidePath, lastSidePathSegment, createPageParamsSetter } =
+  const { sidePath, lastSidePathSegment, popSidePathUntilClear } =
     usePageParams();
 
   const { upgradeProfile } = useGetPageUpgradeProfile();
@@ -76,7 +76,7 @@ const UpgradeProfilesPage: FC = () => {
       </PageContent>
 
       <SidePanel
-        onClose={createPageParamsSetter({ sidePath: [], name: "" })}
+        onClose={popSidePathUntilClear}
         isOpen={!!sidePath.length}
       >
         {lastSidePathSegment === "add" && (

--- a/src/pages/dashboard/profiles/upgrade-profiles/UpgradeProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/upgrade-profiles/UpgradeProfilesPage.tsx
@@ -75,10 +75,7 @@ const UpgradeProfilesPage: FC = () => {
         />
       </PageContent>
 
-      <SidePanel
-        onClose={popSidePathUntilClear}
-        isOpen={!!sidePath.length}
-      >
+      <SidePanel onClose={popSidePathUntilClear} isOpen={!!sidePath.length}>
         {lastSidePathSegment === "add" && (
           <SidePanel.Suspense key="add">
             <UpgradeProfileAddSidePanel />

--- a/src/pages/dashboard/profiles/usg-profiles/USGProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/usg-profiles/USGProfilesPage.tsx
@@ -155,10 +155,7 @@ const USGProfilesPage: FC = () => {
         />
       </PageContent>
 
-      <SidePanel
-        onClose={popSidePathUntilClear}
-        isOpen={!!sidePath.length}
-      >
+      <SidePanel onClose={popSidePathUntilClear} isOpen={!!sidePath.length}>
         {lastSidePathSegment === "add" && (
           <SidePanel.Suspense key="add">
             <USGProfileAddSidePanel

--- a/src/pages/dashboard/profiles/usg-profiles/USGProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/usg-profiles/USGProfilesPage.tsx
@@ -54,7 +54,7 @@ const USGProfileRunFixSidePanel = lazy(() =>
 
 const USGProfilesPage: FC = () => {
   const {
-    createPageParamsSetter,
+    popSidePathUntilClear,
     lastSidePathSegment,
     sidePath,
     currentPage,
@@ -156,7 +156,7 @@ const USGProfilesPage: FC = () => {
       </PageContent>
 
       <SidePanel
-        onClose={createPageParamsSetter({ sidePath: [], name: "" })}
+        onClose={popSidePathUntilClear}
         isOpen={!!sidePath.length}
       >
         {lastSidePathSegment === "add" && (

--- a/src/pages/dashboard/profiles/wsl-profiles/WslProfilesPage.test.tsx
+++ b/src/pages/dashboard/profiles/wsl-profiles/WslProfilesPage.test.tsx
@@ -27,11 +27,6 @@ describe("WslProfilesPage", () => {
       await screen.findByRole("button", { name: "Add profile" }),
     );
 
-    await user.click(
-      await screen.findByRole("button", { name: "Add WSL profile" }),
-    );
-    await expectLoadingState();
-
     expect(
       await screen.findByRole("heading", { name: "Add WSL profile" }),
     ).toBeInTheDocument();

--- a/src/pages/dashboard/profiles/wsl-profiles/WslProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/wsl-profiles/WslProfilesPage.tsx
@@ -13,7 +13,6 @@ import {
   useRemoveWslProfile,
 } from "@/features/wsl-profiles";
 import { DEFAULT_PAGE_SIZE } from "@/libs/pageParamsManager/constants";
-import { Notification } from "@canonical/react-components";
 import { lazy, useEffect, type FC } from "react";
 import useProfiles from "@/hooks/useProfiles";
 import useSetDynamicFilterValidation from "@/hooks/useDynamicFilterValidation";
@@ -93,16 +92,6 @@ const WslProfilesPage: FC = () => {
         }
       />
       <PageContent hasTable>
-        <Notification severity="caution" title="WSL profiles is a beta feature">
-          We are gathering feedback to improve this feature.{" "}
-          <a
-            target="_blank"
-            rel="noreferrer noopener nofollow"
-            href="https://discourse.ubuntu.com/t/feedback-on-the-new-web-portal/50528"
-          >
-            Share your feedback
-          </a>
-        </Notification>
         <ProfilesContainer
           type={ProfileTypes.wsl}
           profiles={wslProfiles}

--- a/src/pages/dashboard/profiles/wsl-profiles/WslProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/wsl-profiles/WslProfilesPage.tsx
@@ -110,10 +110,7 @@ const WslProfilesPage: FC = () => {
           isPending={isGettingWslLimits || isGettingWslProfiles}
         />
       </PageContent>
-      <SidePanel
-        onClose={popSidePathUntilClear}
-        isOpen={!!sidePath.length}
-      >
+      <SidePanel onClose={popSidePathUntilClear} isOpen={!!sidePath.length}>
         {lastSidePathSegment === "add" && (
           <SidePanel.Suspense key="add">
             <WslProfileAddSidePanel />

--- a/src/pages/dashboard/profiles/wsl-profiles/WslProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/wsl-profiles/WslProfilesPage.tsx
@@ -50,7 +50,7 @@ const WslProfilesPage: FC = () => {
     setRemoveProfile,
     setIsRemovingProfile,
   } = useProfiles();
-  const { sidePath, lastSidePathSegment, createPageParamsSetter } =
+  const { sidePath, lastSidePathSegment, popSidePathUntilClear } =
     usePageParams();
 
   const { wslProfile } = useGetPageWslProfile();
@@ -111,7 +111,7 @@ const WslProfilesPage: FC = () => {
         />
       </PageContent>
       <SidePanel
-        onClose={createPageParamsSetter({ sidePath: [], name: "" })}
+        onClose={popSidePathUntilClear}
         isOpen={!!sidePath.length}
       >
         {lastSidePathSegment === "add" && (


### PR DESCRIPTION
## Summary

Dani specified new standards for side panels cancel / close behavior. This PR applies these standards to the Profiles side panels, 

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [ ] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
