### PR TITLE
Feat: Add available versions column to instance > packages tab

### DIFF
--- a/.changeset/neat-pots-shave.md
+++ b/.changeset/neat-pots-shave.md
@@ -2,4 +2,4 @@
 "landscape-ui": minor
 ---
 
-Add "available version" column to instance>packages tab
+Add "available version" column to instance>packages tab with NO_DATA_TEXT

--- a/.changeset/neat-pots-shave.md
+++ b/.changeset/neat-pots-shave.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": minor
+---
+
+Add "available version" column to instance>packages tab

--- a/src/features/packages/components/PackageList/PackageList.test.tsx
+++ b/src/features/packages/components/PackageList/PackageList.test.tsx
@@ -45,6 +45,7 @@ describe("PackageList", () => {
       expect(screen.getByText("Name")).toBeInTheDocument();
       expect(screen.getByText("Status")).toBeInTheDocument();
       expect(screen.getByText("Current version")).toBeInTheDocument();
+      expect(screen.getByText("Available version")).toBeInTheDocument();
       expect(screen.getByText("Details")).toBeInTheDocument();
 
       packagesWithUpgrade.forEach((pkg) => {
@@ -174,7 +175,7 @@ describe("PackageList", () => {
     expect(checkbox).toBeDisabled();
   });
 
-  it("shows available version details when package has an available version", () => {
+  it("shows available version when it differs from current version", () => {
     const packageWithAvailableVersion: InstancePackage = {
       id: 100,
       name: "curl",
@@ -188,7 +189,51 @@ describe("PackageList", () => {
       <PackageList {...props} packages={[packageWithAvailableVersion]} />,
     );
 
-    expect(screen.getByText("available version: 8.0")).toBeInTheDocument();
+    const row = screen
+      .getByText(packageWithAvailableVersion.name)
+      .closest("tr");
+    assert(row);
+    expect(within(row).getByText("8.0")).toBeInTheDocument();
+  });
+
+  it("shows --- when available version matches current version", () => {
+    const packageWithSameVersion: InstancePackage = {
+      id: 101,
+      name: "wget",
+      summary: "network downloader",
+      status: "installed",
+      current_version: "1.0.0",
+      available_version: "1.0.0",
+    };
+
+    renderWithProviders(
+      <PackageList {...props} packages={[packageWithSameVersion]} />,
+    );
+
+    const row = screen.getByText(packageWithSameVersion.name).closest("tr");
+    assert(row);
+    expect(within(row).getByText("---")).toBeInTheDocument();
+  });
+
+  it("shows --- when available version is missing", () => {
+    const packageWithoutAvailableVersion: InstancePackage = {
+      id: 102,
+      name: "nano",
+      summary: "text editor",
+      status: "installed",
+      current_version: "7.2",
+      available_version: null,
+    };
+
+    renderWithProviders(
+      <PackageList {...props} packages={[packageWithoutAvailableVersion]} />,
+    );
+
+    const row = screen
+      .getByText(packageWithoutAvailableVersion.name)
+      .closest("tr");
+    assert(row);
+    expect(within(row).getByText("---")).toBeInTheDocument();
   });
 
   it("shows Installed status when installed packages have no available version", () => {

--- a/src/features/packages/components/PackageList/PackageList.test.tsx
+++ b/src/features/packages/components/PackageList/PackageList.test.tsx
@@ -6,6 +6,7 @@ import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import PackageList from "./PackageList";
 import type { InstancePackage } from "../../types";
+import { NO_DATA_TEXT } from "@/components/layout/NoData";
 
 const instanceId = 1;
 const instancePackages = getInstancePackages(instanceId);
@@ -196,7 +197,7 @@ describe("PackageList", () => {
     expect(within(row).getByText("8.0")).toBeInTheDocument();
   });
 
-  it("shows --- when available version matches current version", () => {
+  it(`shows ${NO_DATA_TEXT} when available version matches current version`, () => {
     const packageWithSameVersion: InstancePackage = {
       id: 101,
       name: "wget",
@@ -212,10 +213,10 @@ describe("PackageList", () => {
 
     const row = screen.getByText(packageWithSameVersion.name).closest("tr");
     assert(row);
-    expect(within(row).getByText("---")).toBeInTheDocument();
+    expect(within(row).getByText(NO_DATA_TEXT)).toBeInTheDocument();
   });
 
-  it("shows --- when available version is missing", () => {
+  it(`shows ${NO_DATA_TEXT} when available version is missing`, () => {
     const packageWithoutAvailableVersion: InstancePackage = {
       id: 102,
       name: "nano",
@@ -233,7 +234,7 @@ describe("PackageList", () => {
       .getByText(packageWithoutAvailableVersion.name)
       .closest("tr");
     assert(row);
-    expect(within(row).getByText("---")).toBeInTheDocument();
+    expect(within(row).getByText(NO_DATA_TEXT)).toBeInTheDocument();
   });
 
   it("shows Installed status when installed packages have no available version", () => {

--- a/src/features/packages/components/PackageList/PackageList.tsx
+++ b/src/features/packages/components/PackageList/PackageList.tsx
@@ -202,6 +202,8 @@ const PackageList: FC<PackageListProps> = ({
       {
         accessor: "current_version",
         Header: "Current version",
+        Cell: ({ row: { original } }: CellProps<InstancePackage>) =>
+          original.current_version || NO_DATA_TEXT,
       },
       {
         accessor: "available_version",

--- a/src/features/packages/components/PackageList/PackageList.tsx
+++ b/src/features/packages/components/PackageList/PackageList.tsx
@@ -6,7 +6,15 @@ import { ROUTES } from "@/libs/routes";
 import type { UrlParams } from "@/types/UrlParams";
 import { Button, CheckboxInput, Tooltip } from "@canonical/react-components";
 import type { FC } from "react";
-import { lazy, Suspense, useEffect, useMemo, useState } from "react";
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Link, useParams } from "react-router";
 import type { CellProps, Column } from "react-table";
 import type { InstancePackage } from "../../types";
@@ -40,7 +48,7 @@ const PackageList: FC<PackageListProps> = ({
   selectedPackages,
   selectAll,
 }) => {
-  const [selectedByTabState, setSelectedByTabState] = useState(false);
+  const selectedByTabRef = useRef(false);
   const [hideUbuntuProInfo, setHideUbuntuProInfo] = useState(false);
 
   const { instanceId, childInstanceId } = useParams<UrlParams>();
@@ -54,39 +62,45 @@ const PackageList: FC<PackageListProps> = ({
     return [LOADING_PACKAGE];
   }, [packages, packagesLoading]);
 
-  const handleSelectPackage = (pkg: InstancePackage) => {
-    onPackagesSelect(
-      selectedPackages.some(({ name }) => name === pkg.name)
-        ? selectedPackages.filter(({ name }) => name !== pkg.name)
-        : [...selectedPackages, pkg],
-    );
-  };
+  const handleSelectPackage = useCallback(
+    (pkg: InstancePackage) => {
+      onPackagesSelect(
+        selectedPackages.some(({ name }) => name === pkg.name)
+          ? selectedPackages.filter(({ name }) => name !== pkg.name)
+          : [...selectedPackages, pkg],
+      );
+    },
+    [onPackagesSelect, selectedPackages],
+  );
 
-  const handleToggleAllPackages = () => {
+  const handleToggleAllPackages = useCallback(() => {
     onPackagesSelect(
       selectedPackages.length > 0
         ? []
         : packages.filter((pkg) => !isUbuntuProRequired(pkg)),
     );
-  };
+  }, [onPackagesSelect, packages, selectedPackages.length]);
 
   useEffect(() => {
-    if (!selectAll || selectedByTabState || !packages.length) {
+    if (!selectAll || selectedByTabRef.current || !packages.length) {
       return;
     }
 
     handleToggleAllPackages();
-    setSelectedByTabState(true);
-  }, [selectAll, packages]);
+    selectedByTabRef.current = true;
+  }, [selectAll, packages.length, handleToggleAllPackages]);
 
-  const handlePackageClick = (singlePackage: InstancePackage) => {
-    setSidePanelContent(
-      "Package details",
-      <Suspense fallback={<LoadingState />}>
-        <PackageDetails singlePackage={singlePackage} />
-      </Suspense>,
-    );
-  };
+  const handlePackageClick = useCallback(
+    (singlePackage: InstancePackage) => {
+      setSidePanelContent(
+        "Package details",
+        <Suspense fallback={<LoadingState />}>
+          <PackageDetails singlePackage={singlePackage} />
+        </Suspense>,
+      );
+    },
+    [setSidePanelContent],
+  );
 
   const columns = useMemo<Column<InstancePackage>[]>(
     () => [
@@ -212,7 +226,15 @@ const PackageList: FC<PackageListProps> = ({
         ),
       },
     ],
-    [packages, selectedPackages.length],
+    [
+      childInstanceId,
+      handlePackageClick,
+      handleSelectPackage,
+      handleToggleAllPackages,
+      instanceId,
+      packages,
+      selectedPackages,
+    ],
   );
 
   return (
@@ -227,7 +249,9 @@ const PackageList: FC<PackageListProps> = ({
       <ResponsiveTable
         columns={columns}
         data={packagesToShow}
-        getCellProps={handleCellProps}
+        getCellProps={(cell) => {
+          return handleCellProps(cell, columns.length);
+        }}
         emptyMsg={emptyMsg}
       />
     </>

--- a/src/features/packages/components/PackageList/PackageList.tsx
+++ b/src/features/packages/components/PackageList/PackageList.tsx
@@ -19,6 +19,7 @@ import {
   isUbuntuProRequired,
 } from "./helpers";
 import classes from "./PackageList.module.scss";
+import { NO_DATA_TEXT } from "@/components/layout/NoData";
 
 const PackageDetails = lazy(async () => import("../PackageDetails"));
 
@@ -189,19 +190,20 @@ const PackageList: FC<PackageListProps> = ({
         Header: "Current version",
       },
       {
+        accessor: "available_version",
+        Header: "Available version",
+        Cell: ({ row: { original } }: CellProps<InstancePackage>) =>
+          original.available_version &&
+          original.available_version !== original.current_version
+            ? original.available_version
+            : NO_DATA_TEXT,
+      },
+      {
         accessor: "summary",
         className: classes.details,
         Header: "Details",
         Cell: ({ row: { original } }: CellProps<InstancePackage>) =>
-          original.available_version ? (
-            <>
-              <span>{original.summary}</span>
-              <br />
-              <span>{`available version: ${original.available_version}`}</span>
-            </>
-          ) : (
-            original.summary
-          ),
+          original.summary,
       },
       {
         ...LIST_ACTIONS_COLUMN_PROPS,

--- a/src/features/packages/components/PackageList/helpers.ts
+++ b/src/features/packages/components/PackageList/helpers.ts
@@ -42,13 +42,16 @@ export const getPackageStatusInfo = (pkg: InstancePackage) => {
   return pkgStatusInfo;
 };
 
-export const handleCellProps = ({ column, row }: Cell<InstancePackage>) => {
+export const handleCellProps = (
+  { column, row }: Cell<InstancePackage>,
+  totalColumns: number,
+) => {
   const cellProps: Partial<TableCellProps & HTMLProps<HTMLTableCellElement>> =
     {};
 
   if (row.original.name === "loading") {
     if (column.id === "name") {
-      cellProps.colSpan = 5;
+      cellProps.colSpan = totalColumns;
     } else {
       cellProps.className = classes.hidden;
       cellProps["aria-hidden"] = true;


### PR DESCRIPTION
## Summary

[Resolves LNDENG-4257](https://warthogs.atlassian.net/browse/LNDENG-4257)
- add available versions column to packages tab
- show "---" (NO_DATA_TEXT) if no available version is available
- add test coverage

<img width="1259" height="392" alt="image" src="https://github.com/user-attachments/assets/18101c02-5499-4b5f-b29d-1ffde213e4da" />

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [X] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [ ] Patch (fix)
- [X] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [X] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [X] **UI verified** — I have verified the changes locally.
- [X] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
