### PR TITLE
Snap build for landscape-ui

### DIFF
--- a/.changeset/long-pots-move.md
+++ b/.changeset/long-pots-move.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": minor
+---
+
+Add support for snap packaging for landscape-ui

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ src/**/*.module.scss.d.ts
 /playwright-report/
 /playwright/
 .cert
+snap/*.snap

--- a/snap/README.md
+++ b/snap/README.md
@@ -4,24 +4,26 @@ Serves the Landscape web dashboard (Vite/React SPA) over HTTPS and reverse-proxi
 
 ---
 
-## Build
+## Contents
 
-### macOS (via Multipass)
+- [Build](#build--linux)
+  - [Linux](#build--linux)
+  - [macOS (Multipass)](#build--macos-multipass)
+- [Install](#install)
+- [Run](#run)
+- [Access](#access)
+- [Connecting to a backend](#connecting-to-a-backend)
+  - [Linux](#linux)
+  - [macOS (Multipass)](#macos-multipass)
+- [Mock mode (MSW)](#mock-mode-msw)
+- [Configuration](#configuration)
+- [Logs and data paths](#logs-and-data-paths)
+- [Snap files](#snap-files)
+- [Appendix: MSW trade-offs](#appendix-msw-trade-offs)
 
-`snapcraft` only runs on Linux, so on macOS the build script manages a Multipass Ubuntu 24.04 VM automatically — creating it on first run and reusing it on subsequent runs.
+---
 
-**Prerequisites:** [Multipass](https://multipass.run) installed.
-
-```sh
-cd landscape-packaging/landscape-ui
-
-./snap/build-snap.sh              # production build
-./snap/build-snap.sh --mock       # MSW-enabled build — no backend needed
-```
-
-The VM is named `landscape-ui-build`. The script mounts the project directory into the VM at `/build`, rsyncs source to `/root/landscape-ui-src/`, and runs `snapcraft pack --destructive-mode` there. The `.snap` file is copied back to `snap/`.
-
-### Linux
+## Build — Linux
 
 **Prerequisites:**
 
@@ -42,7 +44,26 @@ The `.snap` file is written to `snap/output/`.
 
 ---
 
+## Build — macOS (Multipass)
+
+`snapcraft` only runs on Linux. On macOS the build script manages a Multipass Ubuntu 24.04 VM automatically — creating it on first run and reusing it on subsequent runs.
+
+**Prerequisites:** [Multipass](https://multipass.run) installed.
+
+```sh
+cd landscape-packaging/landscape-ui
+
+./snap/build-snap.sh              # production build
+./snap/build-snap.sh --mock       # MSW-enabled build — no backend needed
+```
+
+The VM is named `landscape-ui-build`. The script mounts the project directory into the VM at `/build`, rsyncs source to `/root/landscape-ui-src/`, and runs `snapcraft pack --destructive-mode` there. The `.snap` file is copied back to `snap/`.
+
+---
+
 ## Install
+
+Snaps can only be installed directly on Linux. If you're on a Mac or other OS, do the following steps inside the same multipass VM where you packed the snap.
 
 ```sh
 sudo snap install --devmode landscape-ui_*.snap
@@ -81,92 +102,69 @@ A self-signed TLS certificate is generated on first start. Accept the browser wa
 
 ```sh
 multipass info landscape-ui-build | grep IPv4
-# open https://<ip>/new_dashboard/
+# then open https://<ip>/new_dashboard/ on the host
 ```
 
 ---
 
 ## Connecting to a backend
 
-The snap proxies `/api/` and `/debarchive/` to configurable hosts. There are two supported setups.
+The snap proxies `/api/` to the Landscape API and `/debarchive/` to the deb archive service. The `/debarchive/v1beta1/` URL slug used by the browser is fixed — nginx strips the `/debarchive` prefix before forwarding, so the backend always receives `/v1beta1/` regardless of host or port.
 
-### Option A — backend on the Mac host (snap in Multipass VM)
+### Linux
 
-Run the landscape-backend rock stack on your Mac as normal (`docker compose up` in `landscape-packaging/rock/`), then point the snap at the Mac's IP as seen from the VM:
+**Rock stack (localhost defaults)**
+
+The snap defaults match the rock stack's haproxy (`443`) and debarchive (`8000`) ports. Start the stack and install the snap — no `snap set` required.
 
 ```sh
-# The Mac host is always reachable from Multipass VMs at 192.168.64.1
+cd landscape-packaging/rock
+docker compose up -d
+```
+
+**Backend containers without the rock stack**
+
+If services are running directly (not via the rock stack), ports will differ. Point the snap at them explicitly:
+
+```sh
+sudo snap set landscape-ui \
+  landscape.ui.backend-host=localhost \
+  landscape.ui.backend-port=9091 \
+  landscape.ui.backend-scheme=http \
+  landscape.ui.debarchive-host=localhost \
+  landscape.ui.debarchive-port=8000 \
+  landscape.ui.debarchive-scheme=http
+```
+
+### macOS (Multipass)
+
+Run the backend on your Mac with the snap running in Multipass. The Mac host is always reachable from Multipass VMs at `192.168.64.1`:
+
+**Option A — Using the landscape-backend rock stack:**
+
+```sh
 multipass exec landscape-ui-build -- sudo snap set landscape-ui \
   landscape.ui.backend-host=192.168.64.1 \
   landscape.ui.backend-port=443 \
   landscape.ui.debarchive-host=192.168.64.1 \
-  landscape.ui.debarchive-port=443
+  landscape.ui.debarchive-port=8000
 ```
 
-The snap nginx proxies to `https://192.168.64.1:443` with TLS verification disabled (self-signed backend cert is fine).
+---
 
-Open `https://192.168.64.24/new_dashboard/` (use your VM's actual IP).
+**Option B — Using the docker setup from landscape-packaging, no rock build:**
 
-### Option B — backend inside the Multipass VM (fully self-contained)
-
-Run the rock stack inside the same VM as the snap. Useful for demos or QA where you want a fully isolated environment.
-
-**1. Install Docker in the VM:**
-
-```sh
-multipass exec landscape-ui-build -- bash -c "
-  curl -fsSL https://get.docker.com | sudo sh
-  sudo usermod -aG docker ubuntu
-"
-```
-
-**2. Copy the rock image into the VM and import it:**
-
-```sh
-# On your Mac — copy the built .rock file into the VM
-multipass transfer \
-  landscape-packaging/rock/landscape-backend_*.rock \
-  landscape-ui-build:/home/ubuntu/
-
-# In the VM — import into Docker
-multipass exec landscape-ui-build -- bash -c "
-  docker run -d -p 6100:5000 --name registry registry:2
-  skopeo copy --dest-tls-verify=false \
-    oci-archive:/home/ubuntu/landscape-backend_*.rock \
-    docker://localhost:6100/landscape-backend:latest
-  docker pull localhost:6100/landscape-backend:latest
-  docker tag localhost:6100/landscape-backend:latest landscape-backend:latest
-"
-```
-
-**3. Copy the compose stack and start it:**
-
-```sh
-multipass transfer --recursive \
-  landscape-packaging/rock/. \
-  landscape-ui-build:/home/ubuntu/landscape-rock/
-
-multipass exec landscape-ui-build -- bash -c "
-  cd /home/ubuntu/landscape-rock
-  LANDSCAPE_BOOTSTRAP_SCHEMA_ARGS='--with-computers' docker compose up -d
-"
-```
-
-**4. Point the snap at localhost (default — no `snap set` needed):**
-
-The snap's default `backend-host` is `localhost` and `backend-port` is `443`, matching the compose stack's haproxy port. If you previously changed these, reset them:
+Same as above but with different ports:
 
 ```sh
 multipass exec landscape-ui-build -- sudo snap set landscape-ui \
-  landscape.ui.backend-host=localhost \
-  landscape.ui.backend-port=443 \
-  landscape.ui.debarchive-host=localhost \
-  landscape.ui.debarchive-port=443
+  landscape.ui.backend-host=192.168.64.1 \
+  landscape.ui.backend-port=9091 \
+  landscape.ui.backend-scheme=http \
+  landscape.ui.debarchive-host=192.168.64.1 \
+  landscape.ui.debarchive-port=8000 \
+  landscape.ui.debarchive-scheme=http
 ```
-
-The compose stack's haproxy listens on port 443 inside the VM, so the snap proxies to `https://localhost:443`.
-
-Open `https://<vm-ip>/new_dashboard/`.
 
 ---
 
@@ -175,10 +173,12 @@ Open `https://<vm-ip>/new_dashboard/`.
 Build with `--mock` to embed [Mock Service Worker](https://mswjs.io/) in the bundle. All API calls are intercepted in-browser — no Landscape backend is required. Useful for UI development and demo purposes.
 
 ```sh
-./snap/build-snap.sh --mock          # macOS
 ./snap/build-snap-linux.sh --mock    # Linux
+./snap/build-snap.sh --mock          # macOS
 sudo snap install --devmode snap/landscape-ui_*.snap
 ```
+
+See [Appendix: MSW trade-offs](#appendix-msw-trade-offs) for the implications of including or dropping this feature.
 
 ---
 
@@ -186,17 +186,17 @@ sudo snap install --devmode snap/landscape-ui_*.snap
 
 Use `snap set` to configure the snap at runtime. Changes take effect immediately (the service restarts automatically).
 
-| Key                            | Default        | Description                  |
-| ------------------------------ | -------------- | ---------------------------- |
-| `landscape.ui.listen-port`     | `443`          | HTTPS listen port            |
-| `landscape.ui.backend-host` | `localhost` | Landscape API host |
-| `landscape.ui.backend-port` | `443` | Landscape API port (haproxy) |
-| `landscape.ui.backend-scheme` | `https` | Landscape API scheme (`http` or `https`) |
-| `landscape.ui.debarchive-host` | `localhost` | Deb archive host |
-| `landscape.ui.debarchive-port` | `8000` | Deb archive port |
-| `landscape.ui.debarchive-scheme` | `http` | Deb archive scheme (`http` or `https`) |
-| `landscape.ui.cert-file`       | auto-generated | Path to TLS certificate      |
-| `landscape.ui.key-file`        | auto-generated | Path to TLS private key      |
+| Key                              | Default        | Description                              |
+| -------------------------------- | -------------- | ---------------------------------------- |
+| `landscape.ui.listen-port`       | `443`          | HTTPS listen port                        |
+| `landscape.ui.backend-host`      | `localhost`    | Landscape API host                       |
+| `landscape.ui.backend-port`      | `443`          | Landscape API port (haproxy)             |
+| `landscape.ui.backend-scheme`    | `https`        | Landscape API scheme (`http` or `https`) |
+| `landscape.ui.debarchive-host`   | `localhost`    | Deb archive host                         |
+| `landscape.ui.debarchive-port`   | `8000`         | Deb archive port                         |
+| `landscape.ui.debarchive-scheme` | `http`         | Deb archive scheme (`http` or `https`)   |
+| `landscape.ui.cert-file`         | auto-generated | Path to TLS certificate                  |
+| `landscape.ui.key-file`          | auto-generated | Path to TLS private key                  |
 
 **Example — point to a running Landscape server:**
 
@@ -238,3 +238,35 @@ sudo snap set landscape-ui \
 | `snap/hooks/configure`             | Restarts service on `snap set`                                           |
 | `snap/build-snap.sh`               | macOS build script (Multipass)                                           |
 | `snap/build-snap-linux.sh`         | Linux build script (native)                                              |
+
+---
+
+## Appendix: MSW trade-offs
+
+[Mock Service Worker](https://mswjs.io/) intercepts API requests in the browser's service worker layer. The `--mock` build flag embeds it in the snap bundle.
+
+### Keeping MSW support
+
+**Pros**
+
+- Snap works without any backend — useful for demos, UI development, offline QA
+- No `snap set` configuration needed after install
+
+**Cons**
+
+- Two source changes required to make MSW work in production builds:
+  - `main.tsx`: the `isDevEnv &&` guard on the MSW start call must be removed, because `import.meta.env.DEV` is `false` in all Vite production builds
+  - `vite.config.ts`: the `exclude-msw` plugin must skip deleting `mockServiceWorker.js` when `VITE_MSW_ENABLED=true`
+- `mockServiceWorker.js` is included in every `--mock` build (~50 KB)
+- `VITE_MSW_ENABLED=true` and `VITE_MSW_ENDPOINTS_TO_INTERCEPT=/` must both be set at build time; missing either silently disables interception
+
+### Dropping MSW support
+
+Revert these changes and the snap becomes real-backend-only:
+
+- `main.tsx` — restore `isDevEnv &&` guard
+- `vite.config.ts` — always delete `mockServiceWorker.js` from dist
+- `build-snap.sh` / `build-snap-linux.sh` — remove `VITE_MSW_ENABLED` and `VITE_MSW_ENDPOINTS_TO_INTERCEPT` from `.env.production.local`; remove `--mock` flag handling
+- `snap/README.md` — remove Mock mode section
+
+Simpler build scripts, no production-mode MSW edge cases, smaller bundle.

--- a/snap/README.md
+++ b/snap/README.md
@@ -189,10 +189,12 @@ Use `snap set` to configure the snap at runtime. Changes take effect immediately
 | Key                            | Default        | Description                  |
 | ------------------------------ | -------------- | ---------------------------- |
 | `landscape.ui.listen-port`     | `443`          | HTTPS listen port            |
-| `landscape.ui.backend-host`    | `localhost`    | Landscape API host           |
-| `landscape.ui.backend-port`    | `443`          | Landscape API port (haproxy) |
-| `landscape.ui.debarchive-host` | `localhost`    | Deb archive host             |
-| `landscape.ui.debarchive-port` | `443`          | Deb archive port (haproxy)   |
+| `landscape.ui.backend-host` | `localhost` | Landscape API host |
+| `landscape.ui.backend-port` | `443` | Landscape API port (haproxy) |
+| `landscape.ui.backend-scheme` | `https` | Landscape API scheme (`http` or `https`) |
+| `landscape.ui.debarchive-host` | `localhost` | Deb archive host |
+| `landscape.ui.debarchive-port` | `8000` | Deb archive port |
+| `landscape.ui.debarchive-scheme` | `http` | Deb archive scheme (`http` or `https`) |
 | `landscape.ui.cert-file`       | auto-generated | Path to TLS certificate      |
 | `landscape.ui.key-file`        | auto-generated | Path to TLS private key      |
 

--- a/snap/README.md
+++ b/snap/README.md
@@ -23,8 +23,6 @@ The VM is named `landscape-ui-build`. The script mounts the project directory in
 
 ### Linux
 
-Run the build directly — no VM required.
-
 **Prerequisites:**
 
 ```sh
@@ -188,15 +186,15 @@ sudo snap install --devmode snap/landscape-ui_*.snap
 
 Use `snap set` to configure the snap at runtime. Changes take effect immediately (the service restarts automatically).
 
-| Key | Default | Description |
-|-----|---------|-------------|
-| `landscape.ui.listen-port` | `443` | HTTPS listen port |
-| `landscape.ui.backend-host` | `localhost` | Landscape API host |
-| `landscape.ui.backend-port` | `443` | Landscape API port (haproxy) |
-| `landscape.ui.debarchive-host` | `localhost` | Deb archive host |
-| `landscape.ui.debarchive-port` | `443` | Deb archive port (haproxy) |
-| `landscape.ui.cert-file` | auto-generated | Path to TLS certificate |
-| `landscape.ui.key-file` | auto-generated | Path to TLS private key |
+| Key                            | Default        | Description                  |
+| ------------------------------ | -------------- | ---------------------------- |
+| `landscape.ui.listen-port`     | `443`          | HTTPS listen port            |
+| `landscape.ui.backend-host`    | `localhost`    | Landscape API host           |
+| `landscape.ui.backend-port`    | `443`          | Landscape API port (haproxy) |
+| `landscape.ui.debarchive-host` | `localhost`    | Deb archive host             |
+| `landscape.ui.debarchive-port` | `443`          | Deb archive port (haproxy)   |
+| `landscape.ui.cert-file`       | auto-generated | Path to TLS certificate      |
+| `landscape.ui.key-file`        | auto-generated | Path to TLS private key      |
 
 **Example — point to a running Landscape server:**
 
@@ -218,23 +216,23 @@ sudo snap set landscape-ui \
 
 ## Logs and data paths
 
-| Path | Contents |
-|------|----------|
-| `/var/snap/landscape-ui/common/nginx.conf` | Rendered nginx config (read-only reference) |
-| `/var/snap/landscape-ui/common/nginx-error.log` | nginx error log |
-| `/var/snap/landscape-ui/common/nginx-access.log` | nginx access log |
-| `/var/snap/landscape-ui/common/ssl/` | Auto-generated TLS certificate and key |
+| Path                                             | Contents                                    |
+| ------------------------------------------------ | ------------------------------------------- |
+| `/var/snap/landscape-ui/common/nginx.conf`       | Rendered nginx config (read-only reference) |
+| `/var/snap/landscape-ui/common/nginx-error.log`  | nginx error log                             |
+| `/var/snap/landscape-ui/common/nginx-access.log` | nginx access log                            |
+| `/var/snap/landscape-ui/common/ssl/`             | Auto-generated TLS certificate and key      |
 
 ---
 
 ## Snap files
 
-| File | Purpose |
-|------|---------|
-| `snap/snapcraft.yaml` | Snap definition |
+| File                               | Purpose                                                                  |
+| ---------------------------------- | ------------------------------------------------------------------------ |
+| `snap/snapcraft.yaml`              | Snap definition                                                          |
 | `snap/local/start-landscape-ui.sh` | Service entrypoint — reads snap config, renders nginx.conf, starts nginx |
-| `snap/local/nginx.conf.tmpl` | nginx config template (envsubst) |
-| `snap/local/generate-cert.sh` | Self-signed cert generation (idempotent) |
-| `snap/hooks/configure` | Restarts service on `snap set` |
-| `snap/build-snap.sh` | macOS build script (Multipass) |
-| `snap/build-snap-linux.sh` | Linux build script (native) |
+| `snap/local/nginx.conf.tmpl`       | nginx config template (envsubst)                                         |
+| `snap/local/generate-cert.sh`      | Self-signed cert generation (idempotent)                                 |
+| `snap/hooks/configure`             | Restarts service on `snap set`                                           |
+| `snap/build-snap.sh`               | macOS build script (Multipass)                                           |
+| `snap/build-snap-linux.sh`         | Linux build script (native)                                              |

--- a/snap/README.md
+++ b/snap/README.md
@@ -1,0 +1,240 @@
+# landscape-ui snap
+
+Serves the Landscape web dashboard (Vite/React SPA) over HTTPS and reverse-proxies API traffic to the Landscape backend services.
+
+---
+
+## Build
+
+### macOS (via Multipass)
+
+`snapcraft` only runs on Linux, so on macOS the build script manages a Multipass Ubuntu 24.04 VM automatically — creating it on first run and reusing it on subsequent runs.
+
+**Prerequisites:** [Multipass](https://multipass.run) installed.
+
+```sh
+cd landscape-packaging/landscape-ui
+
+./snap/build-snap.sh              # production build
+./snap/build-snap.sh --mock       # MSW-enabled build — no backend needed
+```
+
+The VM is named `landscape-ui-build`. The script mounts the project directory into the VM at `/build`, rsyncs source to `/root/landscape-ui-src/`, and runs `snapcraft pack --destructive-mode` there. The `.snap` file is copied back to `snap/`.
+
+### Linux
+
+Run the build directly — no VM required.
+
+**Prerequisites:**
+
+```sh
+sudo snap install snapcraft --classic
+```
+
+Node.js ≥ 24 is installed automatically by snapcraft via the `node/24/stable` build snap.
+
+```sh
+cd landscape-packaging/landscape-ui
+
+./snap/build-snap-linux.sh              # production build
+./snap/build-snap-linux.sh --mock       # MSW-enabled build — no backend needed
+```
+
+The `.snap` file is written to `snap/output/`.
+
+---
+
+## Install
+
+```sh
+sudo snap install --devmode landscape-ui_*.snap
+```
+
+`devmode` is required — the snap is `grade: devel`.
+
+---
+
+## Run
+
+The snap service starts automatically after installation. To manage it manually:
+
+```sh
+sudo snap start landscape-ui
+sudo snap stop landscape-ui
+sudo snap restart landscape-ui
+sudo snap services landscape-ui      # show status
+sudo snap logs landscape-ui          # show recent logs
+sudo snap logs -f landscape-ui       # follow logs
+```
+
+---
+
+## Access
+
+The dashboard is served at:
+
+```
+https://<host-ip>/new_dashboard/
+```
+
+A self-signed TLS certificate is generated on first start. Accept the browser warning to proceed.
+
+**In a Multipass VM:**
+
+```sh
+multipass info landscape-ui-build | grep IPv4
+# open https://<ip>/new_dashboard/
+```
+
+---
+
+## Connecting to a backend
+
+The snap proxies `/api/` and `/debarchive/` to configurable hosts. There are two supported setups.
+
+### Option A — backend on the Mac host (snap in Multipass VM)
+
+Run the landscape-backend rock stack on your Mac as normal (`docker compose up` in `landscape-packaging/rock/`), then point the snap at the Mac's IP as seen from the VM:
+
+```sh
+# The Mac host is always reachable from Multipass VMs at 192.168.64.1
+multipass exec landscape-ui-build -- sudo snap set landscape-ui \
+  landscape.ui.backend-host=192.168.64.1 \
+  landscape.ui.backend-port=443 \
+  landscape.ui.debarchive-host=192.168.64.1 \
+  landscape.ui.debarchive-port=443
+```
+
+The snap nginx proxies to `https://192.168.64.1:443` with TLS verification disabled (self-signed backend cert is fine).
+
+Open `https://192.168.64.24/new_dashboard/` (use your VM's actual IP).
+
+### Option B — backend inside the Multipass VM (fully self-contained)
+
+Run the rock stack inside the same VM as the snap. Useful for demos or QA where you want a fully isolated environment.
+
+**1. Install Docker in the VM:**
+
+```sh
+multipass exec landscape-ui-build -- bash -c "
+  curl -fsSL https://get.docker.com | sudo sh
+  sudo usermod -aG docker ubuntu
+"
+```
+
+**2. Copy the rock image into the VM and import it:**
+
+```sh
+# On your Mac — copy the built .rock file into the VM
+multipass transfer \
+  landscape-packaging/rock/landscape-backend_*.rock \
+  landscape-ui-build:/home/ubuntu/
+
+# In the VM — import into Docker
+multipass exec landscape-ui-build -- bash -c "
+  docker run -d -p 6100:5000 --name registry registry:2
+  skopeo copy --dest-tls-verify=false \
+    oci-archive:/home/ubuntu/landscape-backend_*.rock \
+    docker://localhost:6100/landscape-backend:latest
+  docker pull localhost:6100/landscape-backend:latest
+  docker tag localhost:6100/landscape-backend:latest landscape-backend:latest
+"
+```
+
+**3. Copy the compose stack and start it:**
+
+```sh
+multipass transfer --recursive \
+  landscape-packaging/rock/. \
+  landscape-ui-build:/home/ubuntu/landscape-rock/
+
+multipass exec landscape-ui-build -- bash -c "
+  cd /home/ubuntu/landscape-rock
+  LANDSCAPE_BOOTSTRAP_SCHEMA_ARGS='--with-computers' docker compose up -d
+"
+```
+
+**4. Point the snap at localhost (default — no `snap set` needed):**
+
+The snap's default `backend-host` is `localhost` and `backend-port` is `443`, matching the compose stack's haproxy port. If you previously changed these, reset them:
+
+```sh
+multipass exec landscape-ui-build -- sudo snap set landscape-ui \
+  landscape.ui.backend-host=localhost \
+  landscape.ui.backend-port=443 \
+  landscape.ui.debarchive-host=localhost \
+  landscape.ui.debarchive-port=443
+```
+
+The compose stack's haproxy listens on port 443 inside the VM, so the snap proxies to `https://localhost:443`.
+
+Open `https://<vm-ip>/new_dashboard/`.
+
+---
+
+## Mock mode (MSW)
+
+Build with `--mock` to embed [Mock Service Worker](https://mswjs.io/) in the bundle. All API calls are intercepted in-browser — no Landscape backend is required. Useful for UI development and demo purposes.
+
+```sh
+./snap/build-snap.sh --mock          # macOS
+./snap/build-snap-linux.sh --mock    # Linux
+sudo snap install --devmode snap/landscape-ui_*.snap
+```
+
+---
+
+## Configuration
+
+Use `snap set` to configure the snap at runtime. Changes take effect immediately (the service restarts automatically).
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `landscape.ui.listen-port` | `443` | HTTPS listen port |
+| `landscape.ui.backend-host` | `localhost` | Landscape API host |
+| `landscape.ui.backend-port` | `443` | Landscape API port (haproxy) |
+| `landscape.ui.debarchive-host` | `localhost` | Deb archive host |
+| `landscape.ui.debarchive-port` | `443` | Deb archive port (haproxy) |
+| `landscape.ui.cert-file` | auto-generated | Path to TLS certificate |
+| `landscape.ui.key-file` | auto-generated | Path to TLS private key |
+
+**Example — point to a running Landscape server:**
+
+```sh
+sudo snap set landscape-ui \
+  landscape.ui.backend-host=192.168.1.10 \
+  landscape.ui.backend-port=8080
+```
+
+**Example — bring your own certificate:**
+
+```sh
+sudo snap set landscape-ui \
+  landscape.ui.cert-file=/var/snap/landscape-ui/common/ssl/custom.crt \
+  landscape.ui.key-file=/var/snap/landscape-ui/common/ssl/custom.key
+```
+
+---
+
+## Logs and data paths
+
+| Path | Contents |
+|------|----------|
+| `/var/snap/landscape-ui/common/nginx.conf` | Rendered nginx config (read-only reference) |
+| `/var/snap/landscape-ui/common/nginx-error.log` | nginx error log |
+| `/var/snap/landscape-ui/common/nginx-access.log` | nginx access log |
+| `/var/snap/landscape-ui/common/ssl/` | Auto-generated TLS certificate and key |
+
+---
+
+## Snap files
+
+| File | Purpose |
+|------|---------|
+| `snap/snapcraft.yaml` | Snap definition |
+| `snap/local/start-landscape-ui.sh` | Service entrypoint — reads snap config, renders nginx.conf, starts nginx |
+| `snap/local/nginx.conf.tmpl` | nginx config template (envsubst) |
+| `snap/local/generate-cert.sh` | Self-signed cert generation (idempotent) |
+| `snap/hooks/configure` | Restarts service on `snap set` |
+| `snap/build-snap.sh` | macOS build script (Multipass) |
+| `snap/build-snap-linux.sh` | Linux build script (native) |

--- a/snap/build-snap-linux.sh
+++ b/snap/build-snap-linux.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# build-snap-linux.sh — build the landscape-ui snap directly on a Linux host.
+#
+# Requirements:
+#   sudo snap install snapcraft --classic
+#   sudo snap install node --channel=24/stable --classic  (or use system node >=24)
+#
+# Usage:
+#   ./snap/build-snap-linux.sh              # production build
+#   ./snap/build-snap-linux.sh --mock       # MSW-enabled build (no backend needed for testing)
+
+set -e
+
+MOCK=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --mock) MOCK=true ;;
+        *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+ENV_OVERRIDE="$PROJECT_DIR/.env.production.local"
+CLEANUP=false
+
+if [ "$MOCK" = true ]; then
+    printf 'VITE_MSW_ENABLED=true\n' > "$ENV_OVERRIDE"
+    CLEANUP=true
+    echo "MSW mock mode enabled — writing .env.production.local"
+fi
+
+cleanup() {
+    [ "$CLEANUP" = true ] && rm -f "$ENV_OVERRIDE"
+}
+trap cleanup EXIT
+
+cd "$PROJECT_DIR"
+
+# Always clean the frontend part so env changes (e.g. VITE_MSW_ENABLED)
+# are picked up — snapcraft does not track .env files as source inputs.
+snapcraft clean frontend --destructive-mode
+
+mkdir -p snap/output
+snapcraft pack --destructive-mode --output snap/output 2>&1
+
+SNAP_FILE="$(ls snap/output/*.snap 2>/dev/null | head -1)"
+if [ -n "$SNAP_FILE" ]; then
+    echo "Built: $SNAP_FILE"
+else
+    echo "Warning: no .snap file found in snap/output/"
+fi

--- a/snap/build-snap-linux.sh
+++ b/snap/build-snap-linux.sh
@@ -12,10 +12,12 @@
 set -e
 
 MOCK=false
+CLEAN_FRONTEND=false
 
 for arg in "$@"; do
     case "$arg" in
         --mock) MOCK=true ;;
+        --clean) CLEAN_FRONTEND=true ;;
         *) echo "Unknown argument: $arg" >&2; exit 1 ;;
     esac
 done
@@ -28,6 +30,7 @@ CLEANUP=false
 if [ "$MOCK" = true ]; then
     printf 'VITE_MSW_ENABLED=true\nVITE_MSW_ENDPOINTS_TO_INTERCEPT=/\n' > "$ENV_OVERRIDE"
     CLEANUP=true
+    CLEAN_FRONTEND=true
     echo "MSW mock mode enabled — writing .env.production.local"
 fi
 
@@ -38,9 +41,11 @@ trap cleanup EXIT
 
 cd "$PROJECT_DIR"
 
-# Always clean the frontend part so env changes (e.g. VITE_MSW_ENABLED)
-# are picked up — snapcraft does not track .env files as source inputs.
-snapcraft clean frontend --destructive-mode
+if [ "$CLEAN_FRONTEND" = true ]; then
+    # Clean frontend when explicitly requested or when mock mode is used.
+    # This ensures env overrides like VITE_MSW_ENABLED are picked up.
+    snapcraft clean frontend --destructive-mode
+fi
 
 mkdir -p snap/output
 snapcraft pack --destructive-mode --output snap/output 2>&1

--- a/snap/build-snap-linux.sh
+++ b/snap/build-snap-linux.sh
@@ -26,7 +26,7 @@ ENV_OVERRIDE="$PROJECT_DIR/.env.production.local"
 CLEANUP=false
 
 if [ "$MOCK" = true ]; then
-    printf 'VITE_MSW_ENABLED=true\n' > "$ENV_OVERRIDE"
+    printf 'VITE_MSW_ENABLED=true\nVITE_MSW_ENDPOINTS_TO_INTERCEPT=/\n' > "$ENV_OVERRIDE"
     CLEANUP=true
     echo "MSW mock mode enabled — writing .env.production.local"
 fi

--- a/snap/build-snap.sh
+++ b/snap/build-snap.sh
@@ -6,10 +6,12 @@ VM_CPUS="4"
 VM_MEMORY="8G"
 VM_DISK="40G"
 MOCK=false
+CLEAN_FRONTEND=false
 
 for arg in "$@"; do
     case "$arg" in
         --mock) MOCK=true ;;
+        --clean) CLEAN_FRONTEND=true ;;
         --vm=*) VM_NAME="${arg#--vm=}" ;;
         *) echo "Unknown argument: $arg" >&2; exit 1 ;;
     esac
@@ -23,6 +25,7 @@ CLEANUP=false
 if [ "$MOCK" = true ]; then
     printf 'VITE_MSW_ENABLED=true\nVITE_MSW_ENDPOINTS_TO_INTERCEPT=/\n' > "$ENV_OVERRIDE"
     CLEANUP=true
+    CLEAN_FRONTEND=true
     echo "MSW mock mode enabled — writing .env.production.local"
 fi
 
@@ -63,7 +66,12 @@ multipass exec "$VM_NAME" -- sudo rsync -a --delete \
     /build/ /root/landscape-ui-src/
 
 echo "Building snap in VM '$VM_NAME'..."
-multipass exec "$VM_NAME" -- sudo -H sh -c 'set -e; cd /root/landscape-ui-src; snapcraft clean frontend --destructive-mode; mkdir -p /tmp/snap-output; snapcraft pack --destructive-mode --output /tmp/snap-output'
+if [ "$CLEAN_FRONTEND" = true ]; then
+    echo "Cleaning frontend part before build..."
+    multipass exec "$VM_NAME" -- sudo -H sh -c 'set -e; cd /root/landscape-ui-src; snapcraft clean frontend --destructive-mode; mkdir -p /tmp/snap-output; snapcraft pack --destructive-mode --output /tmp/snap-output'
+else
+    multipass exec "$VM_NAME" -- sudo -H sh -c 'set -e; cd /root/landscape-ui-src; mkdir -p /tmp/snap-output; snapcraft pack --destructive-mode --output /tmp/snap-output'
+fi
 
 echo "Copying snap to host..."
 multipass exec "$VM_NAME" -- sudo sh -c 'cp /tmp/snap-output/*.snap /build/snap/'

--- a/snap/build-snap.sh
+++ b/snap/build-snap.sh
@@ -21,7 +21,7 @@ ENV_OVERRIDE="$PROJECT_DIR/.env.production.local"
 CLEANUP=false
 
 if [ "$MOCK" = true ]; then
-    printf 'VITE_MSW_ENABLED=true\n' > "$ENV_OVERRIDE"
+    printf 'VITE_MSW_ENABLED=true\nVITE_MSW_ENDPOINTS_TO_INTERCEPT=/\n' > "$ENV_OVERRIDE"
     CLEANUP=true
     echo "MSW mock mode enabled — writing .env.production.local"
 fi
@@ -54,30 +54,19 @@ ensure_vm
 ensure_mount
 
 echo "Syncing source into VM..."
-multipass exec "$VM_NAME" -- sudo -H -- sh -c "
-    rsync -a --delete \
-        --exclude=node_modules \
-        --exclude=dist \
-        --exclude=parts \
-        --exclude=stage \
-        --exclude=prime \
-        /build/ /root/landscape-ui-src/
-"
+multipass exec "$VM_NAME" -- sudo rsync -a --delete \
+    --exclude=node_modules \
+    --exclude=dist \
+    --exclude=parts \
+    --exclude=stage \
+    --exclude=prime \
+    /build/ /root/landscape-ui-src/
 
 echo "Building snap in VM '$VM_NAME'..."
-multipass exec "$VM_NAME" -- sudo -H -- sh -c "
-    set -e
-    cd /root/landscape-ui-src
-    # Always clean the frontend part so env changes (e.g. VITE_MSW_ENABLED)
-    # are picked up. snapcraft does not track .env files as source inputs.
-    snapcraft clean frontend --destructive-mode
-    mkdir -p /tmp/snap-output
-    snapcraft pack --destructive-mode --output /tmp/snap-output 2>&1
-"
+multipass exec "$VM_NAME" -- sudo -H sh -c 'set -e; cd /root/landscape-ui-src; snapcraft clean frontend --destructive-mode; mkdir -p /tmp/snap-output; snapcraft pack --destructive-mode --output /tmp/snap-output'
 
 echo "Copying snap to host..."
-multipass exec "$VM_NAME" -- sudo -H -- sh -c \
-    "cp /tmp/snap-output/*.snap /build/snap/"
+multipass exec "$VM_NAME" -- sudo sh -c 'cp /tmp/snap-output/*.snap /build/snap/'
 
 SNAP_FILE="$(ls "$PROJECT_DIR/snap"/*.snap 2>/dev/null | head -1)"
 if [ -n "$SNAP_FILE" ]; then

--- a/snap/build-snap.sh
+++ b/snap/build-snap.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+set -e
+
+VM_NAME="landscape-ui-build"
+VM_CPUS="4"
+VM_MEMORY="8G"
+VM_DISK="40G"
+MOCK=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --mock) MOCK=true ;;
+        --vm=*) VM_NAME="${arg#--vm=}" ;;
+        *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+ENV_OVERRIDE="$PROJECT_DIR/.env.production.local"
+CLEANUP=false
+
+if [ "$MOCK" = true ]; then
+    printf 'VITE_MSW_ENABLED=true\n' > "$ENV_OVERRIDE"
+    CLEANUP=true
+    echo "MSW mock mode enabled — writing .env.production.local"
+fi
+
+cleanup() {
+    [ "$CLEANUP" = true ] && rm -f "$ENV_OVERRIDE"
+}
+trap cleanup EXIT
+
+ensure_vm() {
+    if ! multipass info "$VM_NAME" >/dev/null 2>&1; then
+        echo "Creating VM '$VM_NAME'..."
+        multipass launch 24.04 \
+            --name "$VM_NAME" \
+            --cpus "$VM_CPUS" \
+            --memory "$VM_MEMORY" \
+            --disk "$VM_DISK"
+        echo "Installing snapcraft in VM..."
+        multipass exec "$VM_NAME" -- sudo snap install snapcraft --classic
+    fi
+}
+
+ensure_mount() {
+    if ! multipass info "$VM_NAME" --format json | grep -q "$PROJECT_DIR"; then
+        multipass mount "$PROJECT_DIR" "$VM_NAME":/build
+    fi
+}
+
+ensure_vm
+ensure_mount
+
+echo "Syncing source into VM..."
+multipass exec "$VM_NAME" -- sudo -H -- sh -c "
+    rsync -a --delete \
+        --exclude=node_modules \
+        --exclude=dist \
+        --exclude=parts \
+        --exclude=stage \
+        --exclude=prime \
+        /build/ /root/landscape-ui-src/
+"
+
+echo "Building snap in VM '$VM_NAME'..."
+multipass exec "$VM_NAME" -- sudo -H -- sh -c "
+    set -e
+    cd /root/landscape-ui-src
+    # Always clean the frontend part so env changes (e.g. VITE_MSW_ENABLED)
+    # are picked up. snapcraft does not track .env files as source inputs.
+    snapcraft clean frontend --destructive-mode
+    mkdir -p /tmp/snap-output
+    snapcraft pack --destructive-mode --output /tmp/snap-output 2>&1
+"
+
+echo "Copying snap to host..."
+multipass exec "$VM_NAME" -- sudo -H -- sh -c \
+    "cp /tmp/snap-output/*.snap /build/snap/"
+
+SNAP_FILE="$(ls "$PROJECT_DIR/snap"/*.snap 2>/dev/null | head -1)"
+if [ -n "$SNAP_FILE" ]; then
+    echo "Built: $SNAP_FILE"
+else
+    echo "Warning: no .snap file found"
+fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+snapctl restart "$SNAP_INSTANCE_NAME.landscape-ui"

--- a/snap/local/generate-cert.sh
+++ b/snap/local/generate-cert.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+CERT_DIR="$SNAP_COMMON/ssl"
+mkdir -p "$CERT_DIR"
+[ -f "$CERT_DIR/nginx.crt" ] && exit 0
+
+openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \
+  -keyout "$CERT_DIR/nginx.key" \
+  -out "$CERT_DIR/nginx.crt" \
+  -subj "/CN=landscape-ui"

--- a/snap/local/nginx.conf.tmpl
+++ b/snap/local/nginx.conf.tmpl
@@ -42,7 +42,7 @@ http {
         }
 
         location /api/ {
-            proxy_pass https://${LANDSCAPE_UI_BACKEND_HOST}:${LANDSCAPE_UI_BACKEND_PORT};
+            proxy_pass ${LANDSCAPE_UI_BACKEND_SCHEME}://${LANDSCAPE_UI_BACKEND_HOST}:${LANDSCAPE_UI_BACKEND_PORT};
             proxy_ssl_verify off;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -52,7 +52,7 @@ http {
 
         location /debarchive/ {
             rewrite ^/debarchive/(.*) /$1 break;
-            proxy_pass https://${LANDSCAPE_UI_DEBARCHIVE_HOST}:${LANDSCAPE_UI_DEBARCHIVE_PORT};
+            proxy_pass ${LANDSCAPE_UI_DEBARCHIVE_SCHEME}://${LANDSCAPE_UI_DEBARCHIVE_HOST}:${LANDSCAPE_UI_DEBARCHIVE_PORT};
             proxy_ssl_verify off;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;

--- a/snap/local/nginx.conf.tmpl
+++ b/snap/local/nginx.conf.tmpl
@@ -1,0 +1,63 @@
+worker_processes auto;
+pid        ${SNAP_COMMON}/nginx.pid;
+error_log  ${SNAP_COMMON}/nginx-error.log warn;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       ${SNAP}/etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    access_log  ${SNAP_COMMON}/nginx-access.log;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    client_body_temp_path  ${SNAP_COMMON}/nginx-tmp/client;
+    proxy_temp_path        ${SNAP_COMMON}/nginx-tmp/proxy;
+    fastcgi_temp_path      ${SNAP_COMMON}/nginx-tmp/fastcgi;
+    uwsgi_temp_path        ${SNAP_COMMON}/nginx-tmp/uwsgi;
+    scgi_temp_path         ${SNAP_COMMON}/nginx-tmp/scgi;
+
+    server {
+        listen ${LANDSCAPE_UI_LISTEN_PORT} ssl;
+
+        ssl_certificate     ${LANDSCAPE_UI_CERT_FILE};
+        ssl_certificate_key ${LANDSCAPE_UI_KEY_FILE};
+
+        ssl_protocols       TLSv1.2 TLSv1.3;
+        ssl_ciphers         HIGH:!aNULL:!MD5;
+
+        root ${SNAP}/var/www/landscape-ui;
+        index index.html;
+
+        location /new_dashboard/ {
+            try_files $uri /index.html;
+        }
+
+        location = / {
+            return 301 /new_dashboard/;
+        }
+
+        location /api/ {
+            proxy_pass https://${LANDSCAPE_UI_BACKEND_HOST}:${LANDSCAPE_UI_BACKEND_PORT};
+            proxy_ssl_verify off;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /debarchive/ {
+            rewrite ^/debarchive/(.*) /$1 break;
+            proxy_pass https://${LANDSCAPE_UI_DEBARCHIVE_HOST}:${LANDSCAPE_UI_DEBARCHIVE_PORT};
+            proxy_ssl_verify off;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/snap/local/start-landscape-ui.sh
+++ b/snap/local/start-landscape-ui.sh
@@ -1,0 +1,49 @@
+#! /bin/sh
+
+KEY_MAPPINGS="
+LANDSCAPE_UI_BACKEND_HOST|landscape.ui.backend-host|localhost
+LANDSCAPE_UI_BACKEND_PORT|landscape.ui.backend-port|443
+LANDSCAPE_UI_DEBARCHIVE_HOST|landscape.ui.debarchive-host|localhost
+LANDSCAPE_UI_DEBARCHIVE_PORT|landscape.ui.debarchive-port|443
+LANDSCAPE_UI_LISTEN_PORT|landscape.ui.listen-port|443
+LANDSCAPE_UI_CERT_FILE|landscape.ui.cert-file|
+LANDSCAPE_UI_KEY_FILE|landscape.ui.key-file|
+"
+
+# Set env based on snap configs, falling back to default if unset
+while IFS='|' read -r env_key snap_key default_val; do
+    [ -z "$env_key" ] && continue
+
+    # Fetch the value from the snap configuration
+    snap_val="$(snapctl get "$snap_key")"
+
+    if [ -z "$snap_val" ]; then
+        snapctl set "$snap_key"="$default_val"
+    fi
+
+    # Export the variable: Use snap_val if it exists, otherwise use default_val
+    export "$env_key=${snap_val:-$default_val}"
+done <<EOF
+$KEY_MAPPINGS
+EOF
+
+# Generate self-signed cert if no cert configured
+if [ -z "$LANDSCAPE_UI_CERT_FILE" ]; then
+    sh "$SNAP/generate-cert.sh"
+    export LANDSCAPE_UI_CERT_FILE="$SNAP_COMMON/ssl/nginx.crt"
+    export LANDSCAPE_UI_KEY_FILE="$SNAP_COMMON/ssl/nginx.key"
+fi
+
+# Create nginx temp directories
+mkdir -p \
+    "$SNAP_COMMON/nginx-tmp/client" \
+    "$SNAP_COMMON/nginx-tmp/proxy" \
+    "$SNAP_COMMON/nginx-tmp/fastcgi" \
+    "$SNAP_COMMON/nginx-tmp/uwsgi" \
+    "$SNAP_COMMON/nginx-tmp/scgi"
+
+# Render nginx config from template
+envsubst '${SNAP} ${SNAP_COMMON} ${LANDSCAPE_UI_LISTEN_PORT} ${LANDSCAPE_UI_CERT_FILE} ${LANDSCAPE_UI_KEY_FILE} ${LANDSCAPE_UI_BACKEND_HOST} ${LANDSCAPE_UI_BACKEND_PORT} ${LANDSCAPE_UI_DEBARCHIVE_HOST} ${LANDSCAPE_UI_DEBARCHIVE_PORT}' \
+    < "$SNAP/nginx.conf.tmpl" > "$SNAP_COMMON/nginx.conf"
+
+exec nginx -c "$SNAP_COMMON/nginx.conf" -g "daemon off;"

--- a/snap/local/start-landscape-ui.sh
+++ b/snap/local/start-landscape-ui.sh
@@ -3,8 +3,10 @@
 KEY_MAPPINGS="
 LANDSCAPE_UI_BACKEND_HOST|landscape.ui.backend-host|localhost
 LANDSCAPE_UI_BACKEND_PORT|landscape.ui.backend-port|443
+LANDSCAPE_UI_BACKEND_SCHEME|landscape.ui.backend-scheme|https
 LANDSCAPE_UI_DEBARCHIVE_HOST|landscape.ui.debarchive-host|localhost
-LANDSCAPE_UI_DEBARCHIVE_PORT|landscape.ui.debarchive-port|443
+LANDSCAPE_UI_DEBARCHIVE_PORT|landscape.ui.debarchive-port|8000
+LANDSCAPE_UI_DEBARCHIVE_SCHEME|landscape.ui.debarchive-scheme|http
 LANDSCAPE_UI_LISTEN_PORT|landscape.ui.listen-port|443
 LANDSCAPE_UI_CERT_FILE|landscape.ui.cert-file|
 LANDSCAPE_UI_KEY_FILE|landscape.ui.key-file|
@@ -43,7 +45,7 @@ mkdir -p \
     "$SNAP_COMMON/nginx-tmp/scgi"
 
 # Render nginx config from template
-envsubst '${SNAP} ${SNAP_COMMON} ${LANDSCAPE_UI_LISTEN_PORT} ${LANDSCAPE_UI_CERT_FILE} ${LANDSCAPE_UI_KEY_FILE} ${LANDSCAPE_UI_BACKEND_HOST} ${LANDSCAPE_UI_BACKEND_PORT} ${LANDSCAPE_UI_DEBARCHIVE_HOST} ${LANDSCAPE_UI_DEBARCHIVE_PORT}' \
+envsubst '${SNAP} ${SNAP_COMMON} ${LANDSCAPE_UI_LISTEN_PORT} ${LANDSCAPE_UI_CERT_FILE} ${LANDSCAPE_UI_KEY_FILE} ${LANDSCAPE_UI_BACKEND_SCHEME} ${LANDSCAPE_UI_BACKEND_HOST} ${LANDSCAPE_UI_BACKEND_PORT} ${LANDSCAPE_UI_DEBARCHIVE_SCHEME} ${LANDSCAPE_UI_DEBARCHIVE_HOST} ${LANDSCAPE_UI_DEBARCHIVE_PORT}' \
     < "$SNAP/nginx.conf.tmpl" > "$SNAP_COMMON/nginx.conf"
 
 exec nginx -c "$SNAP_COMMON/nginx.conf" -g "daemon off;"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,67 @@
+name: landscape-ui
+title: Landscape UI
+version: '26.10.0'
+summary: Web UI for Landscape
+description: |
+  Serves the Landscape web interface and proxies API requests to the
+  Landscape backend services.
+website: https://documentation.ubuntu.com/landscape/
+contact: https://discourse.ubuntu.com/c/project/landscape
+license: Proprietary
+issues: https://bugs.launchpad.net/~landscape
+source-code: https://github.com/canonical/landscape-ui
+
+base: core24
+grade: devel
+confinement: devmode
+
+platforms:
+  amd64:
+    build-on: [amd64]
+    build-for: [amd64]
+  arm64:
+    build-on: [arm64]
+    build-for: [arm64]
+
+parts:
+  frontend:
+    plugin: nil
+    source: .
+    build-snaps:
+      - node/24/stable
+    override-build: |
+      set -eux
+      export PATH="/snap/node/current/bin:$PATH"
+      export CI=true
+      npm install -g pnpm
+      pnpm install --frozen-lockfile --ignore-scripts
+      pnpm exec vite build
+      mkdir -p "$CRAFT_PART_INSTALL/dist"
+      cp -r dist/. "$CRAFT_PART_INSTALL/dist/"
+    organize:
+      dist/: var/www/landscape-ui/
+
+  runtime:
+    plugin: nil
+    stage-packages:
+      - nginx
+      - openssl
+      - gettext-base
+
+  nginx-wrapper:
+    plugin: dump
+    source: snap/local/
+    stage:
+      - start-landscape-ui.sh
+      - nginx.conf.tmpl
+      - generate-cert.sh
+
+apps:
+  landscape-ui:
+    daemon: simple
+    command: start-landscape-ui.sh
+    restart-condition: on-failure
+    restart-delay: 5s
+    plugs:
+      - network
+      - network-bind

--- a/snap/tests/test-nginx-config-render.sh
+++ b/snap/tests/test-nginx-config-render.sh
@@ -1,0 +1,126 @@
+#!/bin/sh
+# Tests for nginx.conf.tmpl rendering via the envsubst call in start-landscape-ui.sh.
+#
+# Run: sh snap/tests/test-nginx-config-render.sh
+
+set -e
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+SNAP_DIR="$(dirname "$TESTS_DIR")"
+TEMPLATE="$SNAP_DIR/local/nginx.conf.tmpl"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; echo "        expected: $2"; echo "        got:      $3"; FAIL=$((FAIL + 1)); }
+
+render() {
+    SNAP="$1" \
+    SNAP_COMMON="$2" \
+    LANDSCAPE_UI_LISTEN_PORT="$3" \
+    LANDSCAPE_UI_CERT_FILE="$4" \
+    LANDSCAPE_UI_KEY_FILE="$5" \
+    LANDSCAPE_UI_BACKEND_SCHEME="$6" \
+    LANDSCAPE_UI_BACKEND_HOST="$7" \
+    LANDSCAPE_UI_BACKEND_PORT="$8" \
+    LANDSCAPE_UI_DEBARCHIVE_SCHEME="$9" \
+    LANDSCAPE_UI_DEBARCHIVE_HOST="${10}" \
+    LANDSCAPE_UI_DEBARCHIVE_PORT="${11}" \
+    envsubst '${SNAP} ${SNAP_COMMON} ${LANDSCAPE_UI_LISTEN_PORT} ${LANDSCAPE_UI_CERT_FILE} ${LANDSCAPE_UI_KEY_FILE} ${LANDSCAPE_UI_BACKEND_SCHEME} ${LANDSCAPE_UI_BACKEND_HOST} ${LANDSCAPE_UI_BACKEND_PORT} ${LANDSCAPE_UI_DEBARCHIVE_SCHEME} ${LANDSCAPE_UI_DEBARCHIVE_HOST} ${LANDSCAPE_UI_DEBARCHIVE_PORT}' \
+    < "$TEMPLATE"
+}
+
+assert_contains() {
+    label="$1"; needle="$2"; haystack="$3"
+    if echo "$haystack" | grep -qF "$needle"; then
+        pass "$label"
+    else
+        fail "$label" "$needle" "(not found)"
+    fi
+}
+
+assert_not_contains() {
+    label="$1"; needle="$2"; haystack="$3"
+    if echo "$haystack" | grep -qF "$needle"; then
+        fail "$label" "(absent)" "$needle"
+    else
+        pass "$label"
+    fi
+}
+
+echo "nginx.conf.tmpl rendering tests"
+echo "================================"
+
+CONF=$(render \
+    /snap/landscape-ui/current \
+    /var/snap/landscape-ui/common \
+    443 \
+    /var/snap/landscape-ui/common/ssl/nginx.crt \
+    /var/snap/landscape-ui/common/ssl/nginx.key \
+    https localhost 443 \
+    http  localhost 8000)
+
+echo ""
+echo "defaults"
+assert_contains "listen port"          "listen 443 ssl"                                       "$CONF"
+assert_contains "ssl_certificate"      "ssl_certificate     /var/snap/landscape-ui/common/ssl/nginx.crt" "$CONF"
+assert_contains "ssl_certificate_key"  "ssl_certificate_key /var/snap/landscape-ui/common/ssl/nginx.key" "$CONF"
+assert_contains "mime.types path"      "include       /snap/landscape-ui/current/etc/nginx/mime.types"   "$CONF"
+assert_contains "web root"             "root /snap/landscape-ui/current/var/www/landscape-ui"  "$CONF"
+assert_contains "api proxy_pass"       "proxy_pass https://localhost:443"                      "$CONF"
+assert_contains "debarchive proxy_pass""proxy_pass http://localhost:8000"                      "$CONF"
+REWRITE_NEEDLE='rewrite ^/debarchive/(.*) /$1 break'
+assert_contains "debarchive rewrite"   "$REWRITE_NEEDLE"                                       "$CONF"
+assert_contains "spa try_files"        "try_files \$uri /index.html"                           "$CONF"
+assert_contains "root redirect"        "return 301 /new_dashboard/"                            "$CONF"
+assert_contains "proxy_ssl_verify off" "proxy_ssl_verify off"                                  "$CONF"
+assert_not_contains "nginx vars unexpanded" "\${uri}"                                          "$CONF"
+assert_not_contains "nginx vars unexpanded" "\${host}"                                         "$CONF"
+
+echo ""
+echo "custom host and port"
+CONF=$(render \
+    /snap/landscape-ui/current \
+    /var/snap/landscape-ui/common \
+    8443 \
+    /var/snap/landscape-ui/common/ssl/nginx.crt \
+    /var/snap/landscape-ui/common/ssl/nginx.key \
+    https 192.168.64.1 443 \
+    http  192.168.64.1 8000)
+
+assert_contains "custom listen port"        "listen 8443 ssl"                          "$CONF"
+assert_contains "custom api host"           "proxy_pass https://192.168.64.1:443"      "$CONF"
+assert_contains "custom debarchive host"    "proxy_pass http://192.168.64.1:8000"      "$CONF"
+
+echo ""
+echo "http backend scheme"
+CONF=$(render \
+    /snap/landscape-ui/current \
+    /var/snap/landscape-ui/common \
+    443 \
+    /var/snap/landscape-ui/common/ssl/nginx.crt \
+    /var/snap/landscape-ui/common/ssl/nginx.key \
+    http localhost 9080 \
+    http localhost 8000)
+
+assert_contains "http backend scheme"       "proxy_pass http://localhost:9080"         "$CONF"
+assert_not_contains "no https backend"      "proxy_pass https://localhost:9080"        "$CONF"
+
+echo ""
+echo "https debarchive scheme"
+CONF=$(render \
+    /snap/landscape-ui/current \
+    /var/snap/landscape-ui/common \
+    443 \
+    /var/snap/landscape-ui/common/ssl/nginx.crt \
+    /var/snap/landscape-ui/common/ssl/nginx.key \
+    https localhost 443 \
+    https localhost 443)
+
+assert_contains "https debarchive scheme"   "proxy_pass https://localhost:443"         "$CONF"
+
+echo ""
+echo "================================"
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -12,7 +12,6 @@ describe("main", () => {
 
     await startApp({
       mode: "development",
-      isDevEnv: true,
       isMswEnabled: true,
       loadWorker,
       render,
@@ -29,24 +28,7 @@ describe("main", () => {
 
     await startApp({
       mode: "development",
-      isDevEnv: true,
       isMswEnabled: false,
-      loadWorker,
-      render,
-    });
-
-    expect(loadWorker).not.toHaveBeenCalled();
-    expect(render).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not start worker when enabled outside dev", async () => {
-    const loadWorker = vi.fn();
-    const render = vi.fn();
-
-    await startApp({
-      mode: "production",
-      isDevEnv: false,
-      isMswEnabled: true,
       loadWorker,
       render,
     });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -73,7 +73,7 @@ export const startApp = async ({
     return;
   }
 
-  if (isDevEnv && isMswEnabled) {
+  if (isMswEnabled) {
     const { worker } = await loadWorker();
     await worker.start();
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -54,7 +54,6 @@ export const renderApp = (
 
 interface StartAppOptions {
   mode?: string;
-  isDevEnv?: boolean;
   isMswEnabled?: boolean;
   loadWorker?: WorkerLoader;
   render?: () => void;
@@ -62,7 +61,6 @@ interface StartAppOptions {
 
 export const startApp = async ({
   mode = import.meta.env.MODE,
-  isDevEnv = IS_DEV_ENV,
   isMswEnabled = IS_MSW_ENABLED,
   loadWorker = defaultLoadWorker,
   render = () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(({ mode }) => {
         name: "exclude-msw",
         apply: "build",
         closeBundle() {
+          if (env.VITE_MSW_ENABLED === "true") return;
           const mswPath = path.resolve(__dirname, "dist/mockServiceWorker.js");
           if (fs.existsSync(mswPath)) {
             fs.unlinkSync(mswPath);


### PR DESCRIPTION
## Summary

Add support for packaging landscape-ui as a snap. Build options include selfHosted or saas, mocks enabled or disabled. Backend service URLs are set at runtime. 

Including support for MSWs meant making changes to vite.config.ts, main.tsx and main.test.tsx to allow mocks to run on a build created with `vite build`. If the snap doesn't need to support MSWs then those changes can be removed. See end of README for more details.

Resolves [LNDENG-4694](https://warthogs.atlassian.net/browse/LNDENG-4694)

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [X] `dev` — internal testing → publishes to `ppa-build-dev`
- [ ] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [ ] Patch (fix)
- [X] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [X] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [X] **UI verified** — I have verified the changes locally.
- [ ] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)


[LNDENG-4694]: https://warthogs.atlassian.net/browse/LNDENG-4694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ