### PR TITLE
Update fields for Mirror, Publications, and Targets

### DIFF
--- a/.changeset/bumpy-icons-travel.md
+++ b/.changeset/bumpy-icons-travel.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Show GPG Key in mirrors and publications, unlock publications distribution fields if non-signature-preserving, and lock link type field for publication target

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.test.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.test.tsx
@@ -129,7 +129,7 @@ describe("AddMirrorForm", () => {
   });
 
   it("submits a mirror with preserve signatures enabled", async () => {
-    await user.click(screen.getByLabelText("Preserve signatures"));
+    await user.click(screen.getByLabelText("Preserve upstream signing key"));
     await user.click(screen.getByRole("button", { name: "Add mirror" }));
 
     expect(mockCreateMirror).toHaveBeenCalledExactlyOnceWith(

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
@@ -260,6 +260,18 @@ const AddMirrorForm: FC = () => {
                   tooltipMessage="The source URL is set automatically by the source type."
                 />
               )}
+              <CheckboxInput
+                label="Preserve upstream signing key"
+                {...formik.getFieldProps("preserveSignatures")}
+                checked={formik.values.preserveSignatures}
+                inline
+              />{" "}
+              <Tooltip
+                position="right"
+                message="Signature-preserving mirrors directly copy the packages from the source to their destination without signing or syncing the packages."
+              >
+                <Icon name={ICONS.help} />
+              </Tooltip>
             </Blocks.Item>
             <Blocks.Item
               title="Mirror contents"
@@ -351,28 +363,14 @@ const AddMirrorForm: FC = () => {
                   isLoading={isMirrorContentsLoading}
                 />
               )}
-              <div className="u-sv2">
-                <CheckboxInput
-                  label="Preserve signatures"
-                  {...formik.getFieldProps("preserveSignatures")}
-                  checked={formik.values.preserveSignatures}
-                  inline
-                />{" "}
-                <Tooltip
-                  position="right"
-                  message="Signature-preserving mirrors directly copy the packages from the source to their destination without signing or syncing the packages."
-                >
-                  <Icon name={ICONS.help} />
-                </Tooltip>
-              </div>
-              <p className={classes.heading}>Filter options:</p>
               <div className={classes.wrapper}>
                 <div className={classes.formContainer}>
                   <Input
                     type="text"
-                    label="Package filter"
+                    label="Filter"
                     {...formik.getFieldProps("packageFilter")}
                     disabled={formik.values.preserveSignatures}
+                    help="The filter limits what packages are mirrored."
                   />
                 </div>
                 <MirrorFilterHelpButton />

--- a/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.test.tsx
+++ b/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.test.tsx
@@ -154,7 +154,7 @@ describe("EditMirrorForm", () => {
 
     await expectLoadingState();
 
-    const checkbox = screen.getByLabelText("Preserve signatures");
+    const checkbox = screen.getByLabelText("Preserve upstream signing key");
     expect(checkbox).toBeChecked();
     expect(checkbox).toBeDisabled();
   });

--- a/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
+++ b/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
@@ -112,6 +112,19 @@ const EditMirrorForm: FC = () => {
                 value={mirror.archiveRoot}
                 tooltipMessage="You can’t change the source URL after the mirror is created."
               />
+              <CheckboxInput
+                label="Preserve upstream signing key"
+                {...formik.getFieldProps("preserveSignatures")}
+                checked={formik.values.preserveSignatures}
+                disabled
+                inline
+              />{" "}
+              <Tooltip
+                position="right"
+                message="Signature-preserving mirrors directly copy the packages from the source to their destination without signing or syncing the packages."
+              >
+                <Icon name={ICONS.help} />
+              </Tooltip>
             </Blocks.Item>
             <Blocks.Item title="Mirror contents">
               <ReadOnlyField
@@ -129,29 +142,14 @@ const EditMirrorForm: FC = () => {
                 value={mirror.architectures?.join(", ") || NO_DATA_TEXT}
                 tooltipMessage="You can’t change the architectures after the mirror is created."
               />
-              <div className="u-sv2">
-                <CheckboxInput
-                  label="Preserve signatures"
-                  {...formik.getFieldProps("preserveSignatures")}
-                  checked={formik.values.preserveSignatures}
-                  disabled
-                  inline
-                />{" "}
-                <Tooltip
-                  position="right"
-                  message="Signature-preserving mirrors directly copy the packages from the source to their destination without signing or syncing the packages."
-                >
-                  <Icon name={ICONS.help} />
-                </Tooltip>
-              </div>
-              <p className={classes.heading}>Filter options:</p>
               <div className={classes.wrapper}>
                 <div className={classes.formContainer}>
                   <Input
                     type="text"
-                    label="Package filter"
+                    label="Filter"
                     {...formik.getFieldProps("packageFilter")}
                     disabled={formik.values.preserveSignatures}
+                    help="The filter limits what packages are mirrored."
                   />
                 </div>
                 <MirrorFilterHelpButton />

--- a/src/features/mirrors/components/MirrorDetails/MirrorDetails.test.tsx
+++ b/src/features/mirrors/components/MirrorDetails/MirrorDetails.test.tsx
@@ -18,6 +18,61 @@ describe("MirrorDetails", () => {
     );
 
     await expectLoadingState();
+
+    expect(
+      screen.getByRole("heading", { name: mirrors[0].displayName }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("heading", { name: "Details" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Source type")).toBeInTheDocument();
+    expect(screen.getByText("Source URL")).toBeInTheDocument();
+    expect(screen.getByText("Last update")).toBeInTheDocument();
+    expect(screen.getAllByText("Packages")).toHaveLength(2);
+
+    expect(
+      screen.getByRole("heading", { name: "Contents" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Distribution")).toBeInTheDocument();
+    expect(screen.getByText("Components")).toBeInTheDocument();
+    expect(screen.getByText("Architectures")).toBeInTheDocument();
+    expect(
+      screen.getByText("Preserve upstream signing key"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Filter")).toBeInTheDocument();
+    expect(screen.getByText(/Download .udeb/i)).toBeInTheDocument();
+    expect(screen.getByText("Download sources")).toBeInTheDocument();
+    expect(screen.getByText(/Download installer files/i)).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("heading", { name: "Authentication" }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByRole("heading", { name: "Used in" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders GPG key fingerprint", async () => {
+    renderWithProviders(
+      <Suspense fallback={<LoadingState />}>
+        <MirrorDetails />
+      </Suspense>,
+      undefined,
+      `?name=${mirrors[2].name}`,
+    );
+
+    await expectLoadingState();
+
+    expect(
+      screen.getByRole("heading", { name: "Authentication" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Verification GPG Key")).toBeInTheDocument();
+    expect(
+      screen.getByText(mirrors[2].gpgKey?.fingerprint),
+    ).toBeInTheDocument();
   });
 
   it("displays preserve signatures status", async () => {
@@ -37,7 +92,7 @@ describe("MirrorDetails", () => {
 
     await expectLoadingState();
 
-    const label = screen.getByText("Preserve signatures");
+    const label = screen.getByText("Preserve upstream signing key");
     expect(label).toBeInTheDocument();
     expect(label.closest("div")?.nextSibling?.textContent).toBe("Yes");
   });

--- a/src/features/mirrors/components/MirrorDetails/MirrorDetails.tsx
+++ b/src/features/mirrors/components/MirrorDetails/MirrorDetails.tsx
@@ -152,6 +152,11 @@ const MirrorDetails: FC = () => {
                   }
                   large
                 />
+
+                <InfoGrid.Item
+                  label="Preserve upstream signing key"
+                  value={boolToLabel(mirror.preserveSignatures)}
+                />
                 <InfoGrid.Item
                   label="Last update"
                   value={
@@ -187,15 +192,7 @@ const MirrorDetails: FC = () => {
                   value={mirror.architectures?.join(", ")}
                   large
                 />
-                <InfoGrid.Item
-                  label="Preserve signatures"
-                  value={boolToLabel(mirror.preserveSignatures)}
-                />
-                <InfoGrid.Item
-                  label="Package filter"
-                  value={mirror.filter}
-                  large
-                />
+                <InfoGrid.Item label="Filter" value={mirror.filter} large />
                 {mirror.filter && (
                   <InfoGrid.Item
                     label="Include dependencies in filter"

--- a/src/features/mirrors/components/MirrorDetails/MirrorDetails.tsx
+++ b/src/features/mirrors/components/MirrorDetails/MirrorDetails.tsx
@@ -21,6 +21,7 @@ import {
 import classes from "./MirrorDetails.module.scss";
 import MirrorPackagesList from "../MirrorPackagesList";
 import LoadingState from "@/components/layout/LoadingState";
+import { UBUNTU_ARCHIVE_HOST, UBUNTU_PRO_HOST, UBUNTU_SNAPSHOTS_HOST } from "../../constants";
 
 const MirrorDetails: FC = () => {
   const { name, createSidePathPusher, sidePath, setPageParams } =
@@ -212,6 +213,20 @@ const MirrorDetails: FC = () => {
                 />
               </InfoGrid>
             </Blocks.Item>
+            {![
+              UBUNTU_ARCHIVE_HOST,
+              UBUNTU_SNAPSHOTS_HOST,
+              UBUNTU_PRO_HOST,
+            ].includes(new URL(mirror.archiveRoot).host) && (
+            <Blocks.Item title="Authentication">
+              <InfoGrid dense>
+                <InfoGrid.Item
+                  label="Verification GPG Key"
+                  value={mirror.gpgKey?.fingerprint}
+                />
+              </InfoGrid>
+            </Blocks.Item>
+            )}
             <Blocks.Item title="Used in">
               {isGettingPublications ? (
                 <LoadingState />

--- a/src/features/mirrors/components/MirrorDetails/MirrorDetails.tsx
+++ b/src/features/mirrors/components/MirrorDetails/MirrorDetails.tsx
@@ -21,7 +21,11 @@ import {
 import classes from "./MirrorDetails.module.scss";
 import MirrorPackagesList from "../MirrorPackagesList";
 import LoadingState from "@/components/layout/LoadingState";
-import { UBUNTU_ARCHIVE_HOST, UBUNTU_PRO_HOST, UBUNTU_SNAPSHOTS_HOST } from "../../constants";
+import {
+  UBUNTU_ARCHIVE_HOST,
+  UBUNTU_PRO_HOST,
+  UBUNTU_SNAPSHOTS_HOST,
+} from "../../constants";
 
 const MirrorDetails: FC = () => {
   const { name, createSidePathPusher, sidePath, setPageParams } =
@@ -218,14 +222,14 @@ const MirrorDetails: FC = () => {
               UBUNTU_SNAPSHOTS_HOST,
               UBUNTU_PRO_HOST,
             ].includes(new URL(mirror.archiveRoot).host) && (
-            <Blocks.Item title="Authentication">
-              <InfoGrid dense>
-                <InfoGrid.Item
-                  label="Verification GPG Key"
-                  value={mirror.gpgKey?.fingerprint}
-                />
-              </InfoGrid>
-            </Blocks.Item>
+              <Blocks.Item title="Authentication">
+                <InfoGrid dense>
+                  <InfoGrid.Item
+                    label="Verification GPG Key"
+                    value={mirror.gpgKey?.fingerprint}
+                  />
+                </InfoGrid>
+              </Blocks.Item>
             )}
             <Blocks.Item title="Used in">
               {isGettingPublications ? (

--- a/src/features/mirrors/components/PublishMirrorForm/components/PublishMirrorNewForm/PublishMirrorNewForm.tsx
+++ b/src/features/mirrors/components/PublishMirrorForm/components/PublishMirrorNewForm/PublishMirrorNewForm.tsx
@@ -24,6 +24,7 @@ import PublishMirrorContentsBlock from "../PublishMirrorContentsBlock";
 import type { Mirror, PublicationTarget } from "@canonical/landscape-openapi";
 import type { SelectOption } from "@/types/SelectOption";
 import * as Yup from "yup";
+import ReadOnlyField from "@/components/form/ReadOnlyField";
 
 interface PublishMirrorNewFormProps {
   readonly mirror: Mirror;
@@ -132,13 +133,21 @@ const PublishMirrorNewForm: FC<PublishMirrorNewFormProps> = ({
             {...formik.getFieldProps("publicationTarget")}
           />
 
-          <Textarea
-            label="Signing GPG key"
-            rows={4}
-            error={getFormikError(formik, "signingKey")}
-            {...formik.getFieldProps("signingKey")}
-            className="u-no-margin--bottom"
-          />
+          {mirror.preserveSignatures ? (
+            <ReadOnlyField
+              label="Signing GPG key"
+              value=""
+              tooltipMessage="This mirror is preserving the upstream signing key"
+            />
+          ) : (
+            <Textarea
+              label="Signing GPG key"
+              rows={4}
+              error={getFormikError(formik, "signingKey")}
+              {...formik.getFieldProps("signingKey")}
+              className="u-no-margin--bottom"
+            />
+          )}
         </Blocks.Item>
 
         <PublishMirrorContentsBlock mirror={mirror} />

--- a/src/features/publication-targets/components/EditTargetForm/EditTargetForm.test.tsx
+++ b/src/features/publication-targets/components/EditTargetForm/EditTargetForm.test.tsx
@@ -187,31 +187,15 @@ describe("EditTargetForm", () => {
       expect(screen.getByText(filesystem.path)).toBeInTheDocument();
     });
 
-    it("pre-populates linkMethod select", () => {
+    it("pre-populates linkMethod as read-only", () => {
       renderWithProviders(<EditTargetForm target={filesystemTarget} />);
 
-      expect(screen.getByLabelText(/link method/i)).toHaveValue(
-        filesystem.linkMethod ?? "",
-      );
+      expect(screen.getByText(filesystem.linkMethod ?? "")).toBeInTheDocument();
     });
 
     it("submits and shows success notification", async () => {
       renderWithProviders(<EditTargetForm target={filesystemTarget} />);
 
-      await user.click(screen.getByRole("button", { name: /save/i }));
-
-      expect(
-        await screen.findByText(/publication target edited/i),
-      ).toBeInTheDocument();
-    });
-
-    it("user can change linkMethod and submit successfully", async () => {
-      renderWithProviders(<EditTargetForm target={filesystemTarget} />);
-
-      await user.selectOptions(
-        screen.getByLabelText(/link method/i),
-        "SYMLINK",
-      );
       await user.click(screen.getByRole("button", { name: /save/i }));
 
       expect(

--- a/src/features/publication-targets/components/EditTargetForm/EditTargetForm.test.tsx
+++ b/src/features/publication-targets/components/EditTargetForm/EditTargetForm.test.tsx
@@ -190,7 +190,7 @@ describe("EditTargetForm", () => {
     it("pre-populates linkMethod as read-only", () => {
       renderWithProviders(<EditTargetForm target={filesystemTarget} />);
 
-      expect(screen.getByText(filesystem.linkMethod ?? "")).toBeInTheDocument();
+      expect(screen.getByText("Hardlink")).toBeInTheDocument();
     });
 
     it("submits and shows success notification", async () => {

--- a/src/features/publication-targets/components/EditTargetForm/EditTargetForm.tsx
+++ b/src/features/publication-targets/components/EditTargetForm/EditTargetForm.tsx
@@ -14,6 +14,7 @@ import type {
 import useNotify from "@/hooks/useNotify";
 import {
   EMPTY_VALUES,
+  LINK_METHOD_OPTIONS,
   TARGET_TYPE_LABELS,
   VALIDATION_SCHEMA,
 } from "../../constants";
@@ -339,7 +340,11 @@ const EditTargetForm: FC<EditTargetFormProps> = ({ target }) => {
           />
           <ReadOnlyField
             label="Link method"
-            {...formik.getFieldProps("linkMethod")}
+            value={
+              LINK_METHOD_OPTIONS.find(
+                (o) => o.value === formik.getFieldProps("linkMethod").value,
+              )?.label
+            }
             tooltipMessage="The link method cannot be changed after the target has been created. To use a different link method, create a new publication target."
           />
         </>

--- a/src/features/publication-targets/components/EditTargetForm/EditTargetForm.tsx
+++ b/src/features/publication-targets/components/EditTargetForm/EditTargetForm.tsx
@@ -4,11 +4,7 @@ import useDebug from "@/hooks/useDebug";
 import usePageParams from "@/hooks/usePageParams";
 import { getFormikError } from "@/utils/formikErrors";
 import useEditPublicationTarget from "../../api/useEditPublicationTarget";
-import {
-  CheckboxInput,
-  Form,
-  Input,
-} from "@canonical/react-components";
+import { CheckboxInput, Form, Input } from "@canonical/react-components";
 import { useFormik } from "formik";
 import type { FC } from "react";
 import type {

--- a/src/features/publication-targets/components/EditTargetForm/EditTargetForm.tsx
+++ b/src/features/publication-targets/components/EditTargetForm/EditTargetForm.tsx
@@ -8,7 +8,6 @@ import {
   CheckboxInput,
   Form,
   Input,
-  Select,
 } from "@canonical/react-components";
 import { useFormik } from "formik";
 import type { FC } from "react";
@@ -19,7 +18,6 @@ import type {
 import useNotify from "@/hooks/useNotify";
 import {
   EMPTY_VALUES,
-  LINK_METHOD_OPTIONS,
   TARGET_TYPE_LABELS,
   VALIDATION_SCHEMA,
 } from "../../constants";
@@ -343,11 +341,10 @@ const EditTargetForm: FC<EditTargetFormProps> = ({ target }) => {
             tooltipMessage="The path cannot be changed after the target has been created. To use a different path, create a new publication target."
             {...formik.getFieldProps("path")}
           />
-          <Select
+          <ReadOnlyField
             label="Link method"
-            options={LINK_METHOD_OPTIONS}
-            error={getFormikError(formik, "linkMethod")}
             {...formik.getFieldProps("linkMethod")}
+            tooltipMessage="The link method cannot be changed after the target has been created. To use a different link method, create a new publication target."
           />
         </>
       )}

--- a/src/features/publications/components/AddPublicationForm/AddPublicationForm.test.tsx
+++ b/src/features/publications/components/AddPublicationForm/AddPublicationForm.test.tsx
@@ -49,14 +49,14 @@ describe("AddPublicationForm", () => {
     await user.selectOptions(sourceSelect, "aaaa-bbbb-cccc");
   };
 
-  it("updates uploader fields when a mirror source is selected", async () => {
+  it("updates contents fields when a mirror source is selected", async () => {
     const user = userEvent.setup();
 
     renderForm();
 
     await selectMirrorSource(user);
 
-    expect(screen.getByText("jammy")).toBeInTheDocument();
+    expect(screen.getByLabelText(/^distribution$/i)).toHaveValue("jammy");
     expect(
       screen.getByRole("combobox", { name: "Architectures" }),
     ).toBeInTheDocument();
@@ -159,7 +159,7 @@ describe("AddPublicationForm", () => {
 
     renderForm();
 
-    await selectMirrorSource(user, "ubuntu-archive-mirror");
+    await selectMirrorSource(user);
 
     expect(
       screen.getByRole("heading", { name: "Signing GPG Key" }),
@@ -176,6 +176,24 @@ describe("AddPublicationForm", () => {
     expect(
       screen.queryByRole("heading", { name: "Signing GPG Key" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("locks distribution field when mirror has preserveSignatures=true", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await selectMirrorSource(user, "ubuntu-security-mirror");
+
+    expect(screen.getByText("noble")).toBeInTheDocument();
+  });
+
+  it("locks distribution field when local repository is selected", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await selectLocalSource(user);
+
+    expect(screen.getByText("distribution 1")).toBeInTheDocument();
   });
 
   it("hides signing key field when local repository is selected", async () => {

--- a/src/features/publications/components/AddPublicationForm/AddPublicationForm.tsx
+++ b/src/features/publications/components/AddPublicationForm/AddPublicationForm.tsx
@@ -234,13 +234,22 @@ const AddPublicationForm: FC = () => {
           />
         </Blocks.Item>
 
-        <Blocks.Item title="Uploaders">
-          <ReadOnlyField
-            label="Distribution"
-            required
-            value={formik.values.uploader_distribution}
-            tooltipMessage="The distribution is derived from the selected source."
-          />
+        <Blocks.Item title="Contents">
+          {isLocalSourceType || selectedSource?.preserveSignatures
+          ? <ReadOnlyField
+              label="Distribution"
+              required
+              value={formik.values.uploader_distribution}
+              tooltipMessage="The distribution is derived from the selected source."
+            />
+          : <Input
+              type="text"
+              label="Distribution"
+              required
+              error={getFormikError(formik, "uploader_distribution")}
+              {...formik.getFieldProps("uploader_distribution")}
+            />
+          }
 
           {!isLocalSourceType && (
             <Select

--- a/src/features/publications/components/AddPublicationForm/AddPublicationForm.tsx
+++ b/src/features/publications/components/AddPublicationForm/AddPublicationForm.tsx
@@ -235,21 +235,22 @@ const AddPublicationForm: FC = () => {
         </Blocks.Item>
 
         <Blocks.Item title="Contents">
-          {isLocalSourceType || selectedSource?.preserveSignatures
-          ? <ReadOnlyField
+          {isLocalSourceType || selectedSource?.preserveSignatures ? (
+            <ReadOnlyField
               label="Distribution"
               required
               value={formik.values.uploader_distribution}
               tooltipMessage="The distribution is derived from the selected source."
             />
-          : <Input
+          ) : (
+            <Input
               type="text"
               label="Distribution"
               required
               error={getFormikError(formik, "uploader_distribution")}
               {...formik.getFieldProps("uploader_distribution")}
             />
-          }
+          )}
 
           {!isLocalSourceType && (
             <Select

--- a/src/features/publications/components/PublicationDetails/PublicationDetails.test.tsx
+++ b/src/features/publications/components/PublicationDetails/PublicationDetails.test.tsx
@@ -12,7 +12,7 @@ import moment from "moment";
 
 describe("PublicationDetails", () => {
   const user = userEvent.setup();
-  const [publication] = publications;
+  const [publication, publicationWithKey] = publications;
 
   const sourceDisplayName =
     mirrors.find((m) => m.name === publication.source)?.displayName ??
@@ -54,6 +54,21 @@ describe("PublicationDetails", () => {
     for (const { label, value } of infoItems) {
       expect(container).toHaveInfoItem(label, value);
     }
+  });
+
+  it("renders GPG key fingerprint when it exists", async () => {
+    const { container } = renderWithProviders(
+      <PublicationDetails
+        publication={publicationWithKey}
+        sourceDisplayName={sourceDisplayName}
+        publicationTargetDisplayName={publicationTargetDisplayName}
+      />,
+    );
+
+    expect(container).toHaveInfoItem(
+      "Signing GPG Key",
+      publicationWithKey.gpgKey?.fingerprint,
+    );
   });
 
   it("opens republish modal", async () => {

--- a/src/features/publications/components/PublicationDetails/PublicationDetails.tsx
+++ b/src/features/publications/components/PublicationDetails/PublicationDetails.tsx
@@ -94,6 +94,13 @@ const PublicationDetails = ({
                   : NO_DATA_TEXT
               }
             />
+
+            {publication.gpgKey && (
+              <InfoGrid.Item
+                label="Signing GPG Key"
+                value={publication.gpgKey.fingerprint}
+              />
+            )}
           </InfoGrid>
         </Blocks.Item>
 

--- a/src/tests/mocks/mirrors.ts
+++ b/src/tests/mocks/mirrors.ts
@@ -44,7 +44,7 @@ export const mirrors = [
     lastDownloadDate: new Date("2024-04-01T12:00:00Z"),
     gpgKey: {
       armor: "-----BEGIN PGP PUBLIC KEY BLOCK-----",
-      fingerprint: "ABCDEF1234567890"
+      fingerprint: "ABCDEF1234567890",
     },
   },
 ] as const satisfies Mirror[];

--- a/src/tests/mocks/mirrors.ts
+++ b/src/tests/mocks/mirrors.ts
@@ -42,6 +42,9 @@ export const mirrors = [
     downloadSources: false,
     downloadUdebs: false,
     lastDownloadDate: new Date("2024-04-01T12:00:00Z"),
-    gpgKey: { armor: "-----BEGIN PGP PUBLIC KEY BLOCK-----" },
+    gpgKey: {
+      armor: "-----BEGIN PGP PUBLIC KEY BLOCK-----",
+      fingerprint: "ABCDEF1234567890"
+    },
   },
 ] as const satisfies Mirror[];

--- a/src/tests/mocks/publications.ts
+++ b/src/tests/mocks/publications.ts
@@ -41,6 +41,7 @@ export const publications = [
     skipContents: true,
     gpgKey: {
       armor: "-----BEGIN PGP PRIVATE KEY BLOCK-----...",
+      fingerprint: "38683D0347E42FDA",
     },
     publishTime: new Date("March 12, 2026"),
   },


### PR DESCRIPTION
## Summary

- Locked `link type` field for editing publication targets
- Unlocked `distribution` field for publications from non-signature-preserving mirrors
- Updated Filter and Signature-preserving fields to match [Dani's design](https://www.figma.com/design/IgBhJyoWLf4y05pIyFixdk?node-id=319-2692&m=dev#1752329868)
- Show Verification Key in mirrors and Signing Key in publications, when appropriate

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
