### PR TITLE
Standardize Empty States usage

### DIFF
--- a/.changeset/light-camels-sit.md
+++ b/.changeset/light-camels-sit.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Fix empty state spacing and links that used to be buttons

--- a/src/components/layout/AppErrorBoundary/FallbackComponent.module.scss
+++ b/src/components/layout/AppErrorBoundary/FallbackComponent.module.scss
@@ -13,5 +13,5 @@
 }
 
 :global(.is-dark) .errorDetails {
-  background-color: rgba(255, 255, 255, 0.03);
+  background-color: rgb(255 255 255 / 3%);
 }

--- a/src/components/layout/AppErrorBoundary/FallbackComponent.module.scss
+++ b/src/components/layout/AppErrorBoundary/FallbackComponent.module.scss
@@ -1,0 +1,17 @@
+@import "vanilla-framework/scss/settings_spacing";
+@import "vanilla-framework/scss/settings_colors";
+
+.errorDetails {
+  background-color: $colors--theme--background-code;
+  border: 1px solid $colors--theme--border-low-contrast;
+  border-radius: 4px;
+  margin-bottom: 0;
+  margin-top: $spv--large;
+  max-height: 200px;
+  overflow: auto;
+  padding: $spv--large;
+}
+
+:global(.is-dark) .errorDetails {
+  background-color: rgba(255, 255, 255, 0.03);
+}

--- a/src/components/layout/AppErrorBoundary/FallbackComponent.module.scss
+++ b/src/components/layout/AppErrorBoundary/FallbackComponent.module.scss
@@ -15,3 +15,8 @@
 :global(.is-dark) .errorDetails {
   background-color: rgb(255 255 255 / 3%);
 }
+
+.emptyState {
+  max-width: 100%;
+  width: max-content;
+}

--- a/src/components/layout/AppErrorBoundary/FallbackComponent.tsx
+++ b/src/components/layout/AppErrorBoundary/FallbackComponent.tsx
@@ -2,6 +2,7 @@ import EmptyState from "@/components/layout/EmptyState";
 import { IS_DEV_ENV } from "@/constants";
 import { Button } from "@canonical/react-components";
 import type { FallbackRender } from "@sentry/react";
+import classes from "./FallbackComponent.module.scss";
 
 export const FallbackComponent: FallbackRender = (errorData) => {
   const { error, resetError, componentStack } = errorData;
@@ -14,6 +15,7 @@ export const FallbackComponent: FallbackRender = (errorData) => {
 
   return (
     <EmptyState
+      size="max"
       body={
         <>
           <p className="u-no-margin--bottom">
@@ -21,20 +23,12 @@ export const FallbackComponent: FallbackRender = (errorData) => {
           </p>
           {IS_DEV_ENV && (
             <pre
-              style={{
-                backgroundColor: "#f4f4f4",
-                border: "1px solid #e0e0e0",
-                borderRadius: "4px",
-                marginTop: "1rem",
-                maxHeight: "200px",
-                overflow: "auto",
-                padding: "1rem",
-              }}
+              className={classes.errorDetails}
             >
               <strong>Error:</strong> {errorMessage}
               <br />
-              <strong>Stack trace:</strong>
               <br />
+              <strong>Stack trace:</strong>
               {componentStack}
             </pre>
           )}

--- a/src/components/layout/AppErrorBoundary/FallbackComponent.tsx
+++ b/src/components/layout/AppErrorBoundary/FallbackComponent.tsx
@@ -15,7 +15,7 @@ export const FallbackComponent: FallbackRender = (errorData) => {
 
   return (
     <EmptyState
-      size="max"
+      className={classes.emptyState}
       body={
         <>
           <p className="u-no-margin--bottom">

--- a/src/components/layout/AppErrorBoundary/FallbackComponent.tsx
+++ b/src/components/layout/AppErrorBoundary/FallbackComponent.tsx
@@ -22,9 +22,7 @@ export const FallbackComponent: FallbackRender = (errorData) => {
             Please try again or contact our support team.
           </p>
           {IS_DEV_ENV && (
-            <pre
-              className={classes.errorDetails}
-            >
+            <pre className={classes.errorDetails}>
               <strong>Error:</strong> {errorMessage}
               <br />
               <br />

--- a/src/components/layout/EmptyState.module.scss
+++ b/src/components/layout/EmptyState.module.scss
@@ -7,14 +7,25 @@
   gap: $spv--small;
   margin-left: auto;
   margin-right: auto;
+  padding: 0 $sph--large;
 
-  &:global(.size-medium) {
-    max-width: 420px;
+  &:global(.size-fixed) {
+    max-width: 500px;
   }
 
-  &:global(.size-large) {
-    max-width: 550px;
+  &:global(.size-max) {
+    max-width: 100%;
+    width: max-content;
   }
+}
+
+:global(#root) > :global(.p-strip) > .inner {
+  padding: 0 $sph--x-large;
+}
+
+.body {
+  margin-bottom: 0;
+  max-width: inherit;
 }
 
 .cta {

--- a/src/components/layout/EmptyState.module.scss
+++ b/src/components/layout/EmptyState.module.scss
@@ -1,8 +1,10 @@
+@import "vanilla-framework/scss/settings_spacing";
+
 .inner {
   align-items: flex-start;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: $spv--small;
   margin-left: auto;
   margin-right: auto;
 
@@ -16,5 +18,5 @@
 }
 
 .cta {
-  margin-top: 1rem;
+  margin-top: $spv--large;
 }

--- a/src/components/layout/EmptyState.module.scss
+++ b/src/components/layout/EmptyState.module.scss
@@ -7,20 +7,14 @@
   gap: $spv--small;
   margin-left: auto;
   margin-right: auto;
-  padding: 0 $sph--large;
+  max-width: 500px;
+  padding-left: $sph--large;
+  padding-right: $sph--large;
 
-  &:global(.size-fixed) {
-    max-width: 500px;
+  :global(#root) > & {
+    padding-left: $sph--x-large;
+    padding-right: $sph--x-large;
   }
-
-  &:global(.size-max) {
-    max-width: 100%;
-    width: max-content;
-  }
-}
-
-:global(#root) > :global(.p-strip) > .inner {
-  padding: 0 $sph--x-large;
 }
 
 .body {

--- a/src/components/layout/EmptyState.tsx
+++ b/src/components/layout/EmptyState.tsx
@@ -1,5 +1,6 @@
 import type { FC, ReactNode } from "react";
 import classes from "./EmptyState.module.scss";
+import classNames from "classnames";
 
 interface EmptyStateProps {
   readonly title?: string;
@@ -7,7 +8,7 @@ interface EmptyStateProps {
   readonly link?: { href: string; text: string };
   readonly icon?: string;
   readonly cta?: ReactNode[];
-  readonly size?: "fixed" | "max";
+  readonly className?: string;
 }
 
 const EmptyState: FC<EmptyStateProps> = ({
@@ -16,33 +17,27 @@ const EmptyState: FC<EmptyStateProps> = ({
   link,
   icon = "",
   cta = [],
-  size = "fixed",
+  className,
 }) => {
   return (
-    <div className="p-strip">
-      <div className={`${classes.inner} size-${size}`}>
-        {icon && (
-          <div>
-            <span
-              style={{ width: 36, height: 36, opacity: 0.2 }}
-              className={`p-icon--${icon}`}
-              aria-hidden
-            />
-          </div>
-        )}
-        {title && <p className="p-heading--4 u-no-margin">{title}</p>}
-        {body && <div className={classes.body}>{body}</div>}
-        {link && (
-          <a
-            href={link.href}
-            target="_blank"
-            rel="nofollow noopener noreferrer"
-          >
-            {link.text}
-          </a>
-        )}
-        {cta.length > 0 && <div className={classes.cta}>{cta}</div>}
-      </div>
+    <div className={classNames("p-strip", classes.inner, className)}>
+      {icon && (
+        <div>
+          <span
+            style={{ width: 36, height: 36, opacity: 0.2 }}
+            className={`p-icon--${icon}`}
+            aria-hidden
+          />
+        </div>
+      )}
+      {title && <p className="p-heading--4 u-no-margin">{title}</p>}
+      {body && <div className={classes.body}>{body}</div>}
+      {link && (
+        <a href={link.href} target="_blank" rel="nofollow noopener noreferrer">
+          {link.text}
+        </a>
+      )}
+      {cta.length > 0 && <div className={classes.cta}>{cta}</div>}
     </div>
   );
 };

--- a/src/components/layout/EmptyState.tsx
+++ b/src/components/layout/EmptyState.tsx
@@ -4,6 +4,7 @@ import classes from "./EmptyState.module.scss";
 interface EmptyStateProps {
   readonly title?: string;
   readonly body?: ReactNode;
+  readonly link?: { href: string; text: string };
   readonly icon?: string;
   readonly cta?: ReactNode[];
   readonly size?: "medium" | "large";
@@ -12,6 +13,7 @@ interface EmptyStateProps {
 const EmptyState: FC<EmptyStateProps> = ({
   title = "",
   body = "",
+  link,
   icon = "",
   cta = [],
   size = "medium",
@@ -30,7 +32,16 @@ const EmptyState: FC<EmptyStateProps> = ({
             </div>
           )}
           {title && <p className="p-heading--4 u-no-margin--bottom">{title}</p>}
-          {body && <div>{body}</div>}
+          {body && <p className="u-no-margin--bottom">{body}</p>}
+          {link && (
+            <a
+              href={link.href}
+              target="_blank"
+              rel="nofollow noopener noreferrer"
+            >
+              {link.text}
+            </a>
+          )}
           {cta.length > 0 && <div className={classes.cta}>{cta}</div>}
         </div>
       </div>

--- a/src/components/layout/EmptyState.tsx
+++ b/src/components/layout/EmptyState.tsx
@@ -7,7 +7,7 @@ interface EmptyStateProps {
   readonly link?: { href: string; text: string };
   readonly icon?: string;
   readonly cta?: ReactNode[];
-  readonly size?: "medium" | "large";
+  readonly size?: "fixed" | "max";
 }
 
 const EmptyState: FC<EmptyStateProps> = ({
@@ -16,34 +16,32 @@ const EmptyState: FC<EmptyStateProps> = ({
   link,
   icon = "",
   cta = [],
-  size = "medium",
+  size = "fixed",
 }) => {
   return (
     <div className="p-strip">
-      <div className="u-fixed-width">
-        <div className={`${classes.inner} size-${size}`}>
-          {icon && (
-            <div>
-              <span
-                style={{ width: 36, height: 36, opacity: 0.2 }}
-                className={`p-icon--${icon}`}
-                aria-hidden
-              />
-            </div>
-          )}
-          {title && <p className="p-heading--4 u-no-margin">{title}</p>}
-          {body && <p className="u-no-margin--bottom">{body}</p>}
-          {link && (
-            <a
-              href={link.href}
-              target="_blank"
-              rel="nofollow noopener noreferrer"
-            >
-              {link.text}
-            </a>
-          )}
-          {cta.length > 0 && <div className={classes.cta}>{cta}</div>}
-        </div>
+      <div className={`${classes.inner} size-${size}`}>
+        {icon && (
+          <div>
+            <span
+              style={{ width: 36, height: 36, opacity: 0.2 }}
+              className={`p-icon--${icon}`}
+              aria-hidden
+            />
+          </div>
+        )}
+        {title && <p className="p-heading--4 u-no-margin">{title}</p>}
+        {body && <div className={classes.body}>{body}</div>}
+        {link && (
+          <a
+            href={link.href}
+            target="_blank"
+            rel="nofollow noopener noreferrer"
+          >
+            {link.text}
+          </a>
+        )}
+        {cta.length > 0 && <div className={classes.cta}>{cta}</div>}
       </div>
     </div>
   );

--- a/src/components/layout/EmptyState.tsx
+++ b/src/components/layout/EmptyState.tsx
@@ -31,7 +31,7 @@ const EmptyState: FC<EmptyStateProps> = ({
               />
             </div>
           )}
-          {title && <p className="p-heading--4 u-no-margin--bottom">{title}</p>}
+          {title && <p className="p-heading--4 u-no-margin">{title}</p>}
           {body && <p className="u-no-margin--bottom">{body}</p>}
           {link && (
             <a

--- a/src/features/access-groups/components/AccessGroupContainer/AccessGroupContainer.tsx
+++ b/src/features/access-groups/components/AccessGroupContainer/AccessGroupContainer.tsx
@@ -35,7 +35,7 @@ const AccessGroupsContainer: FC = () => {
         <EmptyState
           title="No access groups found"
           icon="copy"
-          body="You haven&#39;t added any access groups yet."
+          body="You haven't added any access groups yet."
           link={{
             href: "https://ubuntu.com/landscape/docs/access-groups",
             text: "How to manage access groups in Landscape",

--- a/src/features/access-groups/components/AccessGroupContainer/AccessGroupContainer.tsx
+++ b/src/features/access-groups/components/AccessGroupContainer/AccessGroupContainer.tsx
@@ -35,20 +35,11 @@ const AccessGroupsContainer: FC = () => {
         <EmptyState
           title="No access groups found"
           icon="copy"
-          body={
-            <>
-              <p className="u-no-margin--bottom">
-                You haven&#39;t added any access groups yet.
-              </p>
-              <a
-                href="https://ubuntu.com/landscape/docs/access-groups"
-                target="_blank"
-                rel="nofollow noopener noreferrer"
-              >
-                How to manage access groups in Landscape
-              </a>
-            </>
-          }
+          body="You haven&#39;t added any access groups yet."
+          link={{
+            href: "https://ubuntu.com/landscape/docs/access-groups",
+            text: "How to manage access groups in Landscape",
+          }}
           cta={[
             <Button
               key="add-access-group"

--- a/src/features/activities/components/ActivitiesEmptyState/ActivitiesEmptyState.tsx
+++ b/src/features/activities/components/ActivitiesEmptyState/ActivitiesEmptyState.tsx
@@ -5,18 +5,11 @@ import { DOCUMENTATION_LINK } from "./constants";
 const ActivitiesEmptyState: FC = () => {
   return (
     <EmptyState
-      body={
-        <>
-          <p>There are no activities yet.</p>
-          <a
-            href={DOCUMENTATION_LINK}
-            target="_blank"
-            rel="nofollow noopener noreferrer"
-          >
-            How to manage computers in Landscape
-          </a>
-        </>
-      }
+      body="There are no activities yet."
+      link={{
+        href: DOCUMENTATION_LINK,
+        text: "How to manage computers in Landscape",
+      }}
       icon="switcher-environments"
       title="No activities found"
     />

--- a/src/features/auth/components/ProvidersEmptyState/ProvidersEmptyState.tsx
+++ b/src/features/auth/components/ProvidersEmptyState/ProvidersEmptyState.tsx
@@ -21,20 +21,11 @@ const ProvidersEmptyState: FC = () => {
 
   return (
     <EmptyState
-      body={
-        <>
-          <p className="u-no-margin--bottom">
-            You haven’t added any identity providers yet.
-          </p>
-          <a
-            href="https://ubuntu.com/landscape/docs/managing-computers"
-            target="_blank"
-            rel="nofollow noopener noreferrer"
-          >
-            How to manage computers in Landscape
-          </a>
-        </>
-      }
+      body="You haven’t added any identity providers yet."
+      link={{
+        href: "https://ubuntu.com/landscape/docs/managing-computers",
+        text: "How to manage computers in Landscape",
+      }}
       cta={[
         <Button
           appearance="positive"

--- a/src/features/local-repositories/components/LocalRepositoriesContainer/LocalRepositoriesContainer.test.tsx
+++ b/src/features/local-repositories/components/LocalRepositoriesContainer/LocalRepositoriesContainer.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import LocalRepositoriesContainer from "./LocalRepositoriesContainer";
 import { repositories } from "@/tests/mocks/localRepositories";
 import { screen } from "@testing-library/react";
+import { DEBARCHIVE_DOCUMENTATION_URL } from "@/features/repositories";
 
 describe("LocalRepositoriesContainer", () => {
   it("renders loading state when isPending is true", () => {
@@ -19,41 +20,20 @@ describe("LocalRepositoriesContainer", () => {
     );
 
     expect(
-      screen.getByText("You don't have any local repositories yet"),
+      screen.getByText("You don’t have any local repositories yet"),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /add local repository/i }),
     ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("link", {
+        name: /learn more about repository mirroring/i,
+      }),
+    ).toHaveAttribute("href", DEBARCHIVE_DOCUMENTATION_URL);
   });
 
-  it("renders empty state with link to documentation", () => {
-    renderWithProviders(
-      <LocalRepositoriesContainer isPending={false} repositories={[]} />,
-    );
-
-    const link = screen.getByRole("link", {
-      name: /learn more about repository mirroring/i,
-    });
-    expect(link).toHaveAttribute(
-      "href",
-      expect.stringContaining("landscape/docs/repositories"),
-    );
-    expect(link).toHaveAttribute("target", "_blank");
-  });
-
-  it("renders list when repositories are present", () => {
-    renderWithProviders(
-      <LocalRepositoriesContainer
-        isPending={false}
-        repositories={repositories}
-      />,
-    );
-
-    expect(screen.getByText("repo 1")).toBeInTheDocument();
-    expect(screen.getByText("repo 2")).toBeInTheDocument();
-  });
-
-  it("renders header with search when repositories are present", () => {
+  it("renders header and list when repositories are present", () => {
     renderWithProviders(
       <LocalRepositoriesContainer
         isPending={false}
@@ -64,5 +44,8 @@ describe("LocalRepositoriesContainer", () => {
     expect(
       screen.getByRole("searchbox", { name: /search/i }),
     ).toBeInTheDocument();
+
+    expect(screen.getByText("repo 1")).toBeInTheDocument();
+    expect(screen.getByText("repo 2")).toBeInTheDocument();
   });
 });

--- a/src/features/local-repositories/components/LocalRepositoriesContainer/LocalRepositoriesContainer.tsx
+++ b/src/features/local-repositories/components/LocalRepositoriesContainer/LocalRepositoriesContainer.tsx
@@ -6,6 +6,7 @@ import AddLocalRepositoryButton from "../AddLocalRepositoryButton";
 import EmptyState from "@/components/layout/EmptyState";
 import type { Local } from "@canonical/landscape-openapi";
 import usePageParams from "@/hooks/usePageParams";
+import { DEBARCHIVE_DOCUMENTATION_URL } from "@/features/repositories";
 
 interface LocalRepositoriesContainerProps {
   readonly isPending: boolean;
@@ -25,23 +26,12 @@ const LocalRepositoriesContainer: FC<LocalRepositoriesContainerProps> = ({
   if (!search && !repositories.length) {
     return (
       <EmptyState
-        title="You don't have any local repositories yet"
-        body={
-          <>
-            <p className="u-no-margin--bottom">
-              Use local repositories to host internal packages and distribute
-              them to your fleet, either through publications or via repository
-              profiles.
-            </p>
-            <a
-              href="https://ubuntu.com/landscape/docs/repositories"
-              target="_blank"
-              rel="nofollow noopener noreferrer"
-            >
-              Learn more about repository mirroring
-            </a>
-          </>
-        }
+        title="You don’t have any local repositories yet"
+        body="Use local repositories to host internal packages and distribute them to your fleet, either through publications or via repository profiles."
+        link={{
+          href: DEBARCHIVE_DOCUMENTATION_URL,
+          text: "Learn more about repository mirroring",
+        }}
         cta={[<AddLocalRepositoryButton key="add-local-repository" />]}
       />
     );

--- a/src/features/profiles/components/ProfilesEmptyState/ProfilesEmptyState.tsx
+++ b/src/features/profiles/components/ProfilesEmptyState/ProfilesEmptyState.tsx
@@ -1,7 +1,6 @@
 import EmptyState from "@/components/layout/EmptyState";
 import type { FC } from "react";
 import AddProfileButton from "../AddProfileButton";
-import { Link } from "@canonical/react-components";
 import { getLink, getMessage } from "./helpers";
 import type { ProfileTypes } from "../../helpers";
 
@@ -10,19 +9,13 @@ interface ProfilesEmptyStateProps {
 }
 
 const ProfilesEmptyState: FC<ProfilesEmptyStateProps> = ({ type }) => {
-  const message = getMessage(type);
-  const link = getLink(type);
-
   return (
     <EmptyState
-      body={
-        <>
-          <p>{message}</p>
-          <Link href={link} target="_blank" rel="nofollow noopener noreferrer">
-            How to manage {type} profiles in Landscape
-          </Link>
-        </>
-      }
+      body={getMessage(type)}
+      link={{
+        href: getLink(type),
+        text: `How to manage ${type} profiles in Landscape`,
+      }}
       cta={[<AddProfileButton key="add" />]}
       title={`You haven't added any ${type} profiles yet.`}
       size="large"

--- a/src/features/profiles/components/ProfilesEmptyState/ProfilesEmptyState.tsx
+++ b/src/features/profiles/components/ProfilesEmptyState/ProfilesEmptyState.tsx
@@ -18,7 +18,6 @@ const ProfilesEmptyState: FC<ProfilesEmptyStateProps> = ({ type }) => {
       }}
       cta={[<AddProfileButton key="add" />]}
       title={`You haven't added any ${type} profiles yet.`}
-      size="large"
     />
   );
 };

--- a/src/features/publication-targets/api/useGetPublicationTargets.ts
+++ b/src/features/publication-targets/api/useGetPublicationTargets.ts
@@ -6,35 +6,24 @@ import type {
   ListPublicationTargetsResponse,
   PublicationTarget,
 } from "@canonical/landscape-openapi";
-import usePageParams from "@/hooks/usePageParams";
 
 interface UseGetPublicationTargetsOptions {
   pageSize?: number;
+  search?: string;
 }
 
 export default function useGetPublicationTargets(
   options?: UseGetPublicationTargetsOptions,
 ) {
-  const { search } = usePageParams();
-
-  const { pageSize } = options ?? {};
+  const { pageSize, search } = options ?? {};
   const authFetchDebArchive = useFetchDebArchive();
 
   const { data, isLoading } = useQuery<
     PublicationTarget[],
     AxiosError<ApiError>
   >({
-    queryKey: ["publication-targets", pageSize ?? "all"],
+    queryKey: ["publication-targets", options ?? "all"],
     queryFn: async () => {
-      if (pageSize !== undefined) {
-        const response =
-          await authFetchDebArchive.get<ListPublicationTargetsResponse>(
-            "publicationTargets",
-            { params: { pageSize } },
-          );
-        return response.data.publicationTargets ?? [];
-      }
-
       let pageToken: string | undefined;
       const targets: PublicationTarget[] = [];
 
@@ -42,23 +31,23 @@ export default function useGetPublicationTargets(
         const response =
           await authFetchDebArchive.get<ListPublicationTargetsResponse>(
             "publicationTargets",
-            { params: { pageSize: 1000, pageToken } },
+            { params: {
+              pageSize: pageSize ?? 1000,
+              pageToken,
+              filter: search ? `display_name="${search}*"` : undefined,
+            } },
           );
 
         targets.push(...(response.data.publicationTargets ?? []));
-        pageToken = response.data.nextPageToken || undefined;
+        pageToken = !pageSize ? response.data.nextPageToken : undefined;
       } while (pageToken);
 
       return targets;
     },
   });
 
-  const filteredData = data?.filter((target) =>
-    target.displayName.includes(search),
-  );
-
   return {
-    publicationTargets: filteredData ?? [],
+    publicationTargets: data ?? [],
     isGettingPublicationTargets: isLoading,
     count: data?.length ?? 0,
   };

--- a/src/features/publication-targets/api/useGetPublicationTargets.ts
+++ b/src/features/publication-targets/api/useGetPublicationTargets.ts
@@ -31,11 +31,13 @@ export default function useGetPublicationTargets(
         const response =
           await authFetchDebArchive.get<ListPublicationTargetsResponse>(
             "publicationTargets",
-            { params: {
-              pageSize: pageSize ?? 1000,
-              pageToken,
-              filter: search ? `display_name="${search}*"` : undefined,
-            } },
+            {
+              params: {
+                pageSize: pageSize ?? 1000,
+                pageToken,
+                filter: search ? `display_name="${search}*"` : undefined,
+              },
+            },
           );
 
         targets.push(...(response.data.publicationTargets ?? []));

--- a/src/features/publication-targets/components/EditTargetForm/EditTargetForm.tsx
+++ b/src/features/publication-targets/components/EditTargetForm/EditTargetForm.tsx
@@ -77,7 +77,7 @@ const getFilesystemInitialValues = (
 });
 
 const getInitialValues = (target: PublicationTarget): EditTargetFormValues => {
-  const base = { ...EMPTY_VALUES, displayName: target.displayName ?? "" };
+  const base = { ...EMPTY_VALUES, displayName: target.displayName };
   if (target.s3) return getS3InitialValues(target, base);
   if (target.swift) return getSwiftInitialValues(target, base);
   return getFilesystemInitialValues(target, base);

--- a/src/features/publication-targets/components/PublicationTargetList/PublicationTargetList.test.tsx
+++ b/src/features/publication-targets/components/PublicationTargetList/PublicationTargetList.test.tsx
@@ -135,35 +135,6 @@ describe("PublicationTargetList", () => {
     expect(screen.getByText("Unknown")).toBeInTheDocument();
   });
 
-  it("renders NoData placeholder in Name cell when target has no displayName", () => {
-    (useGetPublicationsByTarget as Mock).mockReturnValue({
-      publications: [],
-      isGettingPublications: false,
-    });
-
-    const noNameTarget: PublicationTarget = {
-      name: "publicationTargets/eeeeeeee-0000-0000-0000-000000000005",
-      publicationTargetId: "eeeeeeee-0000-0000-0000-000000000005",
-      displayName: "",
-      s3: {
-        region: "us-east-1",
-        bucket: "test-bucket",
-        disableMultiDel: false,
-        forceSigV2: false,
-        awsAccessKeyId: "AKIA...",
-        awsSecretAccessKey: "SECRET...",
-      },
-    };
-
-    renderWithProviders(<PublicationTargetList targets={[noNameTarget]} />);
-
-    // Name cell and Publications cell both show NoData — there are two instances
-    expect(screen.getAllByText(NO_DATA_TEXT).length).toBeGreaterThanOrEqual(1);
-    // Verify the Name column in particular is NoData by checking the first cell in the row
-    const cells = screen.getAllByRole("cell");
-    expect(cells[0]).toHaveTextContent(NO_DATA_TEXT);
-  });
-
   it("renders the publications count as a link filtered by publicationTargetId", () => {
     renderWithProviders(<PublicationTargetList targets={publicationTargets} />);
 

--- a/src/features/publication-targets/components/PublicationTargetList/PublicationTargetList.tsx
+++ b/src/features/publication-targets/components/PublicationTargetList/PublicationTargetList.tsx
@@ -1,5 +1,5 @@
 import { LIST_ACTIONS_COLUMN_PROPS } from "@/components/layout/ListActions";
-import NoData, { NO_DATA_TEXT } from "@/components/layout/NoData";
+import NoData from "@/components/layout/NoData";
 import ResponsiveTable from "@/components/layout/ResponsiveTable";
 import { TablePagination } from "@/components/layout/TablePagination";
 import usePageParams from "@/hooks/usePageParams";
@@ -80,7 +80,7 @@ const PublicationTargetList: FC<PublicationTargetListProps> = ({ targets }) => {
             })}
             aria-label={`View details for ${row.original.displayName}`}
           >
-            {row.original.displayName || NO_DATA_TEXT}
+            {row.original.displayName}
           </Button>
         ),
       },

--- a/src/features/publications/components/NoPublicationsEmptyState/NoPublicationsEmptyState.test.tsx
+++ b/src/features/publications/components/NoPublicationsEmptyState/NoPublicationsEmptyState.test.tsx
@@ -2,20 +2,20 @@ import { renderWithProviders } from "@/tests/render";
 import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import NoPublicationsEmptyState from "./NoPublicationsEmptyState";
-import { DOCUMENTATION_URL } from "./constants";
+import { DEBARCHIVE_DOCUMENTATION_URL } from "@/features/repositories";
 
 describe("NoPublicationsEmptyState", () => {
   it("renders title, docs link and CTA", () => {
     renderWithProviders(<NoPublicationsEmptyState />);
 
     expect(
-      screen.getByText(/you don.t have any publications yet/i),
+      screen.getByText("You don’t have any publications yet"),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("link", {
         name: /learn more about repository mirroring/i,
       }),
-    ).toHaveAttribute("href", DOCUMENTATION_URL);
+    ).toHaveAttribute("href", DEBARCHIVE_DOCUMENTATION_URL);
     expect(
       screen.getByRole("button", { name: /add publication/i }),
     ).toBeInTheDocument();

--- a/src/features/publications/components/NoPublicationsEmptyState/NoPublicationsEmptyState.tsx
+++ b/src/features/publications/components/NoPublicationsEmptyState/NoPublicationsEmptyState.tsx
@@ -1,26 +1,16 @@
 import EmptyState from "@/components/layout/EmptyState";
 import AddPublicationButton from "../AddPublicationButton";
-import { DOCUMENTATION_URL } from "./constants";
+import { DEBARCHIVE_DOCUMENTATION_URL } from "@/features/repositories";
 
 const NoPublicationsEmptyState = () => {
   return (
     <EmptyState
       title="You don’t have any publications yet"
-      body={
-        <>
-          <p>
-            On this page you will find all publications created when publishing
-            a mirror or a local repository.{" "}
-          </p>
-          <a
-            href={DOCUMENTATION_URL}
-            target="_blank"
-            rel="nofollow noopener noreferrer"
-          >
-            Learn more about repository mirroring.
-          </a>
-        </>
-      }
+      body="On this page you will find all publications created when publishing a mirror or a local repository."
+      link={{
+        href: DEBARCHIVE_DOCUMENTATION_URL,
+        text: "Learn more about repository mirroring",
+      }}
       cta={[<AddPublicationButton key="add-publication-button" />]}
     />
   );

--- a/src/features/publications/components/NoPublicationsTargetEmptyState/NoPublicationTargetEmptyState.test.tsx
+++ b/src/features/publications/components/NoPublicationsTargetEmptyState/NoPublicationTargetEmptyState.test.tsx
@@ -2,7 +2,7 @@ import { renderWithProviders } from "@/tests/render";
 import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import NoPublicationTargetEmptyState from "./NoPublicationTargetEmptyState";
-import { DOCUMENTATION_URL } from "./constants";
+import { DEBARCHIVE_DOCUMENTATION_URL } from "@/features/repositories";
 
 describe("NoPublicationTargetEmptyState", () => {
   it("renders title, docs link and CTA button", () => {
@@ -17,7 +17,7 @@ describe("NoPublicationTargetEmptyState", () => {
       screen.getByRole("link", {
         name: /learn more about repository mirroring/i,
       }),
-    ).toHaveAttribute("href", DOCUMENTATION_URL);
+    ).toHaveAttribute("href", DEBARCHIVE_DOCUMENTATION_URL);
     expect(
       screen.getByRole("button", { name: /add publication target/i }),
     ).toBeInTheDocument();

--- a/src/features/publications/components/NoPublicationsTargetEmptyState/NoPublicationTargetEmptyState.tsx
+++ b/src/features/publications/components/NoPublicationsTargetEmptyState/NoPublicationTargetEmptyState.tsx
@@ -1,6 +1,6 @@
 import EmptyState from "@/components/layout/EmptyState";
 import { Button, Icon } from "@canonical/react-components";
-import { DOCUMENTATION_URL } from "./constants";
+import { DEBARCHIVE_DOCUMENTATION_URL } from "@/features/repositories";
 import { useNavigate } from "react-router";
 import { ROUTES } from "@/libs/routes";
 
@@ -17,21 +17,11 @@ const NoPublicationTargetEmptyState = () => {
   return (
     <EmptyState
       title="You must first add a publication target in order to add a publication"
-      body={
-        <>
-          <p>
-            On this page you will find all publications created when publishing
-            a mirror or a local repository.
-          </p>
-          <a
-            href={DOCUMENTATION_URL}
-            target="_blank"
-            rel="nofollow noopener noreferrer"
-          >
-            Learn more about repository mirroring.
-          </a>
-        </>
-      }
+      body="On this page you will find all publications created when publishing a mirror or a local repository."
+      link={{
+        href: DEBARCHIVE_DOCUMENTATION_URL,
+        text: "Learn more about repository mirroring",
+      }}
       cta={[
         <Button
           appearance="positive"

--- a/src/features/publications/components/NoPublicationsTargetEmptyState/constants.ts
+++ b/src/features/publications/components/NoPublicationsTargetEmptyState/constants.ts
@@ -1,2 +1,0 @@
-export const DOCUMENTATION_URL =
-  "https://documentation.ubuntu.com/landscape/explanation/features/repository-mirroring";

--- a/src/features/repositories/constants.ts
+++ b/src/features/repositories/constants.ts
@@ -1,2 +1,2 @@
-export const DOCUMENTATION_URL =
+export const DEBARCHIVE_DOCUMENTATION_URL =
   "https://documentation.ubuntu.com/landscape/explanation/features/repository-mirroring";

--- a/src/features/repositories/index.ts
+++ b/src/features/repositories/index.ts
@@ -1,0 +1,1 @@
+export { DEBARCHIVE_DOCUMENTATION_URL } from "./constants";

--- a/src/features/repository-profiles/components/RepositoryProfileContainer/RepositoryProfileContainer.tsx
+++ b/src/features/repository-profiles/components/RepositoryProfileContainer/RepositoryProfileContainer.tsx
@@ -43,18 +43,11 @@ const RepositoryProfileContainer: FC<RepositoryProfileContainerProps> = ({
     return (
       <EmptyState
         title="No repository profiles found"
-        body={
-          <>
-            <p>You haven’t added any repository profiles yet.</p>
-            <a
-              href="https://ubuntu.com/landscape/docs/manage-repositories-web-portal"
-              target="_blank"
-              rel="nofollow noopener noreferrer"
-            >
-              How to manage repositories in Landscape
-            </a>
-          </>
-        }
+        body="You haven’t added any repository profiles yet."
+        link={{
+          href: "https://ubuntu.com/landscape/docs/manage-repositories-web-portal",
+          text: "How to manage repositories in Landscape",
+        }}
         cta={[<RepositoryProfileAddButton key="add" />]}
       />
     );

--- a/src/features/script-profiles/components/NoScriptsEmptyState/NoScriptsEmptyState.tsx
+++ b/src/features/script-profiles/components/NoScriptsEmptyState/NoScriptsEmptyState.tsx
@@ -24,25 +24,20 @@ const NoScriptsEmptyState: FC = () => {
   return (
     <EmptyState
       title="You need at least one script to add a profile."
-      body={
-        <>
-          <p>
-            In order to create a script profile, you need to have added a script
-            to your Landscape organization.
-          </p>
-
-          <Button
-            type="button"
-            appearance="positive"
-            onClick={addScript}
-            className="u-no-margin--bottom"
-            hasIcon
-          >
-            <Icon name="plus" light />
-            <span>Add script</span>
-          </Button>
-        </>
-      }
+      body="In order to create a script profile, you need to have added a script to your Landscape organization."
+      cta={[
+        <Button
+          type="button"
+          appearance="positive"
+          onClick={addScript}
+          className="u-no-margin--bottom"
+          hasIcon
+          key="add-script-button"
+        >
+          <Icon name="plus" light />
+          <span>Add script</span>
+        </Button>,
+      ]}
     />
   );
 };

--- a/src/features/scripts/components/ScriptsEmptyState/ScriptsEmptyState.tsx
+++ b/src/features/scripts/components/ScriptsEmptyState/ScriptsEmptyState.tsx
@@ -23,20 +23,11 @@ const ScriptsEmptyState: FC = () => {
     <EmptyState
       title="No scripts found"
       icon="connected"
-      body={
-        <>
-          <p className="u-no-margin--bottom">
-            You haven’t added any scripts yet.
-          </p>
-          <a
-            href="https://ubuntu.com/landscape/docs/managing-computers"
-            target="_blank"
-            rel="nofollow noopener noreferrer"
-          >
-            How to manage instances in Landscape
-          </a>
-        </>
-      }
+      body="You haven’t added any scripts yet."
+      link={{
+        href: "https://ubuntu.com/landscape/docs/managing-computers",
+        text: "How to manage instances in Landscape",
+      }}
       cta={[
         <Button
           appearance="positive"

--- a/src/features/ubuntupro/components/UbuntuProEmptyState/UbuntuProEmptyState.tsx
+++ b/src/features/ubuntupro/components/UbuntuProEmptyState/UbuntuProEmptyState.tsx
@@ -25,22 +25,11 @@ const UbuntuProEmptyState: FC<UbuntuProEmptyStateProps> = ({ instance }) => {
   return (
     <EmptyState
       title="No Ubuntu Pro entitlement"
-      body={
-        <>
-          <p>
-            This computer is not currently attached to an Ubuntu Pro
-            entitlement, which provides additional security updates and other
-            benefits from Canonical.
-          </p>
-          <a
-            href="https://ubuntu.com/pro"
-            target="_blank"
-            rel="nofollow noopener noreferrer"
-          >
-            Learn more about Ubuntu Pro
-          </a>
-        </>
-      }
+      body="This computer is not currently attached to an Ubuntu Pro entitlement, which provides additional security updates and other benefits from Canonical."
+      link={{
+        href: "https://ubuntu.com/pro",
+        text: "Learn more about Ubuntu Pro",
+      }}
       cta={[
         <Button
           key="attach-ubuntu-pro"

--- a/src/features/wsl/components/WslInstancesEmptyState/WslInstancesEmptyState.tsx
+++ b/src/features/wsl/components/WslInstancesEmptyState/WslInstancesEmptyState.tsx
@@ -22,21 +22,11 @@ const WslInstancesEmptyState: FC = () => {
   return (
     <EmptyState
       title="No WSL instances found"
-      body={
-        <>
-          <p>
-            This computer does not have any WSL instances installed. You can
-            install a new instance by clicking the button below.
-          </p>
-          <a
-            href="https://ubuntu.com/desktop/wsl"
-            target="_blank"
-            rel="nofollow noopener noreferrer"
-          >
-            Learn more about Ubuntu WSL
-          </a>
-        </>
-      }
+      body="This computer does not have any WSL instances installed. You can install a new instance by clicking the button below."
+      link={{
+        href: "https://ubuntu.com/desktop/wsl",
+        text: "Learn more about Ubuntu WSL",
+      }}
       cta={[
         <Button
           key="install-new-instance-button"

--- a/src/pages/EnvError.tsx
+++ b/src/pages/EnvError.tsx
@@ -12,22 +12,20 @@ const EnvError: FC = () => {
       title="Environment Error"
       body={
         <>
-          <p>
-            <span>
-              {isSaas && "This feature is not available in SaaS mode."}
-              {isSelfHosted &&
-                "This feature is not available in Self Hosted mode."}
-            </span>
-          </p>
-          <Link
-            to={ROUTES.root.root()}
-            replace
-            className="p-button--positive u-no-margin--bottom"
-          >
-            Go back to the home page
-          </Link>
+          {isSaas && "This feature is not available in SaaS mode."}
+          {isSelfHosted && "This feature is not available in Self Hosted mode."}
         </>
       }
+      cta={[
+        <Link
+          to={ROUTES.root.root()}
+          replace
+          className="p-button--positive u-no-margin--bottom"
+          key="home-link"
+        >
+          Go back to the home page
+        </Link>,
+      ]}
       icon="warning-grey"
     />
   );

--- a/src/pages/dashboard/alert-notifications/AlertNotificationsPage.test.tsx
+++ b/src/pages/dashboard/alert-notifications/AlertNotificationsPage.test.tsx
@@ -12,11 +12,11 @@ describe("AlertNotificationsPage", () => {
     const emptyStateTitle = await screen.findByText(
       "No subscribed alerts found",
     );
-    const goToAlertsButton = await screen.findByRole("button", {
-      name: "Go to alerts page",
+    const goToAlertsLink = await screen.findByRole("link", {
+      name: "Go to alerts",
     });
 
-    expect(goToAlertsButton).toBeInTheDocument();
+    expect(goToAlertsLink).toBeInTheDocument();
     expect(emptyStateTitle).toBeInTheDocument();
   });
 

--- a/src/pages/dashboard/alert-notifications/AlertNotificationsPage.tsx
+++ b/src/pages/dashboard/alert-notifications/AlertNotificationsPage.tsx
@@ -34,18 +34,22 @@ const AlertNotificationsPage: FC = () => {
 
   const alerts = getAlertsSummaryQueryResult?.data.alerts_summary || [];
 
+  if (
+    (hasPendingInstancesAlert && isGettingPendingInstances) ||
+    getAlertsSummaryQueryLoading
+  ) {
+    return <LoadingState />;
+  }
+
   return (
     <PageMain>
       <PageHeader title="Alerts" />
       <PageContent>
-        {getAlertsSummaryQueryLoading ||
-        (hasPendingInstancesAlert && isGettingPendingInstances) ? (
-          <LoadingState />
-        ) : !alerts.length ? (
+        {!alerts.length ? (
           <EmptyState
             title="No subscribed alerts found"
             icon="connected"
-            body={<p>You are not subscribed to any alerts yet.</p>}
+            body="You are not subscribed to any alerts yet."
             cta={[
               <Button
                 appearance="positive"

--- a/src/pages/dashboard/alert-notifications/AlertNotificationsPage.tsx
+++ b/src/pages/dashboard/alert-notifications/AlertNotificationsPage.tsx
@@ -43,7 +43,7 @@ const AlertNotificationsPage: FC = () => {
     <PageMain>
       <PageHeader title="Alerts" />
       <PageContent>
-        {!alerts.length || alerts.length ? (
+        {!alerts.length ? (
           <EmptyState
             title="No subscribed alerts found"
             icon="connected"

--- a/src/pages/dashboard/alert-notifications/AlertNotificationsPage.tsx
+++ b/src/pages/dashboard/alert-notifications/AlertNotificationsPage.tsx
@@ -9,12 +9,10 @@ import {
 } from "@/features/alert-notifications";
 import { useGetPendingInstances } from "@/features/instances";
 import { ROUTES } from "@/libs/routes";
-import { Button } from "@canonical/react-components";
 import type { FC } from "react";
-import { useNavigate } from "react-router";
+import { Link } from "react-router";
 
 const AlertNotificationsPage: FC = () => {
-  const navigate = useNavigate();
   const { getAlertsSummaryQuery } = useAlertsSummary();
 
   const {
@@ -45,23 +43,20 @@ const AlertNotificationsPage: FC = () => {
     <PageMain>
       <PageHeader title="Alerts" />
       <PageContent>
-        {!alerts.length ? (
+        {!alerts.length || alerts.length ? (
           <EmptyState
             title="No subscribed alerts found"
             icon="connected"
             body="You are not subscribed to any alerts yet."
             cta={[
-              <Button
-                appearance="positive"
+              <Link
                 key="go-to-alerts-page"
-                onClick={() =>
-                  navigate(ROUTES.account.alerts(), { replace: true })
-                }
-                type="button"
-                aria-label="Go to alerts page"
+                to={ROUTES.account.alerts()}
+                replace
+                className="p-button--positive u-no-margin--bottom"
               >
                 Go to alerts
-              </Button>,
+              </Link>,
             ]}
           />
         ) : (

--- a/src/pages/dashboard/instances/[single]/SingleInstanceEmptyState/SingleInstanceEmptyState.test.tsx
+++ b/src/pages/dashboard/instances/[single]/SingleInstanceEmptyState/SingleInstanceEmptyState.test.tsx
@@ -1,5 +1,4 @@
 import { screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { renderWithProviders } from "@/tests/render";
 import SingleInstanceEmptyState from "./SingleInstanceEmptyState";
@@ -37,37 +36,24 @@ describe("SingleInstanceEmptyState", () => {
     expect(screen.getByText("exist")).toBeInTheDocument();
   });
 
-  it("renders 'Back to Instances page' button", () => {
+  it("renders 'Back to Instances page' link", () => {
     renderWithProviders(
       <SingleInstanceEmptyState instanceId="42" childInstanceId={undefined} />,
     );
 
-    expect(screen.getByText("Back to Instances page")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Back to Instances page" }),
+    ).toHaveAttribute("href", "/instances");
   });
 
-  it("renders 'Home page' button", () => {
+  it("renders 'Home page' link", () => {
     renderWithProviders(
       <SingleInstanceEmptyState instanceId="42" childInstanceId={undefined} />,
     );
 
-    expect(screen.getByText("Home page")).toBeInTheDocument();
-  });
-
-  it("navigates to instances page when 'Back to Instances page' is clicked", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(
-      <SingleInstanceEmptyState instanceId="42" childInstanceId={undefined} />,
+    expect(screen.getByRole("link", { name: "Home page" })).toHaveAttribute(
+      "href",
+      "/",
     );
-
-    await user.click(screen.getByText("Back to Instances page"));
-  });
-
-  it("navigates to home page when 'Home page' is clicked", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(
-      <SingleInstanceEmptyState instanceId="42" childInstanceId={undefined} />,
-    );
-
-    await user.click(screen.getByText("Home page"));
   });
 });

--- a/src/pages/dashboard/instances/[single]/SingleInstanceEmptyState/SingleInstanceEmptyState.tsx
+++ b/src/pages/dashboard/instances/[single]/SingleInstanceEmptyState/SingleInstanceEmptyState.tsx
@@ -1,7 +1,6 @@
 import type { FC } from "react";
 import EmptyState from "@/components/layout/EmptyState";
-import { Button } from "@canonical/react-components";
-import { useNavigate } from "react-router";
+import { Link } from "react-router";
 import { ROUTES } from "@/libs/routes";
 
 interface SingleInstanceEmptyStateProps {
@@ -13,14 +12,12 @@ const SingleInstanceEmptyState: FC<SingleInstanceEmptyStateProps> = ({
   childInstanceId,
   instanceId,
 }) => {
-  const navigate = useNavigate();
-
   return (
     <EmptyState
       title="Instance not found"
       icon="connected"
       body={
-        <p className="u-no-margin--bottom">
+        <>
           <span>Seems like the instance with id = </span>
           <code>{instanceId}</code>
           <span> doesn&apos;t </span>
@@ -33,28 +30,25 @@ const SingleInstanceEmptyState: FC<SingleInstanceEmptyStateProps> = ({
             <span>exist</span>
           )}
           .
-        </p>
+        </>
       }
       cta={[
-        <Button
-          appearance="positive"
+        <Link
+          to={ROUTES.instances.root()}
+          replace
+          className="p-button--positive u-no-margin--bottom"
           key="go-back-to-instances-page"
-          onClick={async () =>
-            navigate(ROUTES.instances.root(), { replace: true })
-          }
-          type="button"
-          aria-label="Go back"
         >
           Back to Instances page
-        </Button>,
-        <Button
+        </Link>,
+        <Link
+          to={ROUTES.root.root()}
+          replace
+          className="p-button u-no-margin--bottom"
           key="go-back-to-home-page"
-          onClick={async () => navigate(ROUTES.root.root(), { replace: true })}
-          type="button"
-          aria-label="Go back"
         >
           Home page
-        </Button>,
+        </Link>,
       ]}
     />
   );

--- a/src/pages/dashboard/instances/[single]/SingleInstanceEmptyState/SingleInstanceEmptyState.tsx
+++ b/src/pages/dashboard/instances/[single]/SingleInstanceEmptyState/SingleInstanceEmptyState.tsx
@@ -36,7 +36,7 @@ const SingleInstanceEmptyState: FC<SingleInstanceEmptyStateProps> = ({
         <Link
           to={ROUTES.instances.root()}
           replace
-          className="p-button--positive u-no-margin--bottom"
+          className="p-button--positive"
           key="go-back-to-instances-page"
         >
           Back to Instances page

--- a/src/pages/dashboard/instances/[single]/tabs/hardware/HardwarePanel/HardwarePanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/hardware/HardwarePanel/HardwarePanel.tsx
@@ -17,13 +17,7 @@ const HardwarePanel: FC<HardwarePanelProps> = ({ instance }) => {
       <EmptyState
         title="Hardware information unavailable"
         icon="connected"
-        body={
-          <>
-            <p className="u-no-margin--bottom">
-              Your hardware reporting monitor may be turned off.
-            </p>
-          </>
-        }
+        body="Your hardware reporting monitor may be turned off."
       />
     );
   }

--- a/src/pages/dashboard/repositories/mirrors/MirrorsPage.test.tsx
+++ b/src/pages/dashboard/repositories/mirrors/MirrorsPage.test.tsx
@@ -11,6 +11,7 @@ import { renderWithProviders } from "@/tests/render";
 import MirrorsPage from "./MirrorsPage";
 import { Suspense } from "react";
 import LoadingState from "@/components/layout/LoadingState";
+import { DEBARCHIVE_DOCUMENTATION_URL } from "@/features/repositories";
 
 describe("MirrorsPage", () => {
   afterEach(() => {
@@ -48,7 +49,33 @@ describe("MirrorsPage", () => {
     );
 
     expect(
-      await screen.findByText("You don't have any mirrors yet."),
+      await screen.findByText("You don’t have any mirrors yet"),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("link", {
+        name: /learn more about repository mirroring/i,
+      }),
+    ).toHaveAttribute("href", DEBARCHIVE_DOCUMENTATION_URL);
+
+    expect(
+      screen.getByRole("button", { name: /add mirror/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty list when there are no mirrors with search", async () => {
+    renderWithProviders(
+      <Suspense fallback={<LoadingState />}>
+        <MirrorsPage />
+      </Suspense>,
+      undefined,
+      "?search=randomsearchterm",
+    );
+
+    expect(
+      await screen.findByText(
+        /No mirrors found with the search: "randomsearchterm"/i,
+      ),
     ).toBeInTheDocument();
   });
 

--- a/src/pages/dashboard/repositories/mirrors/MirrorsPage.tsx
+++ b/src/pages/dashboard/repositories/mirrors/MirrorsPage.tsx
@@ -6,6 +6,7 @@ import PageMain from "@/components/layout/PageMain";
 import SidePanel from "@/components/layout/SidePanel";
 import { useListMirrors } from "@/features/mirrors";
 import { MirrorsList } from "@/features/mirrors";
+import { DEBARCHIVE_DOCUMENTATION_URL } from "@/features/repositories";
 import useSetDynamicFilterValidation from "@/hooks/useDynamicFilterValidation";
 import usePageParams from "@/hooks/usePageParams";
 import { Button, Icon, ICONS } from "@canonical/react-components";
@@ -76,12 +77,12 @@ const MirrorsPage: FC = () => {
       : {
           children: (
             <EmptyState
-              title="You don't have any mirrors yet."
-              body={
-                <>
-                  <p>This feature allows you to mirror Debian repositories.</p>
-                </>
-              }
+              title="You don’t have any mirrors yet"
+              body="This feature allows you to mirror Debian repositories."
+              link={{
+                href: DEBARCHIVE_DOCUMENTATION_URL,
+                text: "Learn more about repository mirroring",
+              }}
               cta={buttons}
             />
           ),

--- a/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.test.tsx
+++ b/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.test.tsx
@@ -4,6 +4,8 @@ import { screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import PublicationTargetsPage from "./PublicationTargetsPage";
 import userEvent from "@testing-library/user-event";
+import { setEndpointStatus } from "@/tests/controllers/controller";
+import { DEBARCHIVE_DOCUMENTATION_URL } from "@/features/repositories";
 
 describe("PublicationTargetsPage", () => {
   it("renders the page title", () => {
@@ -19,6 +21,26 @@ describe("PublicationTargetsPage", () => {
 
     expect(
       await screen.findByRole("button", { name: /add publication target/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders empty state when there are no publication targets", async () => {
+    setEndpointStatus({ status: "empty", path: "publicationTargets" });
+
+    renderWithProviders(<PublicationTargetsPage />);
+
+    expect(
+      await screen.findByText("You don’t have any publication targets yet"),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("link", {
+        name: /learn more about repository mirroring/i,
+      }),
+    ).toHaveAttribute("href", DEBARCHIVE_DOCUMENTATION_URL);
+
+    expect(
+      screen.getByRole("button", { name: /add publication target/i }),
     ).toBeInTheDocument();
   });
 

--- a/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.test.tsx
+++ b/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.test.tsx
@@ -8,6 +8,10 @@ import { setEndpointStatus } from "@/tests/controllers/controller";
 import { DEBARCHIVE_DOCUMENTATION_URL } from "@/features/repositories";
 
 describe("PublicationTargetsPage", () => {
+  afterEach(() => {
+    setEndpointStatus({ status: "default", path: "publicationTargets" });
+  });
+
   it("renders the page title", () => {
     renderWithProviders(<PublicationTargetsPage />);
 

--- a/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.tsx
+++ b/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.tsx
@@ -27,7 +27,8 @@ const EditTargetForm = lazy(
 );
 
 const PublicationTargetsPage: FC = () => {
-  const { search, lastSidePathSegment, name, popSidePathUntilClear } = usePageParams();
+  const { search, lastSidePathSegment, name, popSidePathUntilClear } =
+    usePageParams();
   const { publicationTargets, count, isGettingPublicationTargets } =
     useGetPublicationTargets({
       search,
@@ -52,32 +53,33 @@ const PublicationTargetsPage: FC = () => {
 
   const addButton = <PublicationTargetAddButton key="add" />;
 
-  const { actions, children, hasTable } = count || search
-    ? {
-        actions: [addButton],
-        children: (
-          <>
-            <HeaderWithSearch />
-            <PublicationTargetList targets={publicationTargets} />
-          </>
-        ),
-        hasTable: true as const,
-      }
-    : {
-        actions: undefined,
-        children: (
-          <EmptyState
-            title="You don’t have any publication targets yet"
-            body="On this page you will find all publication targets that you create to publish mirrors to."
-            link={{
-              href: DEBARCHIVE_DOCUMENTATION_URL,
-              text: "Learn more about repository mirroring",
-            }}
-            cta={[addButton]}
-          />
-        ),
-        hasTable: undefined,
-      };
+  const { actions, children, hasTable } =
+    count || search
+      ? {
+          actions: [addButton],
+          children: (
+            <>
+              <HeaderWithSearch />
+              <PublicationTargetList targets={publicationTargets} />
+            </>
+          ),
+          hasTable: true as const,
+        }
+      : {
+          actions: undefined,
+          children: (
+            <EmptyState
+              title="You don’t have any publication targets yet"
+              body="On this page you will find all publication targets that you create to publish mirrors to."
+              link={{
+                href: DEBARCHIVE_DOCUMENTATION_URL,
+                text: "Learn more about repository mirroring",
+              }}
+              cta={[addButton]}
+            />
+          ),
+          hasTable: undefined,
+        };
 
   return (
     <PageMain>

--- a/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.tsx
+++ b/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/features/publication-targets";
 import { lazy, type FC } from "react";
 import LoadingState from "@/components/layout/LoadingState";
+import { DEBARCHIVE_DOCUMENTATION_URL } from "@/features/repositories";
 
 const AddPublicationTargetForm = lazy(
   async () =>
@@ -64,22 +65,12 @@ const PublicationTargetsPage: FC = () => {
         actions: undefined,
         children: (
           <EmptyState
-            title="You don't have any publication targets yet"
-            body={
-              <>
-                <p className="u-no-margin--bottom">
-                  On this page you will find all publication targets that you
-                  create to publish mirrors to.
-                </p>
-                <a
-                  href="https://documentation.ubuntu.com/landscape/explanation/features/repository-mirroring"
-                  target="_blank"
-                  rel="nofollow noopener noreferrer"
-                >
-                  Learn more about repository mirroring
-                </a>
-              </>
-            }
+            title="You don’t have any publication targets yet"
+            body="On this page you will find all publication targets that you create to publish mirrors to."
+            link={{
+              href: DEBARCHIVE_DOCUMENTATION_URL,
+              text: "Learn more about repository mirroring",
+            }}
             cta={[addButton]}
           />
         ),
@@ -119,9 +110,7 @@ const PublicationTargetsPage: FC = () => {
 
         {lastSidePathSegment === "edit" && viewTarget && (
           <SidePanel.Suspense key="edit">
-            <SidePanel.Header>
-              Edit {viewTarget.displayName ?? viewTarget.name}
-            </SidePanel.Header>
+            <SidePanel.Header>Edit {viewTarget.displayName}</SidePanel.Header>
             <SidePanel.Content>
               <EditTargetForm target={viewTarget} />
             </SidePanel.Content>

--- a/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.tsx
+++ b/src/pages/dashboard/repositories/publication-targets/PublicationTargetsPage.tsx
@@ -27,9 +27,11 @@ const EditTargetForm = lazy(
 );
 
 const PublicationTargetsPage: FC = () => {
-  const { lastSidePathSegment, name, popSidePathUntilClear } = usePageParams();
+  const { search, lastSidePathSegment, name, popSidePathUntilClear } = usePageParams();
   const { publicationTargets, count, isGettingPublicationTargets } =
-    useGetPublicationTargets();
+    useGetPublicationTargets({
+      search,
+    });
 
   useSetDynamicFilterValidation("sidePath", ["view", "add", "edit"]);
 
@@ -50,7 +52,7 @@ const PublicationTargetsPage: FC = () => {
 
   const addButton = <PublicationTargetAddButton key="add" />;
 
-  const { actions, children, hasTable } = count
+  const { actions, children, hasTable } = count || search
     ? {
         actions: [addButton],
         children: (

--- a/src/pages/dashboard/repositories/publications/constants.ts
+++ b/src/pages/dashboard/repositories/publications/constants.ts
@@ -1,2 +1,0 @@
-export const APT_SOURCES_DOCS_URL =
-  "https://ubuntu.com/landscape/docs/repositories";

--- a/src/pages/dashboard/settings/administrators/tabs/administrators/AdministratorsPanel/AdministratorsPanel.tsx
+++ b/src/pages/dashboard/settings/administrators/tabs/administrators/AdministratorsPanel/AdministratorsPanel.tsx
@@ -37,20 +37,11 @@ const AdministratorsPanel: FC = () => {
         (!getAdministratorsQueryResult ||
           !getAdministratorsQueryResult.data.length) && (
           <EmptyState
-            body={
-              <>
-                <p>
-                  There are no administrators in your Landscape organization.
-                </p>
-                <a
-                  href="https://ubuntu.com/landscape/docs/administrators"
-                  target="_blank"
-                  rel="nofollow noopener noreferrer"
-                >
-                  How to manage administrators in Landscape
-                </a>
-              </>
-            }
+            body="There are no administrators in your Landscape organization."
+            link={{
+              href: "https://ubuntu.com/landscape/docs/administrators",
+              text: "How to manage administrators in Landscape",
+            }}
             cta={[
               <Button
                 type="button"

--- a/src/pages/dashboard/settings/employees/tabs/autoinstall-files/AutoinstallFilesPanel.tsx
+++ b/src/pages/dashboard/settings/employees/tabs/autoinstall-files/AutoinstallFilesPanel.tsx
@@ -49,11 +49,7 @@ const AutoinstallFilesPanel: FC = () => {
       <EmptyState
         icon="file"
         title="No autoinstall files found"
-        body={
-          <p className="u-no-margin--bottom">
-            You haven&#39;t added any autoinstall files yet.
-          </p>
-        }
+        body="You haven&#39;t added any autoinstall files yet."
         cta={[
           <Button
             key="add-autoinstall-file"

--- a/src/pages/dashboard/settings/employees/tabs/autoinstall-files/AutoinstallFilesPanel.tsx
+++ b/src/pages/dashboard/settings/employees/tabs/autoinstall-files/AutoinstallFilesPanel.tsx
@@ -49,7 +49,7 @@ const AutoinstallFilesPanel: FC = () => {
       <EmptyState
         icon="file"
         title="No autoinstall files found"
-        body="You haven&#39;t added any autoinstall files yet."
+        body="You haven't added any autoinstall files yet."
         cta={[
           <Button
             key="add-autoinstall-file"

--- a/src/pages/dashboard/settings/roles/RolesContainer/RolesContainer.tsx
+++ b/src/pages/dashboard/settings/roles/RolesContainer/RolesContainer.tsx
@@ -25,20 +25,11 @@ const RolesContainer: FC = () => {
         (!getRolesQueryResult || !getRolesQueryResult.data.length) && (
           <EmptyState
             title="No roles found"
-            body={
-              <>
-                <p className="u-no-margin--bottom">
-                  You haven’t added any roles yet.
-                </p>
-                <a
-                  href="https://ubuntu.com/landscape/docs/administrators"
-                  target="_blank"
-                  rel="nofollow noopener noreferrer"
-                >
-                  How to manage administrators in Landscape
-                </a>
-              </>
-            }
+            body="You haven’t added any roles yet."
+            link={{
+              href: "https://ubuntu.com/landscape/docs/administrators",
+              text: "How to manage administrators in Landscape",
+            }}
             cta={[
               <Button
                 type="button"

--- a/src/tests/server/handlers/_helpers.ts
+++ b/src/tests/server/handlers/_helpers.ts
@@ -141,21 +141,31 @@ export const getDebArchivePaginationParams = (requestUrl: string) => {
   const { searchParams } = new URL(requestUrl);
   const pageSize = parseInt(searchParams.get("pageSize") ?? "20", 10);
   const pageToken = parseInt(searchParams.get("pageToken") ?? "0", 10) || 0;
+  const search =
+    searchParams.get("filter")?.split("=").pop()?.replaceAll(/"|\*/gm, "") ??
+    "";
 
   return {
     pageSize,
     pageToken,
+    search,
   };
 };
 
 export const getDebArchivePaginatedResponse = <
-  T extends Record<string, unknown>,
+  T extends { displayName: string },
 >(
   data: T[],
   pageToken: number,
   pageSize: number,
+  search?: string,
 ) => {
-  const paginatedData = data.slice(pageToken, pageToken + pageSize);
+  const paginatedData = data
+    .filter(({ displayName }) => {
+      if (!search) return true;
+      return displayName.includes(search ?? "");
+    })
+    .slice(pageToken, pageToken + pageSize);
 
   const nextPageToken =
     pageToken + pageSize < data.length

--- a/src/tests/server/handlers/_helpers.ts
+++ b/src/tests/server/handlers/_helpers.ts
@@ -163,7 +163,7 @@ export const getDebArchivePaginatedResponse = <
   const paginatedData = data
     .filter(({ displayName }) => {
       if (!search) return true;
-      return displayName.includes(search ?? "");
+      return displayName.startsWith(search ?? "");
     })
     .slice(pageToken, pageToken + pageSize);
 

--- a/src/tests/server/handlers/localRepository.ts
+++ b/src/tests/server/handlers/localRepository.ts
@@ -33,7 +33,7 @@ export default [
 
     return HttpResponse.json({
       locals: repositories.filter(({ displayName }) =>
-        displayName.includes(search.replaceAll(/"|\*/gm, "")),
+        displayName.startsWith(search.replaceAll(/"|\*/gm, "")),
       ),
     });
   }),

--- a/src/tests/server/handlers/mirrors.ts
+++ b/src/tests/server/handlers/mirrors.ts
@@ -23,11 +23,13 @@ import {
 const mirrors = [...(mockMirrors as Mirror[])];
 
 const getMirrorsResponse = (requestUrl: string) => {
-  const { pageSize, pageToken } = getDebArchivePaginationParams(requestUrl);
+  const { pageSize, pageToken, search } =
+    getDebArchivePaginationParams(requestUrl);
   const { paginatedData, nextPageToken } = getDebArchivePaginatedResponse(
     mirrors,
     pageToken,
     pageSize,
+    search,
   );
 
   return HttpResponse.json({

--- a/src/tests/server/handlers/publicationTargets.ts
+++ b/src/tests/server/handlers/publicationTargets.ts
@@ -13,7 +13,8 @@ import {
 } from "./_helpers";
 
 const getPublicationTargetsResponse = (requestUrl: string) => {
-  const { pageSize, pageToken, search } = getDebArchivePaginationParams(requestUrl);
+  const { pageSize, pageToken, search } =
+    getDebArchivePaginationParams(requestUrl);
   const { paginatedData, nextPageToken } = getDebArchivePaginatedResponse(
     publicationTargets,
     pageToken,

--- a/src/tests/server/handlers/publicationTargets.ts
+++ b/src/tests/server/handlers/publicationTargets.ts
@@ -13,11 +13,12 @@ import {
 } from "./_helpers";
 
 const getPublicationTargetsResponse = (requestUrl: string) => {
-  const { pageSize, pageToken } = getDebArchivePaginationParams(requestUrl);
+  const { pageSize, pageToken, search } = getDebArchivePaginationParams(requestUrl);
   const { paginatedData, nextPageToken } = getDebArchivePaginatedResponse(
     publicationTargets,
     pageToken,
     pageSize,
+    search,
   );
 
   return HttpResponse.json({

--- a/src/tests/server/handlers/publicationTargets.ts
+++ b/src/tests/server/handlers/publicationTargets.ts
@@ -91,7 +91,6 @@ export default [
     },
   ),
 
-  // Fallback GET for integration tests that don't mock useGetPublicationTargets directly
   http.get(`${API_URL_DEB_ARCHIVE}publicationTargets`, ({ request }) => {
     const endpointStatus = getEndpointStatus();
 

--- a/src/tests/server/handlers/publications.ts
+++ b/src/tests/server/handlers/publications.ts
@@ -50,11 +50,10 @@ const parseApiFilter = (filter: string): ((pub: Publication) => boolean) => {
 
   const displayNameMatch = filter.match(/^display_name="([^"]*)\*"$/);
   if (displayNameMatch) {
-    const [, rawPrefix = ""] = displayNameMatch;
-    const prefix = rawPrefix.toLowerCase();
+    const [, prefix = ""] = displayNameMatch;
     return (pub) =>
-      pub.displayName.toLowerCase().startsWith(prefix) ||
-      (pub.label?.toLowerCase().startsWith(prefix) ?? false);
+      pub.displayName.startsWith(prefix) ||
+      (pub.label?.startsWith(prefix) ?? false);
   }
 
   return () => true;


### PR DESCRIPTION
## Summary

- use consistent spacing in the empty states for debarchive pages
- update other usage of EmptyState to use new `link` prop and `cta` prop when appropriate
- turn some buttons into links
- fix the issues with `FallBackComponent` addressing [LNDENG-4487](https://warthogs.atlassian.net/browse/LNDENG-4487)

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)


[LNDENG-4487]: https://warthogs.atlassian.net/browse/LNDENG-4487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ