### PR TITLE
fix: remove search chip

### DIFF
--- a/.changeset/eighty-toes-cut.md
+++ b/.changeset/eighty-toes-cut.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Remove search chips from appearing when performing a search

--- a/src/components/filter/TableFilterChips/components/TableFilterChips/TableFilterChips.tsx
+++ b/src/components/filter/TableFilterChips/components/TableFilterChips/TableFilterChips.tsx
@@ -51,7 +51,6 @@ const TableFilterChips: FC<TableFilterChipsProps> = ({
     tags,
     toDate,
     type,
-    search,
     query,
     passRateFrom,
     passRateTo,
@@ -86,14 +85,6 @@ const TableFilterChips: FC<TableFilterChipsProps> = ({
         items: parseSearchQuery(query),
         remove: createRemover("query", filterSearchQuery),
         clear: createClearer({ query: "" }),
-      },
-    },
-    {
-      condition: filtersToDisplay.includes("search"),
-      value: {
-        label: "Search",
-        item: search,
-        clear: createClearer({ search: "" }),
       },
     },
     {

--- a/src/components/filter/TableFilterChips/types.ts
+++ b/src/components/filter/TableFilterChips/types.ts
@@ -7,7 +7,6 @@ export type FilterType = Pick<
   | "contractExpiryDays"
   | "fromDate"
   | "os"
-  | "search"
   | "status"
   | "tags"
   | "toDate"

--- a/src/features/access-groups/components/AccessGroupHeader/AccessGroupHeader.tsx
+++ b/src/features/access-groups/components/AccessGroupHeader/AccessGroupHeader.tsx
@@ -1,4 +1,4 @@
-import { PageParamFilter, TableFilterChips } from "@/components/filter";
+import { PageParamFilter } from "@/components/filter";
 import { FILTERS } from "@/features/instances";
 import usePageParams from "@/hooks/usePageParams";
 import { Form, SearchBox } from "@canonical/react-components";
@@ -33,34 +33,31 @@ const AccessGroupHeader: FC = () => {
     FILTERS.groupBy.type === "select" ? FILTERS.groupBy.options : [];
 
   return (
-    <>
-      <div className={classes.container}>
-        <div className={classes.searchContainer}>
-          <Form onSubmit={formik.handleSubmit} noValidate>
-            <SearchBox
-              autocomplete="off"
-              externallyControlled
-              value={formik.values.searchText}
-              onChange={async (value) =>
-                await formik.setFieldValue("searchText", value)
-              }
-              placeholder="Search"
-              onSearch={() => {
-                formik.submitForm();
-              }}
-              onClear={handleClear}
-            />
-          </Form>
-        </div>
-        <PageParamFilter
-          label="Group by"
-          options={groupOptions}
-          key="group-by-filter"
-          pageParamKey="groupBy"
-        />
+    <div className={classes.container}>
+      <div className={classes.searchContainer}>
+        <Form onSubmit={formik.handleSubmit} noValidate>
+          <SearchBox
+            autocomplete="off"
+            externallyControlled
+            value={formik.values.searchText}
+            onChange={async (value) =>
+              await formik.setFieldValue("searchText", value)
+            }
+            placeholder="Search"
+            onSearch={() => {
+              formik.submitForm();
+            }}
+            onClear={handleClear}
+          />
+        </Form>
       </div>
-      <TableFilterChips filtersToDisplay={["search"]} />
-    </>
+      <PageParamFilter
+        label="Group by"
+        options={groupOptions}
+        key="group-by-filter"
+        pageParamKey="groupBy"
+      />
+    </div>
   );
 };
 

--- a/src/features/autoinstall-files/components/AutoinstallFilesHeader/AutoinstallFilesHeader.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFilesHeader/AutoinstallFilesHeader.tsx
@@ -1,4 +1,3 @@
-import { TableFilterChips } from "@/components/filter";
 import HeaderWithSearch from "@/components/form/HeaderWithSearch";
 import { Button, Icon } from "@canonical/react-components";
 import { type FC } from "react";
@@ -12,25 +11,21 @@ const AutoinstallFilesHeader: FC<AutoinstallFilesHeaderProps> = ({
   openAddForm,
 }) => {
   return (
-    <>
-      <HeaderWithSearch
-        actions={
-          <div className={classes.container}>
-            <Button
-              type="button"
-              className="u-no-margin"
-              hasIcon
-              onClick={openAddForm}
-            >
-              <Icon name="plus" />
-              <span>Add new</span>
-            </Button>
-          </div>
-        }
-      />
-
-      <TableFilterChips filtersToDisplay={["search"]} />
-    </>
+    <HeaderWithSearch
+      actions={
+        <div className={classes.container}>
+          <Button
+            type="button"
+            className="u-no-margin"
+            hasIcon
+            onClick={openAddForm}
+          >
+            <Icon name="plus" />
+            <span>Add new</span>
+          </Button>
+        </div>
+      }
+    />
   );
 };
 

--- a/src/features/employees/components/EmployeesPanelHeader/EmployeesPanelHeader.tsx
+++ b/src/features/employees/components/EmployeesPanelHeader/EmployeesPanelHeader.tsx
@@ -16,7 +16,7 @@ const EmployeesPanelHeader: FC = () => {
         }
       />
       <TableFilterChips
-        filtersToDisplay={["search", "status"]}
+        filtersToDisplay={["status"]}
         statusOptions={STATUS_OPTIONS}
       />
     </>

--- a/src/features/events-log/components/EventsLogHeader/EventsLogHeader.tsx
+++ b/src/features/events-log/components/EventsLogHeader/EventsLogHeader.tsx
@@ -1,15 +1,9 @@
-import { TableFilterChips } from "@/components/filter";
 import HeaderWithSearch from "@/components/form/HeaderWithSearch";
 import type { FC } from "react";
 import DaysFilter from "../DaysFilter";
 
 const EventsLogHeader: FC = () => {
-  return (
-    <>
-      <HeaderWithSearch actions={<DaysFilter />} />
-      <TableFilterChips filtersToDisplay={["search"]} />
-    </>
-  );
+  return <HeaderWithSearch actions={<DaysFilter />} />;
 };
 
 export default EventsLogHeader;

--- a/src/features/package-profiles/components/PackageProfileHeader/PackageProfileHeader.tsx
+++ b/src/features/package-profiles/components/PackageProfileHeader/PackageProfileHeader.tsx
@@ -1,14 +1,8 @@
-import { TableFilterChips } from "@/components/filter";
 import HeaderWithSearch from "@/components/form/HeaderWithSearch";
 import type { FC } from "react";
 
 const PackageProfileHeader: FC = () => {
-  return (
-    <>
-      <HeaderWithSearch />
-      <TableFilterChips filtersToDisplay={["search"]} />
-    </>
-  );
+  return <HeaderWithSearch />;
 };
 
 export default PackageProfileHeader;

--- a/src/features/packages/components/PackagesPanelHeader/PackagesPanelHeader.tsx
+++ b/src/features/packages/components/PackagesPanelHeader/PackagesPanelHeader.tsx
@@ -31,7 +31,7 @@ const PackagesPanelHeader: FC<PackagesPanelHeaderProps> = ({
         }
       />
       <TableFilterChips
-        filtersToDisplay={["search", "status"]}
+        filtersToDisplay={["status"]}
         statusOptions={STATUS_OPTIONS}
       />
     </>

--- a/src/features/processes/components/ProcessesHeader/ProcessesHeader.tsx
+++ b/src/features/processes/components/ProcessesHeader/ProcessesHeader.tsx
@@ -8,7 +8,6 @@ import classNames from "classnames";
 import type { FC } from "react";
 import { useParams } from "react-router";
 import classes from "./ProcessesHeader.module.scss";
-import { TableFilterChips } from "@/components/filter";
 import { pluralize } from "@/utils/_helpers";
 
 interface ProcessesHeaderProps {
@@ -86,7 +85,6 @@ const ProcessesHeader: FC<ProcessesHeaderProps> = ({
         }
         afterSearch={handleClearSelection}
       />
-      <TableFilterChips filtersToDisplay={["search"]} />
     </>
   );
 };

--- a/src/features/profiles/components/ProfilesHeader/ProfilesHeader.test.tsx
+++ b/src/features/profiles/components/ProfilesHeader/ProfilesHeader.test.tsx
@@ -38,7 +38,7 @@ describe("ProfilesHeader", () => {
     expect(screen.getByText("From pass rate: 50%")).toBeInTheDocument();
   });
 
-  it("renders only search chips for non-archivable profile types", async () => {
+  it("renders only search box for non-archivable profile types", async () => {
     renderWithProviders(<ProfilesHeader type={ProfileTypes.package} />);
 
     expect(
@@ -49,7 +49,7 @@ describe("ProfilesHeader", () => {
     ).not.toBeInTheDocument();
 
     const search = screen.getByRole("searchbox");
+    expect(search).toBeInTheDocument();
     await userEvent.type(search, "search{enter}");
-    expect(screen.getByText("Search: search")).toBeInTheDocument();
   });
 });

--- a/src/features/profiles/components/ProfilesHeader/ProfilesHeader.tsx
+++ b/src/features/profiles/components/ProfilesHeader/ProfilesHeader.tsx
@@ -18,11 +18,11 @@ const ProfilesHeader: FC<ProfilesHeaderProps> = ({ type }) => {
   const getFilters = (): FilterKey[] => {
     switch (type) {
       case ProfileTypes.script:
-        return ["search", "status"];
+        return ["status"];
       case ProfileTypes.usg:
-        return ["status", "search", "passRateFrom", "passRateTo"];
+        return ["status", "passRateFrom", "passRateTo"];
       default:
-        return ["search"];
+        return [];
     }
   };
 
@@ -59,10 +59,12 @@ const ProfilesHeader: FC<ProfilesHeaderProps> = ({ type }) => {
           </div>
         }
       />
-      <TableFilterChips
-        filtersToDisplay={getFilters()}
-        statusOptions={hasFilters ? STATUS_OPTIONS : undefined}
-      />
+      {hasFilters && (
+        <TableFilterChips
+          filtersToDisplay={getFilters()}
+          statusOptions={STATUS_OPTIONS}
+        />
+      )}
     </>
   );
 };

--- a/src/features/reboot-profiles/components/RebootProfilesHeader/RebootProfilesHeader.tsx
+++ b/src/features/reboot-profiles/components/RebootProfilesHeader/RebootProfilesHeader.tsx
@@ -1,14 +1,8 @@
 import type { FC } from "react";
 import HeaderWithSearch from "@/components/form/HeaderWithSearch";
-import { TableFilterChips } from "@/components/filter";
 
 const RebootProfilesHeader: FC = () => {
-  return (
-    <>
-      <HeaderWithSearch />
-      <TableFilterChips filtersToDisplay={["search"]} />
-    </>
-  );
+  return <HeaderWithSearch />;
 };
 
 export default RebootProfilesHeader;

--- a/src/features/removal-profiles/components/RemovalProfilesHeader/RemovalProfilesHeader.tsx
+++ b/src/features/removal-profiles/components/RemovalProfilesHeader/RemovalProfilesHeader.tsx
@@ -1,14 +1,8 @@
 import type { FC } from "react";
 import HeaderWithSearch from "@/components/form/HeaderWithSearch";
-import { TableFilterChips } from "@/components/filter";
 
 const RemovalProfilesHeader: FC = () => {
-  return (
-    <>
-      <HeaderWithSearch />
-      <TableFilterChips filtersToDisplay={["search"]} />
-    </>
-  );
+  return <HeaderWithSearch />;
 };
 
 export default RemovalProfilesHeader;

--- a/src/features/script-profiles/components/ScriptProfilesHeader/ScriptProfilesHeader.tsx
+++ b/src/features/script-profiles/components/ScriptProfilesHeader/ScriptProfilesHeader.tsx
@@ -22,7 +22,7 @@ const ScriptProfilesHeader: FC = () => {
       />
 
       <TableFilterChips
-        filtersToDisplay={["search", "status"]}
+        filtersToDisplay={["status"]}
         statusOptions={STATUS_OPTIONS}
       />
     </>

--- a/src/features/scripts/components/ScriptsHeader/ScriptsHeader.tsx
+++ b/src/features/scripts/components/ScriptsHeader/ScriptsHeader.tsx
@@ -44,7 +44,7 @@ const ScriptsHeader: FC = () => {
         }
       />
       <TableFilterChips
-        filtersToDisplay={["search", "status"]}
+        filtersToDisplay={["status"]}
         statusOptions={STATUS_OPTIONS}
       />
     </>

--- a/src/features/snaps/components/SnapsHeader/SnapsHeader.tsx
+++ b/src/features/snaps/components/SnapsHeader/SnapsHeader.tsx
@@ -4,7 +4,6 @@ import { getSelectedSnaps } from "../../helpers";
 import type { InstalledSnap } from "../../types";
 import SnapsActions from "../SnapsActions";
 import classes from "./SnapsHeader.module.scss";
-import { TableFilterChips } from "@/components/filter";
 
 interface SnapsHeaderProps {
   readonly handleClearSelection: () => void;
@@ -18,20 +17,17 @@ const SnapsHeader: FC<SnapsHeaderProps> = ({
   installedSnaps,
 }) => {
   return (
-    <>
-      <HeaderWithSearch
-        afterSearch={handleClearSelection}
-        actions={
-          <div className={classes.actions}>
-            <SnapsActions
-              selectedSnapIds={selectedSnapIds}
-              installedSnaps={getSelectedSnaps(installedSnaps, selectedSnapIds)}
-            />
-          </div>
-        }
-      />
-      <TableFilterChips filtersToDisplay={["search"]} />
-    </>
+    <HeaderWithSearch
+      afterSearch={handleClearSelection}
+      actions={
+        <div className={classes.actions}>
+          <SnapsActions
+            selectedSnapIds={selectedSnapIds}
+            installedSnaps={getSelectedSnaps(installedSnaps, selectedSnapIds)}
+          />
+        </div>
+      }
+    />
   );
 };
 

--- a/src/features/upgrade-profiles/components/UpgradeProfilesHeader/UpgradeProfilesHeader.tsx
+++ b/src/features/upgrade-profiles/components/UpgradeProfilesHeader/UpgradeProfilesHeader.tsx
@@ -1,14 +1,8 @@
 import type { FC } from "react";
 import HeaderWithSearch from "@/components/form/HeaderWithSearch";
-import { TableFilterChips } from "@/components/filter";
 
 const UpgradeProfilesHeader: FC = () => {
-  return (
-    <>
-      <HeaderWithSearch />
-      <TableFilterChips filtersToDisplay={["search"]} />
-    </>
-  );
+  return <HeaderWithSearch />;
 };
 
 export default UpgradeProfilesHeader;

--- a/src/features/usg-profiles/components/USGProfilesHeader/USGProfilesHeader.tsx
+++ b/src/features/usg-profiles/components/USGProfilesHeader/USGProfilesHeader.tsx
@@ -21,7 +21,7 @@ const USGProfilesHeader: FC = () => {
         }
       />
       <TableFilterChips
-        filtersToDisplay={["status", "search", "passRateFrom", "passRateTo"]}
+        filtersToDisplay={["status", "passRateFrom", "passRateTo"]}
         statusOptions={USG_STATUSES}
       />
     </>

--- a/src/features/wsl-profiles/components/WslProfilesHeader/WslProfilesHeader.tsx
+++ b/src/features/wsl-profiles/components/WslProfilesHeader/WslProfilesHeader.tsx
@@ -1,14 +1,8 @@
 import type { FC } from "react";
 import HeaderWithSearch from "@/components/form/HeaderWithSearch";
-import { TableFilterChips } from "@/components/filter";
 
 const WslProfilesHeader: FC = () => {
-  return (
-    <>
-      <HeaderWithSearch />
-      <TableFilterChips filtersToDisplay={["search"]} />
-    </>
-  );
+  return <HeaderWithSearch />;
 };
 
 export default WslProfilesHeader;

--- a/src/features/wsl/components/WslInstancesHeader/WslInstancesHeader.tsx
+++ b/src/features/wsl/components/WslInstancesHeader/WslInstancesHeader.tsx
@@ -1,4 +1,4 @@
-import { PageParamFilter, TableFilterChips } from "@/components/filter";
+import { PageParamFilter } from "@/components/filter";
 import HeaderWithSearch from "@/components/form/HeaderWithSearch";
 import LoadingState from "@/components/layout/LoadingState";
 import { useReapplyWslProfile } from "@/features/wsl-profiles";
@@ -200,8 +200,6 @@ const WslInstancesHeader: FC<WslInstancesHeaderProps> = ({
           </div>
         }
       />
-
-      <TableFilterChips filtersToDisplay={["search"]} />
 
       <WslInstanceReinstallModal
         close={closeReinstallModal}

--- a/src/pages/dashboard/instances/[single]/tabs/security-issues/SecurityIssuesPanelHeader/SecurityIssuesPanelHeader.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/security-issues/SecurityIssuesPanelHeader/SecurityIssuesPanelHeader.tsx
@@ -1,4 +1,3 @@
-import { TableFilterChips } from "@/components/filter";
 import HeaderWithSearch from "@/components/form/HeaderWithSearch";
 import { useUsns } from "@/features/usns";
 import useDebug from "@/hooks/useDebug";
@@ -98,7 +97,6 @@ const SecurityIssuesPanelHeader: FC<SecurityIssuesPanelHeaderProps> = ({
           </div>
         }
       />
-      <TableFilterChips filtersToDisplay={["search"]} />
     </>
   );
 };

--- a/src/pages/dashboard/instances/[single]/tabs/users/UserPanelHeader/UserPanelHeader.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/users/UserPanelHeader/UserPanelHeader.tsx
@@ -4,7 +4,6 @@ import UserPanelActionButtons from "../UserPanelActionButtons";
 import type { User } from "@/types/User";
 import { getSelectedUsers } from "./helpers";
 import HeaderWithSearch from "@/components/form/HeaderWithSearch";
-import { TableFilterChips } from "@/components/filter";
 
 interface UserPanelHeaderProps {
   readonly selected: number[];
@@ -18,19 +17,16 @@ const UserPanelHeader: FC<UserPanelHeaderProps> = ({
   users,
 }) => {
   return (
-    <>
-      <HeaderWithSearch
-        actions={
-          <div className={classes.actions}>
-            <UserPanelActionButtons
-              handleClearSelection={handleClearSelection}
-              selectedUsers={getSelectedUsers(users, selected)}
-            />
-          </div>
-        }
-      />
-      <TableFilterChips filtersToDisplay={["search"]} />
-    </>
+    <HeaderWithSearch
+      actions={
+        <div className={classes.actions}>
+          <UserPanelActionButtons
+            handleClearSelection={handleClearSelection}
+            selectedUsers={getSelectedUsers(users, selected)}
+          />
+        </div>
+      }
+    />
   );
 };
 

--- a/src/pages/dashboard/settings/administrators/tabs/administrators/AdministratorsPanelHeader/AdministratorsPanelHeader.tsx
+++ b/src/pages/dashboard/settings/administrators/tabs/administrators/AdministratorsPanelHeader/AdministratorsPanelHeader.tsx
@@ -1,14 +1,8 @@
-import { TableFilterChips } from "@/components/filter";
 import HeaderWithSearch from "@/components/form/HeaderWithSearch";
 import type { FC } from "react";
 
 const AdministratorsPanelHeader: FC = () => {
-  return (
-    <>
-      <HeaderWithSearch />
-      <TableFilterChips filtersToDisplay={["search"]} />
-    </>
-  );
+  return <HeaderWithSearch />;
 };
 
 export default AdministratorsPanelHeader;


### PR DESCRIPTION
## Summary
Removed search chip from appearing when performing a search. The search should remain in the input field itself.

This PR is linked to [this Jira ticket](https://warthogs.atlassian.net/browse/LNDENG-4476)

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
