### PR TITLE
add key id to sources table, update tests

### DIFF
--- a/.changeset/large-boxes-buy.md
+++ b/.changeset/large-boxes-buy.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Add gpg key fingerprint to sources table on repo profiles, fix PUT param empty string replacement

--- a/.github/workflows/run-tests-and-tics.yml
+++ b/.github/workflows/run-tests-and-tics.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22 # test if earlier version fixes test runner issue
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/run-tests-and-tics.yml
+++ b/.github/workflows/run-tests-and-tics.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22 # test if earlier version fixes test runner issue
+          node-version: 24
           cache: "pnpm"
 
       - name: Install dependencies

--- a/src/components/layout/TooltipCell/TooltipCell.module.scss
+++ b/src/components/layout/TooltipCell/TooltipCell.module.scss
@@ -12,3 +12,9 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.tooltipMessage {
+  max-width: 20rem;
+  overflow-wrap: break-word;
+  word-break: break-all;
+}

--- a/src/components/layout/TooltipCell/TooltipCell.tsx
+++ b/src/components/layout/TooltipCell/TooltipCell.tsx
@@ -12,6 +12,7 @@ const TooltipCell: FC<TooltipCellProps> = ({ message, children }) => (
     <Tooltip
       message={message}
       positionElementClassName={classes.tooltipWrapper}
+      tooltipClassName={classes.tooltipMessage}
     >
       {children}
     </Tooltip>

--- a/src/features/repository-profiles/api/useRepositoryProfiles.ts
+++ b/src/features/repository-profiles/api/useRepositoryProfiles.ts
@@ -74,7 +74,7 @@ export default function useRepositoryProfiles() {
           ({ name: sourceName, line, gpg_key }) => ({
             name: sourceName,
             line,
-            gpg_key: gpg_key ? { content: gpg_key } : null,
+            gpg_key: gpg_key ? { content: gpg_key.name } : null,
           }),
         ),
       });
@@ -102,7 +102,7 @@ export default function useRepositoryProfiles() {
           ({ name: sourceName, line, gpg_key }) => ({
             name: sourceName,
             line,
-            gpg_key: gpg_key ? { content: gpg_key } : null,
+            gpg_key: gpg_key ? { content: gpg_key.name } : null,
           }),
         ),
       });

--- a/src/features/repository-profiles/components/RepositoryProfileAddSidePanel/RepositoryProfileAddSidePanel.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileAddSidePanel/RepositoryProfileAddSidePanel.tsx
@@ -72,7 +72,7 @@ const RepositoryProfileAddSidePanel: FC = () => {
                 ? {
                     name: sourceToEdit.name,
                     deb_line: sourceToEdit.line,
-                    gpg_key_name: sourceToEdit.gpg_key ?? "",
+                    gpg_key_name: sourceToEdit.gpg_key?.name ?? "",
                   }
                 : undefined
             }

--- a/src/features/repository-profiles/components/RepositoryProfileDetails/RepositoryProfileDetails.test.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileDetails/RepositoryProfileDetails.test.tsx
@@ -10,6 +10,9 @@ import RepositoryProfileDetails from "./RepositoryProfileDetails";
 import type { RepositoryProfile } from "../../types";
 
 const [profileWithSources, profileWithoutSources] = repositoryProfiles;
+const profileWithNoGpgKey = repositoryProfiles.find(
+  (p) => p.name === "repo-profile-no-gpg-key",
+)!;
 
 const renderDetails = (profile: RepositoryProfile) =>
   renderWithProviders(
@@ -105,5 +108,11 @@ describe("RepositoryProfileDetails", () => {
     expect(
       await screen.findByText(ENDPOINT_STATUS_API_ERROR_MESSAGE),
     ).toBeInTheDocument();
+  });
+
+  it("renders NO_DATA_TEXT in Fingerprint column when source has no gpg_key", async () => {
+    renderDetails(profileWithNoGpgKey);
+
+    expect(await screen.findByText("---")).toBeInTheDocument();
   });
 });

--- a/src/features/repository-profiles/components/RepositoryProfileDetails/RepositoryProfileDetails.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileDetails/RepositoryProfileDetails.tsx
@@ -16,6 +16,7 @@ import Blocks from "@/components/layout/Blocks/Blocks";
 import ViewProfileAssociationBlock from "../../../profiles/components/ViewProfileSidePanel/components/ViewProfileAssociationBlock/ViewProfileAssociationBlock";
 import { ProfileTypes } from "@/features/profiles";
 import TooltipCell from "@/components/layout/TooltipCell/TooltipCell";
+import { NO_DATA_TEXT } from "@/components/layout/NoData/constants";
 
 const SOURCES_PAGE_SIZE = 10;
 
@@ -35,8 +36,10 @@ const aptSourceColumns: Column<APTSource>[] = [
     accessor: "gpg_key.fingerprint",
     Header: "Fingerprint",
     Cell: ({ row: { original } }: CellProps<APTSource>) => (
-      <TooltipCell message={String(original.gpg_key?.fingerprint ?? "")}>
-        {original.gpg_key?.fingerprint}
+      <TooltipCell
+        message={String(original.gpg_key?.fingerprint ?? NO_DATA_TEXT)}
+      >
+        {original.gpg_key?.fingerprint ?? NO_DATA_TEXT}
       </TooltipCell>
     ),
   },

--- a/src/features/repository-profiles/components/RepositoryProfileDetails/RepositoryProfileDetails.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileDetails/RepositoryProfileDetails.tsx
@@ -31,6 +31,15 @@ const aptSourceColumns: Column<APTSource>[] = [
       <TooltipCell message={original.line}>{original.line}</TooltipCell>
     ),
   },
+  {
+    accessor: "key_id",
+    Header: "Key ID",
+    Cell: ({ row: { original } }: CellProps<APTSource>) => (
+      <TooltipCell message={String(original.gpg_key?.key_id ?? "")}>
+        {original.gpg_key?.key_id}
+      </TooltipCell>
+    ),
+  },
 ];
 
 const RepositoryProfileDetails: FC = () => {
@@ -118,7 +127,7 @@ const RepositoryProfileDetails: FC = () => {
             profile={profile}
             type={ProfileTypes.repository}
           />
-          <Blocks.Item title="Sources" titleClassName="p-text--small-caps">
+          <Blocks.Item title="Sources">
             <ModularTable
               columns={aptSourceColumns}
               data={pagedSources}

--- a/src/features/repository-profiles/components/RepositoryProfileDetails/RepositoryProfileDetails.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileDetails/RepositoryProfileDetails.tsx
@@ -32,7 +32,7 @@ const aptSourceColumns: Column<APTSource>[] = [
     ),
   },
   {
-    accessor: "key_id",
+    accessor: "gpg_key.key_id",
     Header: "Key ID",
     Cell: ({ row: { original } }: CellProps<APTSource>) => (
       <TooltipCell message={String(original.gpg_key?.key_id ?? "")}>

--- a/src/features/repository-profiles/components/RepositoryProfileDetails/RepositoryProfileDetails.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileDetails/RepositoryProfileDetails.tsx
@@ -32,11 +32,11 @@ const aptSourceColumns: Column<APTSource>[] = [
     ),
   },
   {
-    accessor: "gpg_key.key_id",
-    Header: "Key ID",
+    accessor: "gpg_key.fingerprint",
+    Header: "Fingerprint",
     Cell: ({ row: { original } }: CellProps<APTSource>) => (
-      <TooltipCell message={String(original.gpg_key?.key_id ?? "")}>
-        {original.gpg_key?.key_id}
+      <TooltipCell message={String(original.gpg_key?.fingerprint ?? "")}>
+        {original.gpg_key?.fingerprint}
       </TooltipCell>
     ),
   },

--- a/src/features/repository-profiles/components/RepositoryProfileEditForm/RepositoryProfileEditForm.test.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileEditForm/RepositoryProfileEditForm.test.tsx
@@ -133,11 +133,11 @@ describe("RepositoryProfileEditForm", () => {
     );
   });
 
-  it("renders gpg_key.key_id in the sources table", async () => {
+  it("renders gpg_key.fingerprint in the sources table", async () => {
     renderEditForm("view,edit");
 
     await screen.findByText(aptSources[0].name);
-    expect(screen.getByText("KEY1ID00")).toBeInTheDocument();
+    expect(screen.getByText("AAAA1111")).toBeInTheDocument();
   });
 
   it("removing a source removes it from the sources table", async () => {

--- a/src/features/repository-profiles/components/RepositoryProfileEditForm/RepositoryProfileEditForm.test.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileEditForm/RepositoryProfileEditForm.test.tsx
@@ -132,4 +132,45 @@ describe("RepositoryProfileEditForm", () => {
       2,
     );
   });
+
+  it("renders gpg_key.key_id in the sources table", async () => {
+    renderEditForm("view,edit");
+
+    await screen.findByText(aptSources[0].name);
+    expect(screen.getByText("KEY1ID00")).toBeInTheDocument();
+  });
+
+  it("removing a source removes it from the sources table", async () => {
+    renderEditForm("view,edit");
+
+    const [firstSource] = aptSources;
+    await screen.findByText(firstSource.name);
+
+    await user.click(
+      screen.getByRole("button", { name: `Remove ${firstSource.name}` }),
+    );
+
+    expect(screen.queryByText(firstSource.name)).not.toBeInTheDocument();
+  });
+
+  it("submitting edit-source form replaces the source in the list", async () => {
+    renderEditForm("view,edit");
+
+    const [firstSource] = aptSources;
+    await screen.findByText(firstSource.name);
+
+    await user.click(
+      screen.getByRole("button", { name: `Edit ${firstSource.name}` }),
+    );
+
+    const nameInput = await screen.findByRole("textbox", {
+      name: /source name/i,
+    });
+    await user.clear(nameInput);
+    await user.type(nameInput, "updated-source");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(await screen.findByText("updated-source")).toBeInTheDocument();
+    expect(screen.queryByText(firstSource.name)).not.toBeInTheDocument();
+  });
 });

--- a/src/features/repository-profiles/components/RepositoryProfileEditForm/RepositoryProfileEditForm.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileEditForm/RepositoryProfileEditForm.tsx
@@ -77,7 +77,7 @@ const RepositoryProfileEditForm: FC = () => {
                 ? {
                     name: sourceToEdit.name,
                     deb_line: sourceToEdit.line,
-                    gpg_key_name: sourceToEdit.gpg_key ?? "",
+                    gpg_key_name: sourceToEdit.gpg_key?.name ?? "",
                   }
                 : undefined
             }

--- a/src/features/repository-profiles/components/RepositoryProfileForm/RepositoryProfileForm.test.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileForm/RepositoryProfileForm.test.tsx
@@ -199,4 +199,52 @@ describe("RepositoryProfileForm", () => {
       await screen.findByText(ENDPOINT_STATUS_API_ERROR_MESSAGE),
     ).toBeInTheDocument();
   });
+
+  it("shows success notification after successful create", async () => {
+    renderWithProviders(
+      <RepositoryProfileForm
+        action="add"
+        aptSources={[aptSources[0]]}
+        onAptSourcesChange={vi.fn()}
+        onAddSourceClick={vi.fn()}
+        onEditSourceClick={vi.fn()}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/Profile name/i), "repo-test");
+    await user.click(
+      screen.getByRole("button", { name: /Add a new repository profile/i }),
+    );
+
+    expect(
+      await screen.findByText(/repository profile created/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows success notification after successful edit", async () => {
+    const [profile] = repositoryProfiles;
+    renderWithProviders(
+      <RepositoryProfileForm
+        action="edit"
+        profile={profile}
+        aptSources={profile.apt_sources}
+        onAptSourcesChange={vi.fn()}
+        onAddSourceClick={vi.fn()}
+        onEditSourceClick={vi.fn()}
+      />,
+    );
+
+    await screen.findByDisplayValue(profile.title);
+    await user.click(
+      screen.getByRole("button", {
+        name: /Save changes to repository profile/i,
+      }),
+    );
+
+    expect(
+      await screen.findByText(
+        new RegExp(`successfully edited ${profile.title}`, "i"),
+      ),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/features/repository-profiles/components/RepositoryProfileFormSourcesSection/RepositoryProfileFormSourcesSection.module.scss
+++ b/src/features/repository-profiles/components/RepositoryProfileFormSourcesSection/RepositoryProfileFormSourcesSection.module.scss
@@ -1,5 +1,5 @@
 .nameColumn {
-  width: 30%;
+  width: 25%;
 }
 
 .actionsColumn {
@@ -8,7 +8,7 @@
 }
 
 .debLine {
-  width: 45%;
+  width: 35%;
 }
 
 .actionsCell {

--- a/src/features/repository-profiles/components/RepositoryProfileFormSourcesSection/RepositoryProfileFormSourcesSection.test.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileFormSourcesSection/RepositoryProfileFormSourcesSection.test.tsx
@@ -101,16 +101,16 @@ describe("RepositoryProfileFormSourcesSection", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders Deb line and Key ID column headers", () => {
+  it("renders Deb line and Fingerprint column headers", () => {
     renderWithProviders(
       <RepositoryProfileFormSourcesSection {...defaultProps} />,
     );
 
     expect(screen.getByText("Deb line")).toBeInTheDocument();
-    expect(screen.getByText("Key ID")).toBeInTheDocument();
+    expect(screen.getByText("Fingerprint")).toBeInTheDocument();
   });
 
-  it("renders gpg_key.key_id in the Key ID column", () => {
+  it("renders gpg_key.fingerprint in the Fingerprint column", () => {
     const [first] = aptSources;
     renderWithProviders(
       <RepositoryProfileFormSourcesSection
@@ -119,10 +119,10 @@ describe("RepositoryProfileFormSourcesSection", () => {
       />,
     );
 
-    expect(screen.getByText(first.gpg_key!.key_id)).toBeInTheDocument();
+    expect(screen.getByText(first.gpg_key!.fingerprint)).toBeInTheDocument();
   });
 
-  it("renders empty Key ID cell when gpg_key is null", () => {
+  it("renders empty Fingerprint cell when gpg_key is null", () => {
     const sourceWithoutKey = { ...aptSources[0], gpg_key: null };
     renderWithProviders(
       <RepositoryProfileFormSourcesSection

--- a/src/features/repository-profiles/components/RepositoryProfileFormSourcesSection/RepositoryProfileFormSourcesSection.test.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileFormSourcesSection/RepositoryProfileFormSourcesSection.test.tsx
@@ -100,4 +100,61 @@ describe("RepositoryProfileFormSourcesSection", () => {
       screen.queryByText("At least one source is required."),
     ).not.toBeInTheDocument();
   });
+
+  it("renders all three column headers", () => {
+    renderWithProviders(
+      <RepositoryProfileFormSourcesSection {...defaultProps} />,
+    );
+
+    expect(screen.getByText("Deb line")).toBeInTheDocument();
+    expect(screen.getByText("Key ID")).toBeInTheDocument();
+  });
+
+  it("renders gpg_key.key_id in the Key ID column", () => {
+    const [first] = aptSources;
+    renderWithProviders(
+      <RepositoryProfileFormSourcesSection
+        {...defaultProps}
+        sources={[first]}
+      />,
+    );
+
+    expect(screen.getByText(first.gpg_key!.key_id)).toBeInTheDocument();
+  });
+
+  it("renders empty Key ID cell when gpg_key is null", () => {
+    const sourceWithoutKey = { ...aptSources[0], gpg_key: null };
+    renderWithProviders(
+      <RepositoryProfileFormSourcesSection
+        {...defaultProps}
+        sources={[sourceWithoutKey]}
+      />,
+    );
+
+    expect(screen.getByText(sourceWithoutKey.name)).toBeInTheDocument();
+  });
+
+  it("shows only the first 10 sources on page 1 when there are more than 10", () => {
+    renderWithProviders(
+      <RepositoryProfileFormSourcesSection {...defaultProps} />,
+    );
+
+    expect(screen.getByText("source1")).toBeInTheDocument();
+    expect(screen.getByText("source10")).toBeInTheDocument();
+    expect(screen.queryByText("source11")).not.toBeInTheDocument();
+  });
+
+  it("navigating to the next page shows remaining sources", async () => {
+    renderWithProviders(
+      <RepositoryProfileFormSourcesSection {...defaultProps} />,
+    );
+
+    expect(screen.queryByText("source11")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    expect(screen.getByText("source11")).toBeInTheDocument();
+    expect(screen.getByText("source12")).toBeInTheDocument();
+    expect(screen.queryByText("source1")).not.toBeInTheDocument();
+  });
 });

--- a/src/features/repository-profiles/components/RepositoryProfileFormSourcesSection/RepositoryProfileFormSourcesSection.test.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileFormSourcesSection/RepositoryProfileFormSourcesSection.test.tsx
@@ -131,7 +131,19 @@ describe("RepositoryProfileFormSourcesSection", () => {
       />,
     );
 
-    expect(screen.getByText(sourceWithoutKey.name)).toBeInTheDocument();
+    expect(screen.getByText("---")).toBeInTheDocument();
+  });
+
+  it("renders (pending) in Fingerprint column when source has gpg_key but is pending", () => {
+    const pendingSourceWithKey = { ...aptSources[0], id: 0 };
+    renderWithProviders(
+      <RepositoryProfileFormSourcesSection
+        {...defaultProps}
+        sources={[pendingSourceWithKey]}
+      />,
+    );
+
+    expect(screen.getByText("(pending)")).toBeInTheDocument();
   });
 
   it("shows only the first 10 sources on page 1 when there are more than 10", () => {

--- a/src/features/repository-profiles/components/RepositoryProfileFormSourcesSection/RepositoryProfileFormSourcesSection.test.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileFormSourcesSection/RepositoryProfileFormSourcesSection.test.tsx
@@ -101,7 +101,7 @@ describe("RepositoryProfileFormSourcesSection", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders all three column headers", () => {
+  it("renders Deb line and Key ID column headers", () => {
     renderWithProviders(
       <RepositoryProfileFormSourcesSection {...defaultProps} />,
     );

--- a/src/features/repository-profiles/components/RepositoryProfileFormSourcesSection/RepositoryProfileFormSourcesSection.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileFormSourcesSection/RepositoryProfileFormSourcesSection.tsx
@@ -65,6 +65,15 @@ const RepositoryProfileFormSourcesSection: FC<
         ),
       },
       {
+        accessor: "key_id",
+        Header: "Key ID",
+        Cell: ({ row: { original } }: CellProps<SourceRow>) => (
+          <TooltipCell message={String(original.source.gpg_key?.key_id ?? "")}>
+            {original.source.gpg_key?.key_id}
+          </TooltipCell>
+        ),
+      },
+      {
         id: "actions",
         Header: "",
         className: classes.actionsColumn,

--- a/src/features/repository-profiles/components/RepositoryProfileFormSourcesSection/RepositoryProfileFormSourcesSection.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileFormSourcesSection/RepositoryProfileFormSourcesSection.tsx
@@ -6,6 +6,7 @@ import type { FC } from "react";
 import { useMemo, useState } from "react";
 import type { CellProps, Column } from "react-table";
 import classes from "./RepositoryProfileFormSourcesSection.module.scss";
+import { NO_DATA_TEXT } from "@/components/layout/NoData";
 
 interface SourceRow extends Record<string, unknown> {
   name: string;
@@ -66,15 +67,26 @@ const RepositoryProfileFormSourcesSection: FC<
       },
       {
         id: "fingerprint",
-        accessor: (row: SourceRow) => row.source.gpg_key?.fingerprint ?? "",
+        accessor: (row: SourceRow) =>
+          row.source.gpg_key?.fingerprint ?? NO_DATA_TEXT,
         Header: "Fingerprint",
-        Cell: ({ row: { original } }: CellProps<SourceRow>) => (
-          <TooltipCell
-            message={String(original.source.gpg_key?.fingerprint ?? "")}
-          >
-            {original.source.gpg_key?.fingerprint}
-          </TooltipCell>
-        ),
+        Cell: ({ row: { original } }: CellProps<SourceRow>) => {
+          if (!original.source.gpg_key) {
+            return NO_DATA_TEXT;
+          }
+          if (original.isPending) {
+            return "(pending)";
+          }
+          return (
+            <TooltipCell
+              message={String(
+                original.source.gpg_key.fingerprint ?? NO_DATA_TEXT,
+              )}
+            >
+              {original.source.gpg_key.fingerprint ?? NO_DATA_TEXT}
+            </TooltipCell>
+          );
+        },
       },
       {
         id: "actions",

--- a/src/features/repository-profiles/components/RepositoryProfileFormSourcesSection/RepositoryProfileFormSourcesSection.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileFormSourcesSection/RepositoryProfileFormSourcesSection.tsx
@@ -65,7 +65,8 @@ const RepositoryProfileFormSourcesSection: FC<
         ),
       },
       {
-        accessor: "key_id",
+        id: "key_id",
+        accessor: (row: SourceRow) => row.source.gpg_key?.key_id ?? "",
         Header: "Key ID",
         Cell: ({ row: { original } }: CellProps<SourceRow>) => (
           <TooltipCell message={String(original.source.gpg_key?.key_id ?? "")}>

--- a/src/features/repository-profiles/components/RepositoryProfileFormSourcesSection/RepositoryProfileFormSourcesSection.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileFormSourcesSection/RepositoryProfileFormSourcesSection.tsx
@@ -65,12 +65,14 @@ const RepositoryProfileFormSourcesSection: FC<
         ),
       },
       {
-        id: "key_id",
-        accessor: (row: SourceRow) => row.source.gpg_key?.key_id ?? "",
-        Header: "Key ID",
+        id: "fingerprint",
+        accessor: (row: SourceRow) => row.source.gpg_key?.fingerprint ?? "",
+        Header: "Fingerprint",
         Cell: ({ row: { original } }: CellProps<SourceRow>) => (
-          <TooltipCell message={String(original.source.gpg_key?.key_id ?? "")}>
-            {original.source.gpg_key?.key_id}
+          <TooltipCell
+            message={String(original.source.gpg_key?.fingerprint ?? "")}
+          >
+            {original.source.gpg_key?.fingerprint}
           </TooltipCell>
         ),
       },

--- a/src/features/repository-profiles/components/RepositoryProfileSourceForm/RepositoryProfileSourceForm.test.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileSourceForm/RepositoryProfileSourceForm.test.tsx
@@ -75,7 +75,13 @@ describe("RepositoryProfileSourceForm", () => {
       profiles: [],
       name: "my-source",
       line: "deb http://example.com/ubuntu focal main",
-      gpg_key: "sign-key",
+      gpg_key: {
+        id: 0,
+        name: "sign-key",
+        key_id: "",
+        fingerprint: "",
+        has_secret: false,
+      },
     };
 
     expect(defaultProps.onSuccess).toHaveBeenCalledWith(expected);
@@ -110,6 +116,45 @@ describe("RepositoryProfileSourceForm", () => {
 
     expect(
       await screen.findByText(/name must start with alphanumeric/i),
+    ).toBeInTheDocument();
+  });
+
+  it("pre-populates fields from initialValues", () => {
+    const initialValues = {
+      name: "existing-source",
+      deb_line: "deb http://archive.ubuntu.com/ubuntu focal main",
+      gpg_key_name: "my-gpg-key",
+    };
+    renderWithProviders(
+      <RepositoryProfileSourceForm
+        {...defaultProps}
+        initialValues={initialValues}
+      />,
+    );
+
+    expect(screen.getByLabelText(/source name/i)).toHaveValue(
+      "existing-source",
+    );
+    expect(screen.getByLabelText(/deb line/i)).toHaveValue(
+      "deb http://archive.ubuntu.com/ubuntu focal main",
+    );
+    expect(screen.getByLabelText(/gpg key/i)).toHaveValue("my-gpg-key");
+  });
+
+  it("shows Save changes button text when initialValues provided", () => {
+    renderWithProviders(
+      <RepositoryProfileSourceForm
+        {...defaultProps}
+        initialValues={{
+          name: "s",
+          deb_line: "deb http://x.com focal main",
+          gpg_key_name: "",
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /save changes/i }),
     ).toBeInTheDocument();
   });
 });

--- a/src/features/repository-profiles/components/RepositoryProfileSourceForm/RepositoryProfileSourceForm.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileSourceForm/RepositoryProfileSourceForm.tsx
@@ -29,7 +29,15 @@ const RepositoryProfileSourceForm: FC<RepositoryProfileSourceFormProps> = ({
         profiles: [],
         name: values.name,
         line: values.deb_line,
-        gpg_key: values.gpg_key_name || null,
+        gpg_key: values.gpg_key_name
+          ? {
+              id: 0,
+              name: values.gpg_key_name,
+              key_id: "",
+              fingerprint: "",
+              has_secret: false,
+            }
+          : null,
       };
       onSuccess(source);
     },

--- a/src/features/repository-profiles/components/RepositoryProfileSourceFormOverlay/RepositoryProfileSourceFormOverlay.test.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileSourceFormOverlay/RepositoryProfileSourceFormOverlay.test.tsx
@@ -41,7 +41,7 @@ describe("RepositoryProfileSourceFormOverlay", () => {
     );
     expect(screen.getByLabelText(/deb line/i)).toHaveValue(sourceToEdit.line);
     expect(screen.getByLabelText(/gpg key/i)).toHaveValue(
-      sourceToEdit.gpg_key ?? "",
+      sourceToEdit.gpg_key?.name ?? "",
     );
   });
 

--- a/src/features/repository-profiles/components/RepositoryProfileSourceFormOverlay/RepositoryProfileSourceFormOverlay.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileSourceFormOverlay/RepositoryProfileSourceFormOverlay.tsx
@@ -16,7 +16,7 @@ const RepositoryProfileSourceFormOverlay: FC<
     ? {
         name: sourceToEdit.name,
         deb_line: sourceToEdit.line,
-        gpg_key_name: sourceToEdit.gpg_key ?? "",
+        gpg_key_name: sourceToEdit.gpg_key?.name ?? "",
       }
     : undefined;
 

--- a/src/features/repository-profiles/types/APTSource.ts
+++ b/src/features/repository-profiles/types/APTSource.ts
@@ -3,7 +3,7 @@ import type { GPGKey } from "./GPGKey";
 
 export interface APTSource extends Record<string, unknown> {
   access_group: AccessGroup["name"];
-  gpg_key: GPGKey["name"] | null;
+  gpg_key: GPGKey | null;
   id: number;
   line: string;
   name: string;

--- a/src/tests/mocks/apt-sources.ts
+++ b/src/tests/mocks/apt-sources.ts
@@ -1,10 +1,59 @@
 import type { APTSource } from "@/features/repository-profiles";
+import type { GPGKey } from "@/features/repository-profiles";
+
+const mockGpgKeys: Record<
+  "key1" | "key2" | "key3" | "key4" | "key5" | "key6",
+  GPGKey
+> = {
+  key1: {
+    id: 1,
+    name: "key1",
+    key_id: "KEY1ID00",
+    fingerprint: "AAAA1111",
+    has_secret: false,
+  },
+  key2: {
+    id: 2,
+    name: "key2",
+    key_id: "KEY2ID00",
+    fingerprint: "BBBB2222",
+    has_secret: false,
+  },
+  key3: {
+    id: 3,
+    name: "key3",
+    key_id: "KEY3ID00",
+    fingerprint: "CCCC3333",
+    has_secret: false,
+  },
+  key4: {
+    id: 4,
+    name: "key4",
+    key_id: "KEY4ID00",
+    fingerprint: "DDDD4444",
+    has_secret: false,
+  },
+  key5: {
+    id: 5,
+    name: "key5",
+    key_id: "KEY5ID00",
+    fingerprint: "EEEE5555",
+    has_secret: false,
+  },
+  key6: {
+    id: 6,
+    name: "key6",
+    key_id: "KEY6ID00",
+    fingerprint: "FFFF6666",
+    has_secret: false,
+  },
+};
 
 export const aptSources = [
   {
     id: 1,
     access_group: "group1",
-    gpg_key: "key1",
+    gpg_key: mockGpgKeys.key1,
     line: "deb http://example.com/ubuntu focal main",
     name: "source1",
     profiles: [
@@ -24,7 +73,7 @@ export const aptSources = [
   {
     id: 2,
     access_group: "group2",
-    gpg_key: "key2",
+    gpg_key: mockGpgKeys.key2,
     line: "deb http://example.com/ubuntu focal main",
     name: "source2",
     profiles: ["repo-profile-1"] as string[],
@@ -32,7 +81,7 @@ export const aptSources = [
   {
     id: 3,
     access_group: "group3",
-    gpg_key: "key3",
+    gpg_key: mockGpgKeys.key3,
     line: "deb http://example.com/ubuntu focal main",
     name: "source3",
     profiles: [] as string[],
@@ -40,7 +89,7 @@ export const aptSources = [
   {
     id: 4,
     access_group: "group4",
-    gpg_key: "key4",
+    gpg_key: mockGpgKeys.key4,
     line: "deb http://example.com/ubuntu focal main",
     name: "source4",
     profiles: [] as string[],
@@ -48,7 +97,7 @@ export const aptSources = [
   {
     id: 5,
     access_group: "group5",
-    gpg_key: "key5",
+    gpg_key: mockGpgKeys.key5,
     line: "deb http://example.com/ubuntu focal main",
     name: "source5",
     profiles: [] as string[],
@@ -56,7 +105,7 @@ export const aptSources = [
   {
     id: 6,
     access_group: "group1",
-    gpg_key: "key1",
+    gpg_key: mockGpgKeys.key6,
     line: "deb http://example.com/ubuntu focal main",
     name: "source6",
     profiles: ["repo-profile-1"] as string[],
@@ -65,7 +114,7 @@ export const aptSources = [
   {
     id: 7,
     access_group: "group1",
-    gpg_key: "key1",
+    gpg_key: mockGpgKeys.key1,
     line: "deb http://example.com/ubuntu focal main",
     name: "source7",
     profiles: ["repo-profile-1"] as string[],
@@ -74,7 +123,7 @@ export const aptSources = [
   {
     id: 8,
     access_group: "group1",
-    gpg_key: "key1",
+    gpg_key: mockGpgKeys.key1,
     line: "deb http://example.com/ubuntu focal main",
     name: "source8",
     profiles: ["repo-profile-1"] as string[],
@@ -83,7 +132,7 @@ export const aptSources = [
   {
     id: 9,
     access_group: "group1",
-    gpg_key: "key1",
+    gpg_key: mockGpgKeys.key1,
     line: "deb http://example.com/ubuntu focal main",
     name: "source9",
     profiles: ["repo-profile-1"] as string[],
@@ -92,7 +141,7 @@ export const aptSources = [
   {
     id: 10,
     access_group: "group1",
-    gpg_key: "key1",
+    gpg_key: mockGpgKeys.key1,
     line: "deb http://example.com/ubuntu focal main",
     name: "source10",
     profiles: ["repo-profile-1"] as string[],
@@ -101,7 +150,7 @@ export const aptSources = [
   {
     id: 11,
     access_group: "group1",
-    gpg_key: "key1",
+    gpg_key: mockGpgKeys.key1,
     line: "deb http://example.com/ubuntu focal main",
     name: "source11",
     profiles: ["repo-profile-1"] as string[],
@@ -110,7 +159,7 @@ export const aptSources = [
   {
     id: 12,
     access_group: "group1",
-    gpg_key: "key1",
+    gpg_key: mockGpgKeys.key1,
     line: "deb http://example.com/ubuntu focal main",
     name: "source12",
     profiles: ["repo-profile-1"] as string[],

--- a/src/tests/mocks/repositoryProfiles.ts
+++ b/src/tests/mocks/repositoryProfiles.ts
@@ -165,4 +165,17 @@ export const repositoryProfiles = [
     tags: ["web", "prod"],
     pending_count: 0,
   },
+  {
+    id: 13,
+    name: "repo-profile-no-gpg-key",
+    title: "Repository profile no GPG key",
+    description: "Profile with source missing gpg_key",
+    access_group: "global",
+    all_computers: false,
+    apt_sources: [{ ...aptSources[0], gpg_key: null }],
+    applied_count: 0,
+    pockets: [],
+    tags: [],
+    pending_count: 0,
+  },
 ] as const satisfies RepositoryProfile[];

--- a/src/tests/server/handlers/repositoryProfiles.ts
+++ b/src/tests/server/handlers/repositoryProfiles.ts
@@ -80,7 +80,15 @@ export default [
       id: newId * 100 + i + 1,
       name: s.name,
       line: s.line,
-      gpg_key: s.gpg_key ? s.gpg_key.content : null,
+      gpg_key: s.gpg_key
+        ? {
+            id: 0,
+            name: s.gpg_key.content,
+            key_id: "",
+            fingerprint: "",
+            has_secret: false,
+          }
+        : null,
       access_group: body.access_group ?? "global",
       profiles: [name],
     }));
@@ -137,7 +145,15 @@ export default [
           id: maxId + i + 1,
           name: s.name,
           line: s.line,
-          gpg_key: s.gpg_key ? s.gpg_key.content : null,
+          gpg_key: s.gpg_key
+            ? {
+                id: 0,
+                name: s.gpg_key.content,
+                key_id: "",
+                fingerprint: "",
+                has_secret: false,
+              }
+            : null,
           access_group: body.access_group,
           profiles: [profile.name],
         }));

--- a/src/utils/_helpers.ts
+++ b/src/utils/_helpers.ts
@@ -39,8 +39,10 @@ export const handleParams = ({
   for (const param of Object.keys(requestParams)) {
     const value = requestParams[param];
 
-    if ("string" === typeof value && "" !== value) {
-      paramsToPass[param] = value;
+    if ("string" === typeof value) {
+      if ("" !== value || config.method === "put") {
+        paramsToPass[param] = value;
+      }
     } else if (Array.isArray(value)) {
       if (0 !== value.length) {
         if (isOld) {


### PR DESCRIPTION
## Summary

Sources table in repo profiles view / edit now shows a gpg key id per-source if the source has a gpg key.

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [X] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [X] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [ ] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [X] **UI verified** — I have verified the changes locally.
- [X] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
