### PR TITLE
refactor: update dynamic imports to use component paths

### DIFF
--- a/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
+++ b/src/features/instances/components/InstancesPageActions/InstancesPageActions.tsx
@@ -20,15 +20,11 @@ import classes from "./InstancesPageActions.module.scss";
 import ShutDownModal from "../ShutDownModal";
 import RestartModal from "../RestartModal";
 
-const RunInstanceScriptForm = lazy(async () =>
-  import("@/features/scripts").then((module) => ({
-    default: module.RunInstanceScriptForm,
-  })),
+const RunInstanceScriptForm = lazy(
+  async () => import("@/features/scripts/components/RunInstanceScriptForm"),
 );
-const Upgrades = lazy(async () =>
-  import("@/features/upgrades").then((module) => ({
-    default: module.Upgrades,
-  })),
+const Upgrades = lazy(
+  async () => import("@/features/upgrades/components/Upgrades"),
 );
 const ReportView = lazy(
   async () => import("@/pages/dashboard/instances/ReportView"),
@@ -38,15 +34,11 @@ const DistributionUpgrades = lazy(
   async () => import("../DistributionUpgrades"),
 );
 const TagsAddForm = lazy(async () => import("../TagsAddForm"));
-const AttachTokenForm = lazy(async () =>
-  import("@/features/ubuntupro").then((module) => ({
-    default: module.AttachTokenForm,
-  })),
+const AttachTokenForm = lazy(
+  async () => import("@/features/ubuntupro/components/AttachTokenForm"),
 );
-const ReplaceTokenForm = lazy(async () =>
-  import("@/features/ubuntupro").then((module) => ({
-    default: module.ReplaceTokenForm,
-  })),
+const ReplaceTokenForm = lazy(
+  async () => import("@/features/ubuntupro/components/ReplaceTokenForm"),
 );
 
 interface InstancesPageActionsProps {

--- a/src/features/profiles/components/ViewProfileSidePanel/components/ViewProfileDetailsBlock/ViewProfileDetailsBlock.test.tsx
+++ b/src/features/profiles/components/ViewProfileSidePanel/components/ViewProfileDetailsBlock/ViewProfileDetailsBlock.test.tsx
@@ -4,21 +4,36 @@ import { describe, expect, it, vi } from "vitest";
 import ViewProfileDetailsBlock from "./ViewProfileDetailsBlock";
 import { profiles } from "@/tests/mocks/profiles";
 
-vi.mock("@/features/script-profiles/", () => ({
-  ViewScriptProfileDetailsBlock: () => <div>script details</div>,
-}));
-vi.mock("@/features/removal-profiles/", () => ({
-  ViewRemovalProfileDetailsBlock: () => <div>removal details</div>,
-}));
-vi.mock("@/features/usg-profiles/", () => ({
-  ViewUSGProfileDetailsBlock: () => <div>usg details</div>,
-}));
-vi.mock("@/features/upgrade-profiles/", () => ({
-  ViewUpgradeProfileDetailsBlock: () => <div>upgrade details</div>,
-}));
-vi.mock("@/features/wsl-profiles", () => ({
-  ViewWslProfileDetailsBlock: () => <div>wsl details</div>,
-}));
+vi.mock(
+  "@/features/script-profiles/components/ViewScriptProfileDetailsBlock",
+  () => ({
+    default: () => <div>script details</div>,
+  }),
+);
+vi.mock(
+  "@/features/removal-profiles/components/ViewRemovalProfileDetailsBlock",
+  () => ({
+    default: () => <div>removal details</div>,
+  }),
+);
+vi.mock(
+  "@/features/usg-profiles/components/ViewUSGProfileDetailsBlock",
+  () => ({
+    default: () => <div>usg details</div>,
+  }),
+);
+vi.mock(
+  "@/features/upgrade-profiles/components/ViewUpgradeProfileDetailsBlock",
+  () => ({
+    default: () => <div>upgrade details</div>,
+  }),
+);
+vi.mock(
+  "@/features/wsl-profiles/components/ViewWslProfileDetailsBlock",
+  () => ({
+    default: () => <div>wsl details</div>,
+  }),
+);
 
 const [baseProfile] = profiles;
 

--- a/src/features/profiles/components/ViewProfileSidePanel/components/ViewProfileDetailsBlock/ViewProfileDetailsBlock.tsx
+++ b/src/features/profiles/components/ViewProfileSidePanel/components/ViewProfileDetailsBlock/ViewProfileDetailsBlock.tsx
@@ -10,34 +10,29 @@ import {
 import InfoGrid from "@/components/layout/InfoGrid/InfoGrid";
 import Blocks from "@/components/layout/Blocks";
 
-const ViewRemovalProfileDetailsBlock = lazy(async () =>
-  import("@/features/removal-profiles").then((module) => ({
-    default: module.ViewRemovalProfileDetailsBlock,
-  })),
+const ViewRemovalProfileDetailsBlock = lazy(
+  async () =>
+    import("@/features/removal-profiles/components/ViewRemovalProfileDetailsBlock"),
 );
 
-const ViewScriptProfileDetailsBlock = lazy(async () =>
-  import("@/features/script-profiles").then((module) => ({
-    default: module.ViewScriptProfileDetailsBlock,
-  })),
+const ViewScriptProfileDetailsBlock = lazy(
+  async () =>
+    import("@/features/script-profiles/components/ViewScriptProfileDetailsBlock"),
 );
 
-const ViewUSGProfileDetailsBlock = lazy(async () =>
-  import("@/features/usg-profiles").then((module) => ({
-    default: module.ViewUSGProfileDetailsBlock,
-  })),
+const ViewUSGProfileDetailsBlock = lazy(
+  async () =>
+    import("@/features/usg-profiles/components/ViewUSGProfileDetailsBlock"),
 );
 
-const ViewUpgradeProfileDetailsBlock = lazy(async () =>
-  import("@/features/upgrade-profiles").then((module) => ({
-    default: module.ViewUpgradeProfileDetailsBlock,
-  })),
+const ViewUpgradeProfileDetailsBlock = lazy(
+  async () =>
+    import("@/features/upgrade-profiles/components/ViewUpgradeProfileDetailsBlock"),
 );
 
-const ViewWslProfileDetailsBlock = lazy(async () =>
-  import("@/features/wsl-profiles").then((module) => ({
-    default: module.ViewWslProfileDetailsBlock,
-  })),
+const ViewWslProfileDetailsBlock = lazy(
+  async () =>
+    import("@/features/wsl-profiles/components/ViewWslProfileDetailsBlock"),
 );
 
 interface ViewProfileDetailsBlockProps {

--- a/src/features/publication-targets/components/AddPublicationTargetForm/index.ts
+++ b/src/features/publication-targets/components/AddPublicationTargetForm/index.ts
@@ -1,1 +1,1 @@
-export { default as AddPublicationTargetForm } from "./AddPublicationTargetForm";
+export { default } from "./AddPublicationTargetForm";

--- a/src/features/publication-targets/index.ts
+++ b/src/features/publication-targets/index.ts
@@ -1,4 +1,4 @@
-export { AddPublicationTargetForm } from "./components/AddPublicationTargetForm";
+export { default as AddPublicationTargetForm } from "./components/AddPublicationTargetForm";
 export { default as EditTargetForm } from "./components/EditTargetForm";
 export { default as PublicationTargetAddButton } from "./components/PublicationTargetAddButton";
 export { default as PublicationTargetContainer } from "./components/PublicationTargetContainer";

--- a/src/features/saved-searches/index.ts
+++ b/src/features/saved-searches/index.ts
@@ -2,5 +2,4 @@ export { default as SearchBoxWithSavedSearches } from "./components/SearchBoxWit
 export { default as CreateSavedSearchButton } from "./components/CreateSavedSearchButton";
 export { default as EditSavedSearchButton } from "./components/EditSavedSearchButton";
 export { default as RemoveSavedSearchButton } from "./components/RemoveSavedSearchButton";
-export { default as SavedSearchForm } from "./components/SavedSearchForm";
 export type { SavedSearch } from "./types";

--- a/src/features/script-profiles/components/NoScriptsEmptyState/NoScriptsEmptyState.tsx
+++ b/src/features/script-profiles/components/NoScriptsEmptyState/NoScriptsEmptyState.tsx
@@ -5,10 +5,8 @@ import { Button, Icon } from "@canonical/react-components";
 import type { FC } from "react";
 import { lazy, Suspense } from "react";
 
-const CreateScriptForm = lazy(async () =>
-  import("@/features/scripts").then((module) => ({
-    default: module.CreateScriptForm,
-  })),
+const CreateScriptForm = lazy(
+  async () => import("@/features/scripts/components/CreateScriptForm"),
 );
 
 const NoScriptsEmptyState: FC = () => {

--- a/src/features/scripts/components/ScriptListActions/ScriptListActions.tsx
+++ b/src/features/scripts/components/ScriptListActions/ScriptListActions.tsx
@@ -8,10 +8,10 @@ import { lazy, Suspense } from "react";
 import { useBoolean } from "usehooks-ts";
 import { useArchiveScriptModal, useDeleteScriptModal } from "../../hooks";
 import type { Script } from "../../types";
-import ScriptDetails from "../ScriptDetails";
 
 const EditScriptForm = lazy(async () => import("../EditScriptForm"));
 const RunScriptForm = lazy(async () => import("../RunScriptForm"));
+const ScriptDetails = lazy(async () => import("../ScriptDetails"));
 
 interface ScriptListActionsProps {
   readonly script: Script;

--- a/src/features/scripts/index.tsx
+++ b/src/features/scripts/index.tsx
@@ -5,7 +5,6 @@ export {
 } from "./api";
 export { default as RunInstanceScriptForm } from "./components/RunInstanceScriptForm";
 export { default as ScriptList } from "./components/ScriptList";
-export { default as ScriptsContainer } from "./components/ScriptsContainer";
 export { default as ScriptsEmptyState } from "./components/ScriptsEmptyState";
 export { default as ScriptsTabs } from "./components/ScriptsTabs";
 export { default as CreateScriptForm } from "./components/CreateScriptForm";

--- a/src/features/ubuntupro/index.ts
+++ b/src/features/ubuntupro/index.ts
@@ -1,6 +1,4 @@
-export { default as AttachTokenForm } from "./components/AttachTokenForm";
 export { default as DetachTokenModal } from "./components/DetachTokenModal";
-export { default as ReplaceTokenForm } from "./components/ReplaceTokenForm";
 export { default as UbuntuProEmptyState } from "./components/UbuntuProEmptyState";
 export { default as UbuntuProHeader } from "./components/UbuntuProHeader";
 export { default as UbuntuProInfoRow } from "./components/UbuntuProInfoRow";

--- a/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.tsx
@@ -63,10 +63,8 @@ const EditInstance = lazy(
   async () =>
     import("@/pages/dashboard/instances/[single]/tabs/info/EditInstance"),
 );
-const RunInstanceScriptForm = lazy(async () =>
-  import("@/features/scripts").then((module) => ({
-    default: module.RunInstanceScriptForm,
-  })),
+const RunInstanceScriptForm = lazy(
+  async () => import("@/features/scripts/components/RunInstanceScriptForm"),
 );
 
 const AssignEmployeeToInstanceForm = lazy(

--- a/src/pages/dashboard/profiles/package-profiles/PackageProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/package-profiles/PackageProfilesPage.tsx
@@ -18,34 +18,29 @@ import { lazy, useEffect } from "react";
 import { ProfileTypes } from "@/features/profiles";
 import useProfiles from "@/hooks/useProfiles";
 
-const PackageProfileAddSidePanel = lazy(async () =>
-  import("@/features/package-profiles").then((module) => ({
-    default: module.PackageProfileAddSidePanel,
-  })),
+const PackageProfileAddSidePanel = lazy(
+  async () =>
+    import("@/features/package-profiles/components/PackageProfileAddSidePanel"),
 );
 
-const PackageProfileConstraintsAddSidePanel = lazy(async () =>
-  import("@/features/package-profiles").then((module) => ({
-    default: module.PackageProfileConstraintsAddSidePanel,
-  })),
+const PackageProfileConstraintsAddSidePanel = lazy(
+  async () =>
+    import("@/features/package-profiles/components/PackageProfileConstraintsAddSidePanel"),
 );
 
-const PackageProfileConstraintsEditSidePanel = lazy(async () =>
-  import("@/features/package-profiles").then((module) => ({
-    default: module.PackageProfileConstraintsEditSidePanel,
-  })),
+const PackageProfileConstraintsEditSidePanel = lazy(
+  async () =>
+    import("@/features/package-profiles/components/PackageProfileConstraintsEditSidePanel"),
 );
 
-const PackageProfileDuplicateSidePanel = lazy(async () =>
-  import("@/features/package-profiles").then((module) => ({
-    default: module.PackageProfileDuplicateSidePanel,
-  })),
+const PackageProfileDuplicateSidePanel = lazy(
+  async () =>
+    import("@/features/package-profiles/components/PackageProfileDuplicateSidePanel"),
 );
 
-const PackageProfileEditSidePanel = lazy(async () =>
-  import("@/features/package-profiles").then((module) => ({
-    default: module.PackageProfileEditSidePanel,
-  })),
+const PackageProfileEditSidePanel = lazy(
+  async () =>
+    import("@/features/package-profiles/components/PackageProfileEditSidePanel"),
 );
 
 const PackageProfilesPage: FC = () => {

--- a/src/pages/dashboard/profiles/reboot-profiles/RebootProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/reboot-profiles/RebootProfilesPage.tsx
@@ -19,22 +19,19 @@ import { lazy, useEffect } from "react";
 import { ProfileTypes } from "@/features/profiles";
 import useProfiles from "@/hooks/useProfiles";
 
-const RebootProfileAddSidePanel = lazy(async () =>
-  import("@/features/reboot-profiles").then((module) => ({
-    default: module.RebootProfileAddSidePanel,
-  })),
+const RebootProfileAddSidePanel = lazy(
+  async () =>
+    import("@/features/reboot-profiles/components/RebootProfileAddSidePanel"),
 );
 
-const RebootProfileDuplicateSidePanel = lazy(async () =>
-  import("@/features/reboot-profiles").then((module) => ({
-    default: module.RebootProfileDuplicateSidePanel,
-  })),
+const RebootProfileDuplicateSidePanel = lazy(
+  async () =>
+    import("@/features/reboot-profiles/components/RebootProfileDuplicateSidePanel"),
 );
 
-const RebootProfileEditSidePanel = lazy(async () =>
-  import("@/features/reboot-profiles").then((module) => ({
-    default: module.RebootProfileEditSidePanel,
-  })),
+const RebootProfileEditSidePanel = lazy(
+  async () =>
+    import("@/features/reboot-profiles/components/RebootProfileEditSidePanel"),
 );
 
 const RebootProfilesPage: FC = () => {

--- a/src/pages/dashboard/profiles/removal-profiles/RemovalProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/removal-profiles/RemovalProfilesPage.tsx
@@ -18,16 +18,14 @@ import SidePanel from "@/components/layout/SidePanel";
 import { ProfileTypes } from "@/features/profiles";
 import useProfiles from "@/hooks/useProfiles";
 
-const RemovalProfileAddSidePanel = lazy(async () =>
-  import("@/features/removal-profiles").then((module) => ({
-    default: module.RemovalProfileAddSidePanel,
-  })),
+const RemovalProfileAddSidePanel = lazy(
+  async () =>
+    import("@/features/removal-profiles/components/RemovalProfileAddSidePanel"),
 );
 
-const RemovalProfileEditSidePanel = lazy(async () =>
-  import("@/features/removal-profiles").then((module) => ({
-    default: module.RemovalProfileEditSidePanel,
-  })),
+const RemovalProfileEditSidePanel = lazy(
+  async () =>
+    import("@/features/removal-profiles/components/RemovalProfileEditSidePanel"),
 );
 
 const RemovalProfilesPage: FC = () => {

--- a/src/pages/dashboard/profiles/upgrade-profiles/UpgradeProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/upgrade-profiles/UpgradeProfilesPage.tsx
@@ -19,16 +19,14 @@ import SidePanel from "@/components/layout/SidePanel";
 import { ProfileTypes } from "@/features/profiles";
 import useProfiles from "@/hooks/useProfiles";
 
-const UpgradeProfileAddSidePanel = lazy(() =>
-  import("@/features/upgrade-profiles").then((module) => ({
-    default: module.UpgradeProfileAddSidePanel,
-  })),
+const UpgradeProfileAddSidePanel = lazy(
+  () =>
+    import("@/features/upgrade-profiles/components/UpgradeProfileAddSidePanel"),
 );
 
-const UpgradeProfileEditSidePanel = lazy(() =>
-  import("@/features/upgrade-profiles").then((module) => ({
-    default: module.UpgradeProfileEditSidePanel,
-  })),
+const UpgradeProfileEditSidePanel = lazy(
+  () =>
+    import("@/features/upgrade-profiles/components/UpgradeProfileEditSidePanel"),
 );
 
 const UpgradeProfilesPage: FC = () => {

--- a/src/pages/dashboard/profiles/usg-profiles/USGProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/usg-profiles/USGProfilesPage.tsx
@@ -22,34 +22,29 @@ import { useBoolean } from "usehooks-ts";
 import useSetDynamicFilterValidation from "@/hooks/useDynamicFilterValidation";
 import { ProfileTypes } from "@/features/profiles";
 
-const USGProfileAddSidePanel = lazy(() =>
-  import("@/features/usg-profiles").then((module) => ({
-    default: module.USGProfileAddSidePanel,
-  })),
+const USGProfileAddSidePanel = lazy(
+  () =>
+    import("@/features/usg-profiles/components/USGProfileAddSidePanel/USGProfileAddSidePanel"),
 );
 
-const USGProfileDownloadAuditSidePanel = lazy(() =>
-  import("@/features/usg-profiles").then((module) => ({
-    default: module.USGProfileDownloadAuditSidePanel,
-  })),
+const USGProfileDownloadAuditSidePanel = lazy(
+  () =>
+    import("@/features/usg-profiles/components/USGProfileDownloadAuditSidePanel/USGProfileDownloadAuditSidePanel"),
 );
 
-const USGProfileDuplicateSidePanel = lazy(() =>
-  import("@/features/usg-profiles").then((module) => ({
-    default: module.USGProfileDuplicateSidePanel,
-  })),
+const USGProfileDuplicateSidePanel = lazy(
+  () =>
+    import("@/features/usg-profiles/components/USGProfileDuplicateSidePanel/USGProfileDuplicateSidePanel"),
 );
 
-const USGProfileEditSidePanel = lazy(() =>
-  import("@/features/usg-profiles").then((module) => ({
-    default: module.USGProfileEditSidePanel,
-  })),
+const USGProfileEditSidePanel = lazy(
+  () =>
+    import("@/features/usg-profiles/components/USGProfileEditSidePanel/USGProfileEditSidePanel"),
 );
 
-const USGProfileRunFixSidePanel = lazy(() =>
-  import("@/features/usg-profiles").then((module) => ({
-    default: module.USGProfileRunFixSidePanel,
-  })),
+const USGProfileRunFixSidePanel = lazy(
+  () =>
+    import("@/features/usg-profiles/components/USGProfileRunFixSidePanel/USGProfileRunFixSidePanel"),
 );
 
 const USGProfilesPage: FC = () => {

--- a/src/pages/dashboard/profiles/wsl-profiles/WslProfilesPage.tsx
+++ b/src/pages/dashboard/profiles/wsl-profiles/WslProfilesPage.tsx
@@ -21,16 +21,12 @@ import usePageParams from "@/hooks/usePageParams";
 import SidePanel from "@/components/layout/SidePanel";
 import { ProfileTypes } from "@/features/profiles";
 
-const WslProfileAddSidePanel = lazy(() =>
-  import("@/features/wsl-profiles").then((module) => ({
-    default: module.WslProfileAddSidePanel,
-  })),
+const WslProfileAddSidePanel = lazy(
+  () => import("@/features/wsl-profiles/components/WslProfileAddSidePanel"),
 );
 
-const WslProfileEditSidePanel = lazy(() =>
-  import("@/features/wsl-profiles").then((module) => ({
-    default: module.WslProfileEditSidePanel,
-  })),
+const WslProfileEditSidePanel = lazy(
+  () => import("@/features/wsl-profiles/components/WslProfileEditSidePanel"),
 );
 
 const WslProfilesPage: FC = () => {

--- a/src/pages/dashboard/repositories/local-repositories/LocalRepositoriesPage.tsx
+++ b/src/pages/dashboard/repositories/local-repositories/LocalRepositoriesPage.tsx
@@ -12,34 +12,29 @@ import usePageParams from "@/hooks/usePageParams";
 import type { FC } from "react";
 import { lazy } from "react";
 
-const AddLocalRepositorySidePanel = lazy(async () =>
-  import("@/features/local-repositories").then((module) => ({
-    default: module.AddLocalRepositorySidePanel,
-  })),
+const AddLocalRepositorySidePanel = lazy(
+  async () =>
+    import("@/features/local-repositories/components/AddLocalRepositorySidePanel"),
 );
 
-const ViewLocalRepositorySidePanel = lazy(async () =>
-  import("@/features/local-repositories").then((module) => ({
-    default: module.ViewLocalRepositorySidePanel,
-  })),
+const ViewLocalRepositorySidePanel = lazy(
+  async () =>
+    import("@/features/local-repositories/components/ViewLocalRepositorySidePanel"),
 );
 
-const EditLocalRepositorySidePanel = lazy(async () =>
-  import("@/features/local-repositories").then((module) => ({
-    default: module.EditLocalRepositorySidePanel,
-  })),
+const EditLocalRepositorySidePanel = lazy(
+  async () =>
+    import("@/features/local-repositories/components/EditLocalRepositorySidePanel"),
 );
 
-const ImportRepositoryPackagesSidePanel = lazy(async () =>
-  import("@/features/local-repositories").then((module) => ({
-    default: module.ImportRepositoryPackagesSidePanel,
-  })),
+const ImportRepositoryPackagesSidePanel = lazy(
+  async () =>
+    import("@/features/local-repositories/components/ImportRepositoryPackagesSidePanel"),
 );
 
-const PublishLocalRepositorySidePanel = lazy(async () =>
-  import("@/features/local-repositories").then((module) => ({
-    default: module.PublishLocalRepositorySidePanel,
-  })),
+const PublishLocalRepositorySidePanel = lazy(
+  async () =>
+    import("@/features/local-repositories/components/PublishLocalRepositorySidePanel"),
 );
 
 const LocalRepositoriesPage: FC = () => {

--- a/src/pages/dashboard/repositories/mirrors/MirrorsPage.tsx
+++ b/src/pages/dashboard/repositories/mirrors/MirrorsPage.tsx
@@ -11,28 +11,20 @@ import usePageParams from "@/hooks/usePageParams";
 import { Button, Icon, ICONS } from "@canonical/react-components";
 import { lazy, type FC } from "react";
 
-const EditMirrorForm = lazy(async () =>
-  import("@/features/mirrors").then((module) => ({
-    default: module.EditMirrorForm,
-  })),
+const EditMirrorForm = lazy(
+  async () => import("@/features/mirrors/components/EditMirrorForm"),
 );
 
-const AddMirrorForm = lazy(async () =>
-  import("@/features/mirrors").then((module) => ({
-    default: module.AddMirrorForm,
-  })),
+const AddMirrorForm = lazy(
+  async () => import("@/features/mirrors/components/AddMirrorForm"),
 );
 
-const MirrorDetails = lazy(async () =>
-  import("@/features/mirrors").then((module) => ({
-    default: module.MirrorDetails,
-  })),
+const MirrorDetails = lazy(
+  async () => import("@/features/mirrors/components/MirrorDetails"),
 );
 
-const PublishMirrorForm = lazy(async () =>
-  import("@/features/mirrors").then((module) => ({
-    default: module.PublishMirrorForm,
-  })),
+const PublishMirrorForm = lazy(
+  async () => import("@/features/mirrors/components/PublishMirrorForm"),
 );
 
 const MirrorsPage: FC = () => {

--- a/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.tsx
+++ b/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.tsx
@@ -15,16 +15,14 @@ import {
 import { lazy, type FC } from "react";
 import LoadingState from "@/components/layout/LoadingState";
 
-const AddPublicationTargetForm = lazy(async () =>
-  import("@/features/publication-targets").then((module) => ({
-    default: module.AddPublicationTargetForm,
-  })),
+const AddPublicationTargetForm = lazy(
+  async () =>
+    import("@/features/publication-targets/components/AddPublicationTargetForm"),
 );
 
-const EditTargetForm = lazy(async () =>
-  import("@/features/publication-targets").then((module) => ({
-    default: module.EditTargetForm,
-  })),
+const EditTargetForm = lazy(
+  async () =>
+    import("@/features/publication-targets/components/EditTargetForm"),
 );
 
 const PublicationTargetsPage: FC = () => {

--- a/src/pages/dashboard/repositories/publications/PublicationsPage.tsx
+++ b/src/pages/dashboard/repositories/publications/PublicationsPage.tsx
@@ -5,16 +5,13 @@ import useSetDynamicFilterValidation from "@/hooks/useDynamicFilterValidation";
 import usePageParams from "@/hooks/usePageParams";
 import { lazy, type FC } from "react";
 
-const AddPublicationForm = lazy(async () =>
-  import("@/features/publications").then((module) => ({
-    default: module.AddPublicationForm,
-  })),
+const AddPublicationForm = lazy(
+  async () => import("@/features/publications/components/AddPublicationForm"),
 );
 
-const PublicationDetailsSidePanel = lazy(async () =>
-  import("@/features/publications").then((module) => ({
-    default: module.PublicationDetailsSidePanel,
-  })),
+const PublicationDetailsSidePanel = lazy(
+  async () =>
+    import("@/features/publications/components/PublicationDetailsSidePanel"),
 );
 
 const PublicationsPage: FC = () => {

--- a/src/pages/dashboard/repositories/repository-profiles/RepositoryProfilesPage.tsx
+++ b/src/pages/dashboard/repositories/repository-profiles/RepositoryProfilesPage.tsx
@@ -12,22 +12,19 @@ import usePageParams from "@/hooks/usePageParams";
 import useSetDynamicFilterValidation from "@/hooks/useDynamicFilterValidation";
 import { lazy, type FC } from "react";
 
-const RepositoryProfileAddSidePanel = lazy(async () =>
-  import("@/features/repository-profiles").then((module) => ({
-    default: module.RepositoryProfileAddSidePanel,
-  })),
+const RepositoryProfileAddSidePanel = lazy(
+  async () =>
+    import("@/features/repository-profiles/components/RepositoryProfileAddSidePanel"),
 );
 
-const RepositoryProfileDetails = lazy(async () =>
-  import("@/features/repository-profiles").then((module) => ({
-    default: module.RepositoryProfileDetails,
-  })),
+const RepositoryProfileDetails = lazy(
+  async () =>
+    import("@/features/repository-profiles/components/RepositoryProfileDetails"),
 );
 
-const RepositoryProfileEditForm = lazy(async () =>
-  import("@/features/repository-profiles").then((module) => ({
-    default: module.RepositoryProfileEditForm,
-  })),
+const RepositoryProfileEditForm = lazy(
+  async () =>
+    import("@/features/repository-profiles/components/RepositoryProfileEditForm"),
 );
 
 const RepositoryProfilesPage: FC = () => {

--- a/src/pages/dashboard/scripts/ScriptsPage/ScriptsPage.tsx
+++ b/src/pages/dashboard/scripts/ScriptsPage/ScriptsPage.tsx
@@ -1,13 +1,18 @@
 import PageContent from "@/components/layout/PageContent";
 import PageHeader from "@/components/layout/PageHeader";
 import PageMain from "@/components/layout/PageMain";
+import LoadingState from "@/components/layout/LoadingState";
 import { redirectToExternalUrl } from "@/features/auth";
-import { ScriptsContainer, ScriptsTabs } from "@/features/scripts";
+import { ScriptsTabs } from "@/features/scripts";
 import useAuth from "@/hooks/useAuth";
 import useFetch from "@/hooks/useFetch";
 import { Button, Notification } from "@canonical/react-components";
-import type { FC } from "react";
+import { lazy, Suspense, type FC } from "react";
 import { useBoolean } from "usehooks-ts";
+
+const ScriptsContainer = lazy(
+  async () => import("@/features/scripts/components/ScriptsContainer"),
+);
 
 const ScriptsPage: FC = () => {
   const { isFeatureEnabled } = useAuth();
@@ -47,7 +52,9 @@ const ScriptsPage: FC = () => {
         {isFeatureEnabled("script-profiles") ? (
           <ScriptsTabs />
         ) : (
-          <ScriptsContainer />
+          <Suspense fallback={<LoadingState />}>
+            <ScriptsContainer />
+          </Suspense>
         )}
       </PageContent>
     </PageMain>

--- a/src/pages/dashboard/settings/access-group/AccessGroupsPage.tsx
+++ b/src/pages/dashboard/settings/access-group/AccessGroupsPage.tsx
@@ -8,10 +8,8 @@ import { Button } from "@canonical/react-components";
 import type { FC } from "react";
 import { lazy, Suspense } from "react";
 
-const NewAccessGroupForm = lazy(() =>
-  import("@/features/access-groups").then((module) => ({
-    default: module.NewAccessGroupForm,
-  })),
+const NewAccessGroupForm = lazy(
+  () => import("@/features/access-groups/components/NewAccessGroupForm"),
 );
 
 const AccessGroupsPage: FC = () => {

--- a/src/pages/dashboard/settings/employees/tabs/autoinstall-files/AutoinstallFilesPanel.tsx
+++ b/src/pages/dashboard/settings/employees/tabs/autoinstall-files/AutoinstallFilesPanel.tsx
@@ -13,10 +13,9 @@ import { Button } from "@canonical/react-components";
 import { lazy, Suspense, type FC } from "react";
 import { ADD_AUTOINSTALL_FILE_NOTIFICATION } from "./constants";
 
-const AutoinstallFileForm = lazy(async () =>
-  import("@/features/autoinstall-files").then((module) => ({
-    default: module.AutoinstallFileForm,
-  })),
+const AutoinstallFileForm = lazy(
+  async () =>
+    import("@/features/autoinstall-files/components/AutoinstallFileForm"),
 );
 
 const AutoinstallFilesPanel: FC = () => {


### PR DESCRIPTION
## Summary

This change prevents ineffective lazy loading caused by importing feature barrels inside `React.lazy(...).` When a feature barrel is also part of the normal static import graph, Rolldown/Vite cannot split that lazy import into a separate chunk, so the code stays in the main bundle and the build emits `INEFFECTIVE_DYNAMIC_IMPORT` warnings.

To make lazy loading reliable, the lazy imports were updated to target concrete component entrypoints instead of feature barrels.

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [ ] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [ ] **UI verified** — I have verified the changes locally.
- [ ] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
