### PR TITLE
fix: snaps switch channel form error

### DIFF
--- a/.changeset/crisp-cougars-rescue.md
+++ b/.changeset/crisp-cougars-rescue.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Add informational text when there are no channels to switch a snap to

--- a/src/features/snaps/components/AvailableSnapDetails/AvailableSnapDetails.test.tsx
+++ b/src/features/snaps/components/AvailableSnapDetails/AvailableSnapDetails.test.tsx
@@ -6,7 +6,11 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, vi } from "vitest";
 import AvailableSnapDetails from "./AvailableSnapDetails";
 
-const [chosenSnap] = availableSnapInfo;
+const chosenSnap = availableSnapInfo.find(
+  (snap) => snap["channel-map"].length > 0,
+);
+
+assert(chosenSnap);
 
 const props = {
   instanceId: 1,
@@ -38,6 +42,9 @@ describe("AvailableSnap", () => {
         chosenSnap["channel-map"].find(
           (channel) => channel.confinement === "strict",
         ) ?? chosenSnap["channel-map"][0];
+
+      assert(strictConfinement);
+
       const strictOption = options.find((option) =>
         option.textContent?.includes(
           `${strictConfinement.channel.name} - ${strictConfinement.channel.architecture}`,
@@ -56,6 +63,9 @@ describe("AvailableSnap", () => {
         chosenSnap["channel-map"].find(
           (channel) => channel.confinement === "classic",
         ) ?? chosenSnap["channel-map"][0];
+
+      assert(classicConfinement);
+
       const classicOption = options.find((option) =>
         option.textContent?.includes(
           `${classicConfinement.channel.name} - ${classicConfinement.channel.architecture}`,

--- a/src/features/snaps/components/EditSnap/EditSnap.test.tsx
+++ b/src/features/snaps/components/EditSnap/EditSnap.test.tsx
@@ -156,6 +156,11 @@ describe("EditSnap", () => {
       });
 
       const releaseSelect = await screen.findByRole("combobox");
+
+      expect(
+        await screen.findByText("No available channels to switch to."),
+      ).toBeInTheDocument();
+
       expect(releaseSelect).toBeDisabled();
     });
 

--- a/src/features/snaps/components/EditSnap/EditSnap.test.tsx
+++ b/src/features/snaps/components/EditSnap/EditSnap.test.tsx
@@ -164,6 +164,22 @@ describe("EditSnap", () => {
       expect(releaseSelect).toBeDisabled();
     });
 
+    it("shows the release required error when submitting without available channels", async () => {
+      renderEditSnap({
+        ...SwitchSnapFormProps,
+        installedSnaps: [snapData.snapWithNoChannels],
+      });
+
+      const submitButton = await screen.findByRole("button", {
+        name: /switch/i,
+      });
+      await userEvent.click(submitButton);
+
+      expect(
+        await screen.findByText("Release is required"),
+      ).toBeInTheDocument();
+    });
+
     it("switches between release types", async () => {
       renderEditSnap({
         ...SwitchSnapFormProps,

--- a/src/features/snaps/components/EditSnap/EditSnap.test.tsx
+++ b/src/features/snaps/components/EditSnap/EditSnap.test.tsx
@@ -8,6 +8,9 @@ import { EditSnapType } from "../../helpers";
 import EditSnap from "./EditSnap";
 
 const snapData = {
+  snapWithNoChannels:
+    installedSnaps.find((snap) => snap.snap.name === "Snap 1") ??
+    installedSnaps[0],
   snap2:
     installedSnaps.find((snap) => snap.snap.name === "Snap 2") ??
     installedSnaps[0],
@@ -136,19 +139,32 @@ describe("EditSnap", () => {
   });
 
   describe("Switch Edit Snap Form", () => {
-    beforeEach(async () => {
+    it("renders switch-form only fields", async () => {
       renderEditSnap({
         ...SwitchSnapFormProps,
         installedSnaps: [snapData.snap2],
       });
-    });
 
-    it("renders switch-form only fields", async () => {
       const releaseSelect = await screen.findByRole("combobox");
       expect(releaseSelect).toBeInTheDocument();
     });
 
+    it("keeps the release select disabled when the snap has no available channels", async () => {
+      renderEditSnap({
+        ...SwitchSnapFormProps,
+        installedSnaps: [snapData.snapWithNoChannels],
+      });
+
+      const releaseSelect = await screen.findByRole("combobox");
+      expect(releaseSelect).toBeDisabled();
+    });
+
     it("switches between release types", async () => {
+      renderEditSnap({
+        ...SwitchSnapFormProps,
+        installedSnaps: [snapData.snap2],
+      });
+
       const releaseSelect = await screen.findByRole("combobox");
       expect(releaseSelect).toBeInTheDocument();
 
@@ -161,6 +177,11 @@ describe("EditSnap", () => {
     });
 
     it("submits the switch form and shows success notification", async () => {
+      renderEditSnap({
+        ...SwitchSnapFormProps,
+        installedSnaps: [snapData.snap2],
+      });
+
       const releaseSelect = await screen.findByRole("combobox");
       const options = await screen.findAllByRole("option");
       if (options[0]) {

--- a/src/features/snaps/components/EditSnap/EditSnap.tsx
+++ b/src/features/snaps/components/EditSnap/EditSnap.tsx
@@ -162,6 +162,11 @@ const EditSnap: FC<EditSnapProps> = ({ installedSnaps, type }) => {
           labelClassName="p-text--small p-text--small-caps"
           options={SNAP_CHANNEL_OPTIONS}
           disabled={SNAP_CHANNEL_OPTIONS.length === 0}
+          help={
+            SNAP_CHANNEL_OPTIONS.length === 0
+              ? "No available channels to switch to."
+              : undefined
+          }
           {...formik.getFieldProps("release")}
         />
       )}

--- a/src/features/snaps/components/EditSnap/EditSnap.tsx
+++ b/src/features/snaps/components/EditSnap/EditSnap.tsx
@@ -64,6 +64,8 @@ const EditSnap: FC<EditSnapProps> = ({ installedSnaps, type }) => {
   const initialSnap = installedSnap
     ? snapInfoData?.data["channel-map"][0]
     : null;
+  const hasNoAvailableChannels =
+    !!snapInfoData?.data && snapInfoData.data["channel-map"].length === 0;
 
   const formik = useFormik<SnapFormProps>({
     initialValues: {
@@ -163,7 +165,7 @@ const EditSnap: FC<EditSnapProps> = ({ installedSnaps, type }) => {
           options={SNAP_CHANNEL_OPTIONS}
           disabled={SNAP_CHANNEL_OPTIONS.length === 0}
           help={
-            SNAP_CHANNEL_OPTIONS.length === 0
+            hasNoAvailableChannels
               ? "No available channels to switch to."
               : undefined
           }

--- a/src/features/snaps/components/EditSnap/EditSnap.tsx
+++ b/src/features/snaps/components/EditSnap/EditSnap.tsx
@@ -164,6 +164,7 @@ const EditSnap: FC<EditSnapProps> = ({ installedSnaps, type }) => {
           labelClassName="p-text--small p-text--small-caps"
           options={SNAP_CHANNEL_OPTIONS}
           disabled={SNAP_CHANNEL_OPTIONS.length === 0}
+          error={getFormikError(formik, "release")}
           help={
             hasNoAvailableChannels
               ? "No available channels to switch to."

--- a/src/tests/mocks/snap.ts
+++ b/src/tests/mocks/snap.ts
@@ -181,7 +181,7 @@ export const availableSnapInfo = [
     "channel-map": [],
     "default-track": "latest",
     snap: {
-      id: "1",
+      id: "2",
       name: "canonical",
       publisher: {
         username: "canonical",
@@ -263,7 +263,7 @@ export const availableSnapInfo = [
     ],
     "default-track": "latest",
     snap: {
-      id: "2",
+      id: "3",
       name: "canonical",
       publisher: {
         username: "canonical",
@@ -304,7 +304,7 @@ export const availableSnapInfo = [
     ],
     "default-track": "latest",
     snap: {
-      id: "3",
+      id: "4",
       name: "canonical",
       publisher: {
         username: "canonical",

--- a/src/tests/mocks/snap.ts
+++ b/src/tests/mocks/snap.ts
@@ -181,7 +181,7 @@ export const availableSnapInfo = [
     "channel-map": [],
     "default-track": "latest",
     snap: {
-      id: "2",
+      id: "1",
       name: "canonical",
       publisher: {
         username: "canonical",
@@ -222,7 +222,7 @@ export const availableSnapInfo = [
     ],
     "default-track": "latest",
     snap: {
-      id: "1",
+      id: "2",
       name: "canonical",
       publisher: {
         username: "canonical",

--- a/src/tests/mocks/snap.ts
+++ b/src/tests/mocks/snap.ts
@@ -176,8 +176,24 @@ export const installedSnaps = [
 
 export const availableSnapInfo = [
   {
-    name: "Snap 2",
+    name: "Snap 1",
     "snap-id": "1",
+    "channel-map": [],
+    "default-track": "latest",
+    snap: {
+      id: "1",
+      name: "canonical",
+      publisher: {
+        username: "canonical",
+        validation: "verified",
+        "display-name": "Canonical",
+        id: "1",
+      },
+    },
+  },
+  {
+    name: "Snap 2",
+    "snap-id": "2",
     "channel-map": [
       {
         channel: {
@@ -218,7 +234,7 @@ export const availableSnapInfo = [
   },
   {
     name: "Snap 3",
-    "snap-id": "2",
+    "snap-id": "3",
     "channel-map": [
       {
         channel: {
@@ -259,7 +275,7 @@ export const availableSnapInfo = [
   },
   {
     name: "Snap 4",
-    "snap-id": "3",
+    "snap-id": "4",
     "channel-map": [
       {
         channel: {


### PR DESCRIPTION
## Summary

Added informational text when there is no channel to switch a snap to. Changed mock data to match returned data from the backend.

[Related Jira ticket](https://warthogs.atlassian.net/browse/LNDENG-4470)

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
