### PR TITLE
Fix "Include dependencies in filter" checkbox

### DIFF
--- a/.changeset/eleven-trams-feel.md
+++ b/.changeset/eleven-trams-feel.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Fix "Include dependencies in filter" checkbox

--- a/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.test.tsx
+++ b/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.test.tsx
@@ -158,4 +158,53 @@ describe("EditMirrorForm", () => {
     expect(checkbox).toBeChecked();
     expect(checkbox).toBeDisabled();
   });
+
+  it("submits without filtering dependencies", async () => {
+    renderWithProviders(
+      <Suspense fallback={<LoadingState />}>
+        <TestComponent />
+      </Suspense>,
+      undefined,
+      `?sidePath=edit&name=${encodeURIComponent(mirrors[0].name)}`,
+    );
+
+    await expectLoadingState();
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(mockUpdateMirror).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        filterWithDeps: undefined,
+      }),
+    );
+  });
+
+  it("submits with filtering dependencies", async () => {
+    const mirror = mirrors.find(
+      ({ preserveSignatures }) => !preserveSignatures,
+    );
+
+    assert(mirror);
+
+    renderWithProviders(
+      <Suspense fallback={<LoadingState />}>
+        <TestComponent />
+      </Suspense>,
+      undefined,
+      `?sidePath=edit&name=${encodeURIComponent(mirror.name)}`,
+    );
+
+    await expectLoadingState();
+
+    await user.type(screen.getByRole("textbox", { name: "Filter" }), "abc");
+    await user.click(screen.getByLabelText("Include dependencies in filter"));
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(mockUpdateMirror).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        filterWithDeps: true,
+      }),
+    );
+  });
 });

--- a/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
+++ b/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
@@ -47,7 +47,7 @@ const EditMirrorForm: FC = () => {
       downloadInstallerFiles: !!mirror.downloadInstaller,
       verificationGpgKey: mirror.gpgKey?.armor,
       packageFilter: mirror.filter,
-      includeDependencies: mirror.filterWithDeps,
+      includeDependencies: !!mirror.filterWithDeps,
       keepCurrentGpgKey: !!mirror.gpgKey,
     },
 

--- a/src/features/mirrors/components/EditMirrorForm/types.ts
+++ b/src/features/mirrors/components/EditMirrorForm/types.ts
@@ -6,6 +6,6 @@ export interface FormProps {
   downloadInstallerFiles: boolean;
   verificationGpgKey?: string;
   packageFilter?: string;
-  includeDependencies?: boolean;
+  includeDependencies: boolean;
   keepCurrentGpgKey: boolean;
 }


### PR DESCRIPTION
## Summary

Before, the "Include dependencies in filter" checkbox for the edit mirror form could not be unchecked. I'm guessing Formik just doesn't pick up the `boolean?` type properly.

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
