### PR TITLE
fix failing tests

### DIFF
--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.test.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.test.tsx
@@ -140,7 +140,7 @@ describe("AddMirrorForm", () => {
   });
 
   it("clears package filter and include dependencies when preserve signatures is enabled", async () => {
-    const packageFilterField = screen.getByLabelText("Package filter");
+    const packageFilterField = screen.getByLabelText("Filter");
     const includeDepsCheckbox = screen.getByLabelText(
       "Include dependencies in filter",
     );
@@ -151,7 +151,7 @@ describe("AddMirrorForm", () => {
     expect(packageFilterField).toHaveValue("nginx*");
     expect(includeDepsCheckbox).toBeChecked();
 
-    await user.click(screen.getByLabelText("Preserve signatures"));
+    await user.click(screen.getByLabelText("Preserve upstream signing key"));
 
     expect(packageFilterField).toHaveValue("");
     expect(includeDepsCheckbox).not.toBeChecked();

--- a/src/features/overview/components/InfoTablesContainer/InfoTablesContainer.test.tsx
+++ b/src/features/overview/components/InfoTablesContainer/InfoTablesContainer.test.tsx
@@ -29,8 +29,12 @@ describe("InfoTablesContainer", () => {
     });
 
     it("renders instance list", async () => {
-      const shownInstances = instances.slice(0, LIST_LIMIT);
-      for (const instance of shownInstances) {
+      const instancesWithUpgrades = instances.filter((instance) =>
+        instance.alerts?.some(({ type }) =>
+          ["PackageUpgradesAlert", "SecurityUpgradesAlert"].includes(type),
+        ),
+      );
+      for (const instance of instancesWithUpgrades.slice(0, LIST_LIMIT)) {
         const instanceTitle = await screen.findByText(instance.title);
         expect(instanceTitle).toBeInTheDocument();
       }

--- a/src/features/overview/components/InfoTablesContainer/InfoTablesContainer.test.tsx
+++ b/src/features/overview/components/InfoTablesContainer/InfoTablesContainer.test.tsx
@@ -34,6 +34,7 @@ describe("InfoTablesContainer", () => {
           ["PackageUpgradesAlert", "SecurityUpgradesAlert"].includes(type),
         ),
       );
+      expect(instancesWithUpgrades.length).toBeGreaterThan(0);
       for (const instance of instancesWithUpgrades.slice(0, LIST_LIMIT)) {
         const instanceTitle = await screen.findByText(instance.title);
         expect(instanceTitle).toBeInTheDocument();

--- a/src/tests/mocks/instance.ts
+++ b/src/tests/mocks/instance.ts
@@ -554,6 +554,7 @@ export const instances = [
       distributor: "Canonical",
       release: "12.04",
     },
+    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
@@ -1366,6 +1367,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
+    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1406,6 +1408,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
+    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1446,6 +1449,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
+    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1486,6 +1490,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
+    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1526,6 +1531,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
+    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1566,6 +1572,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
+    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1606,6 +1613,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
+    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1646,6 +1654,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
+    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1686,6 +1695,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
+    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1726,6 +1736,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
+    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1763,6 +1774,7 @@ export const instances = [
       distributor: "Canonical",
       release: "12.04",
     },
+    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",

--- a/src/tests/mocks/instance.ts
+++ b/src/tests/mocks/instance.ts
@@ -5,6 +5,12 @@ import type {
   WindowsInstance,
 } from "@/types/Instance";
 
+const packageUpgradesAlert = {
+  type: "PackageUpgradesAlert",
+  summary: "",
+  severity: "info",
+} as const;
+
 export const ubuntuInstance: Instance = {
   id: 1,
   title: "Application Server 1",
@@ -554,7 +560,7 @@ export const instances = [
       distributor: "Canonical",
       release: "12.04",
     },
-    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
+    alerts: [packageUpgradesAlert],
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
@@ -1367,7 +1373,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
-    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
+    alerts: [packageUpgradesAlert],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1408,7 +1414,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
-    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
+    alerts: [packageUpgradesAlert],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1449,7 +1455,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
-    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
+    alerts: [packageUpgradesAlert],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1490,7 +1496,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
-    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
+    alerts: [packageUpgradesAlert],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1531,7 +1537,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
-    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
+    alerts: [packageUpgradesAlert],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1572,7 +1578,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
-    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
+    alerts: [packageUpgradesAlert],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1613,7 +1619,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
-    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
+    alerts: [packageUpgradesAlert],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1654,7 +1660,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
-    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
+    alerts: [packageUpgradesAlert],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1695,7 +1701,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
-    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
+    alerts: [packageUpgradesAlert],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1736,7 +1742,7 @@ export const instances = [
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",
-    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
+    alerts: [packageUpgradesAlert],
     has_release_upgrades: false,
   } as Instance,
   {
@@ -1774,7 +1780,7 @@ export const instances = [
       distributor: "Canonical",
       release: "12.04",
     },
-    alerts: [{ type: "PackageUpgradesAlert", summary: "", severity: "info" }],
+    alerts: [packageUpgradesAlert],
     employee_id: 1,
     archived: false,
     registered_at: "2023-11-29T18:29:25Z",

--- a/src/tests/server/handlers/instance.ts
+++ b/src/tests/server/handlers/instance.ts
@@ -95,6 +95,17 @@ function matchComputersQuery(
       generatePaginatedResponse<Instance>({ data: [], limit, offset }),
     );
   }
+  if (
+    endpointStatus.status === "empty" &&
+    (endpointStatus.path === "computers-alert-empty" ||
+      endpointStatus.path === "empty-upgrades") &&
+    (query.includes("alert:security-upgrades") ||
+      query.includes("alert:package-upgrades"))
+  ) {
+    return HttpResponse.json(
+      generatePaginatedResponse<Instance>({ data: [], limit, offset }),
+    );
+  }
   if (query.includes("NOT alert:package-upgrades")) {
     return HttpResponse.json(
       generatePaginatedResponse<Instance>({
@@ -120,17 +131,6 @@ function matchComputersQuery(
         limit,
         offset,
       }),
-    );
-  }
-  if (
-    endpointStatus.status === "empty" &&
-    (endpointStatus.path === "computers-alert-empty" ||
-      endpointStatus.path === "empty-upgrades") &&
-    (query.includes("alert:security-upgrades") ||
-      query.includes("alert:package-upgrades"))
-  ) {
-    return HttpResponse.json(
-      generatePaginatedResponse<Instance>({ data: [], limit, offset }),
     );
   }
   if (query.includes("profile:repository:")) {


### PR DESCRIPTION
## Summary

Some test failures were introduced with PRs #602 and #611 / #612 all being merged around the same time. This PR updates tests so that all pass.

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [X] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [X] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [ ] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [ ] **UI verified** — I have verified the changes locally.
- [ ] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
