### PR TITLE
clear package filter when preserve signatures checked

### DIFF
--- a/.changeset/little-onions-wish.md
+++ b/.changeset/little-onions-wish.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Clear package filter field in add mirror form when preserve signatures is checked

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.test.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.test.tsx
@@ -139,6 +139,24 @@ describe("AddMirrorForm", () => {
     );
   });
 
+  it("clears package filter and include dependencies when preserve signatures is enabled", async () => {
+    const packageFilterField = screen.getByLabelText("Package filter");
+    const includeDepsCheckbox = screen.getByLabelText(
+      "Include dependencies in filter",
+    );
+
+    await user.type(packageFilterField, "nginx*");
+    await user.click(includeDepsCheckbox);
+
+    expect(packageFilterField).toHaveValue("nginx*");
+    expect(includeDepsCheckbox).toBeChecked();
+
+    await user.click(screen.getByLabelText("Preserve signatures"));
+
+    expect(packageFilterField).toHaveValue("");
+    expect(includeDepsCheckbox).not.toBeChecked();
+  });
+
   it("submits a third-party mirror", async () => {
     const params = {
       archiveRoot: "https://archive.ubuntu.com/",

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
@@ -134,6 +134,14 @@ const AddMirrorForm: FC = () => {
     disabled: !isArchiveInfoValid(proService),
   }));
 
+  useEffect(() => {
+    if (formik.values.preserveSignatures) {
+      void formik.setFieldValue("packageFilter", "");
+      void formik.setFieldValue("includeDependencies", false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formik.values.preserveSignatures]);
+
   // Once the archive/ESM info finishes loading, hydrate the data-dependent
   // fields (distribution, components, architectures, pro service) for the
   // user's currently selected source type while preserving anything they have


### PR DESCRIPTION
## Summary

clear package filter when preserve signatures checked

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [X] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [X] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [X] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [X] **UI verified** — I have verified the changes locally.
- [X] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
