### PR TITLE
Publication settings design update

### DIFF
--- a/.changeset/red-rice-heal.md
+++ b/.changeset/red-rice-heal.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Make publication automatic installs and upgrades settings less confusing

--- a/src/features/local-repositories/components/PublishLocalRepositorySidePanel/components/PublishRepositoryExistingForm/PublishRepositoryExistingForm.test.tsx
+++ b/src/features/local-repositories/components/PublishLocalRepositorySidePanel/components/PublishRepositoryExistingForm/PublishRepositoryExistingForm.test.tsx
@@ -78,7 +78,7 @@ describe("PublishRepositoryExistingForm", () => {
     expect(screen.getByText("Contents")).toBeInTheDocument();
   });
 
-  it("renders settings checkboxes", () => {
+  it("renders settings block", () => {
     renderWithProviders(
       <PublishRepositoryExistingForm
         repository={repositories[0]}
@@ -86,10 +86,8 @@ describe("PublishRepositoryExistingForm", () => {
       />,
     );
 
+    expect(screen.getByText("Installs and upgrades")).toBeInTheDocument();
     expect(screen.getByLabelText(/hash based indexing/i)).toBeInTheDocument();
-    expect(
-      screen.getByLabelText(/automatic installation/i),
-    ).toBeInTheDocument();
   });
 
   it("renders publish button", () => {

--- a/src/features/local-repositories/components/PublishLocalRepositorySidePanel/components/PublishRepositoryNewForm/PublishRepositoryNewForm.test.tsx
+++ b/src/features/local-repositories/components/PublishLocalRepositorySidePanel/components/PublishRepositoryNewForm/PublishRepositoryNewForm.test.tsx
@@ -1,11 +1,54 @@
 import { renderWithProviders } from "@/tests/render";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import PublishRepositoryNewForm from "./PublishRepositoryNewForm";
 import { repositories } from "@/tests/mocks/localRepositories";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+const mockCreatePublication = vi.fn();
+vi.mock("@/features/publications", async () => {
+  const actual = await vi.importActual("@/features/publications");
+  return {
+    ...actual,
+    useCreatePublication: () => ({
+      createPublication: mockCreatePublication,
+      isCreatingPublication: false,
+    }),
+  };
+});
+
+const fillFormAndSubmit = async (
+  installsAndUpgrades = "Automatic installs and upgrades",
+) => {
+  const user = userEvent.setup();
+
+  const nameInput = screen.getByLabelText(/^publication name$/i);
+  await user.type(nameInput, "Test Publication");
+
+  const targetSelect = screen.getByLabelText(/^publication target$/i);
+  expect(await screen.findByText("prod-s3-us-east")).toBeInTheDocument();
+  await user.selectOptions(
+    targetSelect,
+    "publicationTargets/aaaaaaaa-0000-0000-0000-000000000001",
+  );
+
+  await user.click(
+    screen.getByRole("button", { name: /installs and upgrades/i }),
+  );
+  await user.click(
+    await screen.findByRole("option", {
+      name: new RegExp(installsAndUpgrades, "i"),
+    }),
+  );
+
+  await user.click(screen.getByRole("button", { name: /publish/i }));
+};
+
 describe("PublishRepositoryNewForm", () => {
+  beforeEach(() => {
+    mockCreatePublication.mockReset();
+  });
+
   it("renders form with required fields", () => {
     renderWithProviders(
       <PublishRepositoryNewForm repository={repositories[0]} />,
@@ -71,31 +114,53 @@ describe("PublishRepositoryNewForm", () => {
   });
 
   it("submits form with valid data", async () => {
-    const user = userEvent.setup();
     renderWithProviders(
       <PublishRepositoryNewForm repository={repositories[0]} />,
     );
 
-    const nameInput = screen.getByLabelText(/^publication name$/i);
-    await user.type(nameInput, "Test Publication");
+    await fillFormAndSubmit();
 
-    const targetSelect = screen.getByLabelText(/^publication target$/i);
-    expect(await screen.findByText("prod-s3-us-east")).toBeInTheDocument();
-    await user.selectOptions(
-      targetSelect,
-      "publicationTargets/aaaaaaaa-0000-0000-0000-000000000001",
+    expect(mockCreatePublication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          notAutomatic: false,
+          butAutomaticUpgrades: false,
+        }),
+      }),
     );
-
-    const submitButton = screen.getByRole("button", { name: /publish/i });
-    await user.click(submitButton);
   });
 
-  it("renders help text for settings", () => {
+  it("submits manual installs and upgrades values", async () => {
     renderWithProviders(
       <PublishRepositoryNewForm repository={repositories[0]} />,
     );
 
-    const helpTexts = screen.getAllByText("Help");
-    expect(helpTexts.length).toBeGreaterThan(0);
+    await fillFormAndSubmit("Manual installs and upgrades");
+
+    expect(mockCreatePublication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          notAutomatic: true,
+          butAutomaticUpgrades: false,
+        }),
+      }),
+    );
+  });
+
+  it("submits automatic upgrades only values", async () => {
+    renderWithProviders(
+      <PublishRepositoryNewForm repository={repositories[0]} />,
+    );
+
+    await fillFormAndSubmit("Automatic upgrades only");
+
+    expect(mockCreatePublication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          notAutomatic: true,
+          butAutomaticUpgrades: true,
+        }),
+      }),
+    );
   });
 });

--- a/src/features/local-repositories/components/PublishLocalRepositorySidePanel/components/PublishRepositoryNewForm/PublishRepositoryNewForm.test.tsx
+++ b/src/features/local-repositories/components/PublishLocalRepositorySidePanel/components/PublishRepositoryNewForm/PublishRepositoryNewForm.test.tsx
@@ -16,15 +16,13 @@ describe("PublishRepositoryNewForm", () => {
     expect(screen.getByLabelText(/signing gpg key/i)).toBeInTheDocument();
   });
 
-  it("renders checkbox settings", () => {
+  it("renders settings block", () => {
     renderWithProviders(
       <PublishRepositoryNewForm repository={repositories[0]} />,
     );
 
+    expect(screen.getByText("Installs and upgrades")).toBeInTheDocument();
     expect(screen.getByLabelText(/hash based indexing/i)).toBeInTheDocument();
-    expect(
-      screen.getByLabelText(/limit automatic installation/i),
-    ).toBeInTheDocument();
     expect(screen.getByLabelText(/skip bz2/i)).toBeInTheDocument();
     expect(
       screen.getByLabelText(/skip generating content indexes/i),

--- a/src/features/local-repositories/components/PublishLocalRepositorySidePanel/components/PublishRepositoryNewForm/PublishRepositoryNewForm.tsx
+++ b/src/features/local-repositories/components/PublishLocalRepositorySidePanel/components/PublishRepositoryNewForm/PublishRepositoryNewForm.tsx
@@ -11,6 +11,8 @@ import type { SelectOption } from "@/types/SelectOption";
 import { useGetPublicationTargets } from "@/features/publication-targets";
 import type { Local } from "@canonical/landscape-openapi";
 import {
+  getInitialValues,
+  getInstallsAndUpgradesValues,
   PublicationSettingsBlock,
   useCreatePublication,
   usePublishPublication,
@@ -36,14 +38,19 @@ const PublishRepositoryNewForm: FC<PublishRepositoryNewFormProps> = ({
     usePublishPublication();
 
   const handleSubmit = async (values: PublishNewFormValues) => {
+    const {
+      notAutomatic,
+      butAutomaticUpgrades
+    } = getInstallsAndUpgradesValues(values.installsAndUpgrades);
+
     const valuesforCreation = {
       displayName: values.name,
       publicationTarget: values.publicationTarget,
       source: repository.name ?? "",
       distribution: repository.defaultDistribution,
       acquireByHash: values.hashIndexing,
-      butAutomaticUpgrades: values.automaticUpgrades,
-      notAutomatic: values.limitAutomaticInstallation,
+      butAutomaticUpgrades,
+      notAutomatic,
       skipBz2: values.skipBz2,
       skipContents: values.skipContentIndexing,
       ...(values.signingKey && { gpgKey: { armor: values.signingKey } }),
@@ -81,19 +88,8 @@ const PublishRepositoryNewForm: FC<PublishRepositoryNewFormProps> = ({
     [publicationTargets],
   );
 
-  const initialValues: PublishNewFormValues = {
-    name: "",
-    publicationTarget: publicationTargetOptions[0]?.value || "",
-    signingKey: "",
-    hashIndexing: false,
-    automaticUpgrades: false,
-    limitAutomaticInstallation: false,
-    skipBz2: false,
-    skipContentIndexing: false,
-  };
-
   const formik = useFormik({
-    initialValues: initialValues,
+    initialValues: getInitialValues(publicationTargetOptions[0]?.value),
     onSubmit: handleSubmit,
     validationSchema: VALIDATION_SCHEMA_NEW,
     validateOnMount: true,

--- a/src/features/local-repositories/components/PublishLocalRepositorySidePanel/components/PublishRepositoryNewForm/PublishRepositoryNewForm.tsx
+++ b/src/features/local-repositories/components/PublishLocalRepositorySidePanel/components/PublishRepositoryNewForm/PublishRepositoryNewForm.tsx
@@ -38,10 +38,9 @@ const PublishRepositoryNewForm: FC<PublishRepositoryNewFormProps> = ({
     usePublishPublication();
 
   const handleSubmit = async (values: PublishNewFormValues) => {
-    const {
-      notAutomatic,
-      butAutomaticUpgrades
-    } = getInstallsAndUpgradesValues(values.installsAndUpgrades);
+    const { notAutomatic, butAutomaticUpgrades } = getInstallsAndUpgradesValues(
+      values.installsAndUpgrades,
+    );
 
     const valuesforCreation = {
       displayName: values.name,

--- a/src/features/mirrors/components/PublishMirrorForm/components/PublishMirrorNewForm/PublishMirrorNewForm.tsx
+++ b/src/features/mirrors/components/PublishMirrorForm/components/PublishMirrorNewForm/PublishMirrorNewForm.tsx
@@ -8,6 +8,8 @@ import { useFormik } from "formik";
 import type { FC } from "react";
 import useNotify from "@/hooks/useNotify";
 import {
+  getInitialValues,
+  getInstallsAndUpgradesValues,
   PublicationSettingsBlock,
   useCreatePublication,
   usePublishPublication,
@@ -17,6 +19,7 @@ import PublishMirrorContentsBlock from "../PublishMirrorContentsBlock";
 import type { Mirror, PublicationTarget } from "@canonical/landscape-openapi";
 import type { SelectOption } from "@/types/SelectOption";
 import ReadOnlyField from "@/components/form/ReadOnlyField";
+import type { PublishNewFormValues } from "@/features/publications";
 
 interface PublishMirrorNewFormProps {
   readonly mirror: Mirror;
@@ -36,18 +39,14 @@ const PublishMirrorNewForm: FC<PublishMirrorNewFormProps> = ({
     usePublishPublication();
 
   const formik = useFormik({
-    initialValues: {
-      name: "",
-      publicationTarget: publicationTargets[0]?.name ?? "",
-      signingKey: "",
-      hashIndexing: false,
-      limitAutomaticInstallation: false,
-      automaticUpgrades: false,
-      skipBz2: false,
-      skipContentIndexing: false,
-    },
+    initialValues: getInitialValues(publicationTargets[0]?.name),
 
-    onSubmit: async (values) => {
+    onSubmit: async (values: PublishNewFormValues) => {
+      const {
+        notAutomatic,
+        butAutomaticUpgrades
+      } = getInstallsAndUpgradesValues(values.installsAndUpgrades);
+
       try {
         const { data: publication } = await createPublication({
           body: {
@@ -56,8 +55,8 @@ const PublishMirrorNewForm: FC<PublishMirrorNewFormProps> = ({
             source: mirror.name ?? "",
             distribution: mirror.distribution,
             acquireByHash: values.hashIndexing,
-            notAutomatic: values.limitAutomaticInstallation,
-            butAutomaticUpgrades: values.automaticUpgrades,
+            notAutomatic,
+            butAutomaticUpgrades,
             skipBz2: values.skipBz2,
             skipContents: values.skipContentIndexing,
             gpgKey: values.signingKey

--- a/src/features/mirrors/components/PublishMirrorForm/components/PublishMirrorNewForm/PublishMirrorNewForm.tsx
+++ b/src/features/mirrors/components/PublishMirrorForm/components/PublishMirrorNewForm/PublishMirrorNewForm.tsx
@@ -42,10 +42,8 @@ const PublishMirrorNewForm: FC<PublishMirrorNewFormProps> = ({
     initialValues: getInitialValues(publicationTargets[0]?.name),
 
     onSubmit: async (values: PublishNewFormValues) => {
-      const {
-        notAutomatic,
-        butAutomaticUpgrades
-      } = getInstallsAndUpgradesValues(values.installsAndUpgrades);
+      const { notAutomatic, butAutomaticUpgrades } =
+        getInstallsAndUpgradesValues(values.installsAndUpgrades);
 
       try {
         const { data: publication } = await createPublication({

--- a/src/features/publications/components/AddPublicationForm/AddPublicationForm.test.tsx
+++ b/src/features/publications/components/AddPublicationForm/AddPublicationForm.test.tsx
@@ -88,10 +88,7 @@ describe("AddPublicationForm", () => {
       publicationTargetSelect,
       "aaaaaaaa-0000-0000-0000-000000000001",
     );
-    await user.selectOptions(
-      automaticSelect,
-      "manual",
-    );
+    await user.selectOptions(automaticSelect, "manual");
     await user.click(
       screen.getByRole("checkbox", { name: /Hash based indexing/i }),
     );
@@ -111,9 +108,7 @@ describe("AddPublicationForm", () => {
       "aaaaaaaa-0000-0000-0000-000000000001",
     );
 
-    expect(automaticSelect).toHaveValue(
-      "manual",
-    );
+    expect(automaticSelect).toHaveValue("manual");
 
     expect(
       screen.getByText("main, restricted, universe, multiverse"),

--- a/src/features/publications/components/AddPublicationForm/AddPublicationForm.test.tsx
+++ b/src/features/publications/components/AddPublicationForm/AddPublicationForm.test.tsx
@@ -76,6 +76,9 @@ describe("AddPublicationForm", () => {
     const publicationTargetSelect = screen.getByRole("combobox", {
       name: "Publication target",
     });
+    const automaticSelect = screen.getByRole("combobox", {
+      name: "Installs and upgrades",
+    });
 
     await waitFor(() => {
       expect(publicationTargetSelect).toBeEnabled();
@@ -85,14 +88,12 @@ describe("AddPublicationForm", () => {
       publicationTargetSelect,
       "aaaaaaaa-0000-0000-0000-000000000001",
     );
+    await user.selectOptions(
+      automaticSelect,
+      "manual",
+    );
     await user.click(
       screen.getByRole("checkbox", { name: /Hash based indexing/i }),
-    );
-    await user.click(
-      screen.getByRole("checkbox", { name: /Limit automatic installation/i }),
-    );
-    await user.click(
-      screen.getByRole("checkbox", { name: /Automatic upgrades/i }),
     );
     await user.click(screen.getByRole("checkbox", { name: /Skip bz2/i }));
     await user.click(
@@ -108,6 +109,10 @@ describe("AddPublicationForm", () => {
 
     expect(publicationTargetSelect).toHaveValue(
       "aaaaaaaa-0000-0000-0000-000000000001",
+    );
+
+    expect(automaticSelect).toHaveValue(
+      "manual",
     );
 
     expect(

--- a/src/features/publications/components/AddPublicationForm/AddPublicationForm.test.tsx
+++ b/src/features/publications/components/AddPublicationForm/AddPublicationForm.test.tsx
@@ -76,9 +76,9 @@ describe("AddPublicationForm", () => {
     const publicationTargetSelect = screen.getByRole("combobox", {
       name: "Publication target",
     });
-    const automaticSelect = screen.getByRole("combobox", {
-      name: "Installs and upgrades",
-    });
+    expect(
+      screen.getByRole("button", { name: "Installs and upgrades" }),
+    ).toBeInTheDocument();
 
     await waitFor(() => {
       expect(publicationTargetSelect).toBeEnabled();
@@ -88,7 +88,7 @@ describe("AddPublicationForm", () => {
       publicationTargetSelect,
       "aaaaaaaa-0000-0000-0000-000000000001",
     );
-    await user.selectOptions(automaticSelect, "manual");
+
     await user.click(
       screen.getByRole("checkbox", { name: /Hash based indexing/i }),
     );
@@ -107,8 +107,6 @@ describe("AddPublicationForm", () => {
     expect(publicationTargetSelect).toHaveValue(
       "aaaaaaaa-0000-0000-0000-000000000001",
     );
-
-    expect(automaticSelect).toHaveValue("manual");
 
     expect(
       screen.getByText("main, restricted, universe, multiverse"),

--- a/src/features/publications/components/AddPublicationForm/AddPublicationForm.tsx
+++ b/src/features/publications/components/AddPublicationForm/AddPublicationForm.tsx
@@ -22,7 +22,6 @@ import type { FC } from "react";
 import { useMemo } from "react";
 import { useCreatePublication } from "../../api";
 import {
-  INITIAL_VALUES,
   SOURCE_TYPE_LOCAL_REPOSITORY,
   SOURCE_TYPE_MIRROR,
   SOURCE_TYPE_OPTIONS,
@@ -31,6 +30,7 @@ import {
 import { getPublicationPayload, stripResourcePrefix } from "./helpers";
 import type { FormProps, SelectableSource } from "./types";
 import PublicationSettingsBlock from "../../components/PublicationSettingsBlock";
+import { getInitialValues } from "../../helpers";
 
 const AddPublicationForm: FC = () => {
   const debug = useDebug();
@@ -44,7 +44,13 @@ const AddPublicationForm: FC = () => {
   const { createPublication, isCreatingPublication } = useCreatePublication();
 
   const formik = useFormik<FormProps>({
-    initialValues: INITIAL_VALUES,
+    initialValues: {
+      ...getInitialValues(),
+      sourceType: "",
+      source: "",
+      distribution: "",
+      architectures: [],
+    },
     validationSchema: VALIDATION_SCHEMA,
     onSubmit: async (values) => {
       try {

--- a/src/features/publications/components/AddPublicationForm/constants.ts
+++ b/src/features/publications/components/AddPublicationForm/constants.ts
@@ -1,7 +1,6 @@
 import type { SelectOption } from "@/types/SelectOption";
-import type { FormProps } from "./types";
 import * as Yup from "yup";
-import { REQUIRED_FIELD_MESSAGE } from "../../constants";
+import { REQUIRED_FIELD_MESSAGE, VALIDATION_SCHEMA_NEW } from "../../constants";
 
 export const SOURCE_TYPE_MIRROR = "Mirror";
 export const SOURCE_TYPE_LOCAL_REPOSITORY = "Local repository";
@@ -15,26 +14,9 @@ export const SOURCE_TYPE_OPTIONS: SelectOption[] = [
   },
 ];
 
-export const INITIAL_VALUES: FormProps = {
-  name: "",
-  sourceType: "",
-  source: "",
-  publicationTarget: "",
-  distribution: "",
-  architectures: [],
-  signingKey: "",
-  hashIndexing: false,
-  limitAutomaticInstallation: false,
-  automaticUpgrades: false,
-  skipBz2: false,
-  skipContentIndexing: false,
-};
-
-export const VALIDATION_SCHEMA = Yup.object().shape({
-  name: Yup.string().required(REQUIRED_FIELD_MESSAGE),
+export const VALIDATION_SCHEMA = VALIDATION_SCHEMA_NEW.shape({
   sourceType: Yup.string().required(REQUIRED_FIELD_MESSAGE),
   source: Yup.string().required(REQUIRED_FIELD_MESSAGE),
-  publicationTarget: Yup.string().required(REQUIRED_FIELD_MESSAGE),
   distribution: Yup.string().required(REQUIRED_FIELD_MESSAGE),
   architectures: Yup.array()
     .of(Yup.string())
@@ -43,10 +25,4 @@ export const VALIDATION_SCHEMA = Yup.object().shape({
       then: (schema) => schema,
       otherwise: (schema) => schema.min(1, REQUIRED_FIELD_MESSAGE),
     }),
-  signingKey: Yup.string(),
-  hashIndexing: Yup.boolean(),
-  limitAutomaticInstallation: Yup.boolean(),
-  automaticUpgrades: Yup.boolean(),
-  skipBz2: Yup.boolean(),
-  skipContentIndexing: Yup.boolean(),
 });

--- a/src/features/publications/components/AddPublicationForm/helpers.ts
+++ b/src/features/publications/components/AddPublicationForm/helpers.ts
@@ -1,6 +1,7 @@
 import type { FormProps } from "./types";
 import type { PublicationWritable } from "@canonical/landscape-openapi";
 import { SOURCE_TYPE_LOCAL_REPOSITORY } from "./constants";
+import { getInstallsAndUpgradesValues } from "../../helpers";
 
 export interface CreatePublicationPayload {
   publicationId?: string;
@@ -33,6 +34,10 @@ export const getPublicationPayload = (values: FormProps) => {
     values.sourceType === SOURCE_TYPE_LOCAL_REPOSITORY
       ? []
       : values.architectures;
+  const {
+    notAutomatic,
+    butAutomaticUpgrades
+  } = getInstallsAndUpgradesValues(values.installsAndUpgrades);
 
   return {
     publicationId,
@@ -46,8 +51,8 @@ export const getPublicationPayload = (values: FormProps) => {
       distribution: values.distribution.trim() || undefined,
       architectures: architectures.length > 0 ? architectures : undefined,
       acquireByHash: values.hashIndexing,
-      notAutomatic: values.limitAutomaticInstallation,
-      butAutomaticUpgrades: values.automaticUpgrades,
+      notAutomatic,
+      butAutomaticUpgrades,
       skipBz2: values.skipBz2,
       skipContents: values.skipContentIndexing,
       gpgKey: values.signingKey.trim()

--- a/src/features/publications/components/AddPublicationForm/helpers.ts
+++ b/src/features/publications/components/AddPublicationForm/helpers.ts
@@ -34,10 +34,9 @@ export const getPublicationPayload = (values: FormProps) => {
     values.sourceType === SOURCE_TYPE_LOCAL_REPOSITORY
       ? []
       : values.architectures;
-  const {
-    notAutomatic,
-    butAutomaticUpgrades
-  } = getInstallsAndUpgradesValues(values.installsAndUpgrades);
+  const { notAutomatic, butAutomaticUpgrades } = getInstallsAndUpgradesValues(
+    values.installsAndUpgrades,
+  );
 
   return {
     publicationId,

--- a/src/features/publications/components/PublicationDetails/PublicationDetails.test.tsx
+++ b/src/features/publications/components/PublicationDetails/PublicationDetails.test.tsx
@@ -48,7 +48,7 @@ describe("PublicationDetails", () => {
       { label: "Hash indexing", value: "Yes" },
       {
         label: "Installs and upgrades",
-        value: AUTOMATIC_LABELS.both,
+        value: AUTOMATIC_LABELS.automatic,
       },
       { label: "Skip bz2", value: "No" },
       { label: "Skip content indexing", value: "No" },
@@ -85,7 +85,7 @@ describe("PublicationDetails", () => {
 
     expect(container).toHaveInfoItem(
       "Installs and upgrades",
-      AUTOMATIC_LABELS.upgrades,
+      AUTOMATIC_LABELS.autoUpgrades,
     );
   });
 
@@ -100,7 +100,7 @@ describe("PublicationDetails", () => {
 
     expect(container).toHaveInfoItem(
       "Installs and upgrades",
-      AUTOMATIC_LABELS.neither,
+      AUTOMATIC_LABELS.manual,
     );
   });
 

--- a/src/features/publications/components/PublicationDetails/PublicationDetails.test.tsx
+++ b/src/features/publications/components/PublicationDetails/PublicationDetails.test.tsx
@@ -9,6 +9,7 @@ import { mirrors } from "@/tests/mocks/mirrors";
 import { getSourceType } from "../..";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import moment from "moment";
+import { AUTOMATIC_LABELS } from "../../constants";
 
 describe("PublicationDetails", () => {
   const user = userEvent.setup();
@@ -45,7 +46,10 @@ describe("PublicationDetails", () => {
         value: publication.architectures.join(", "),
       },
       { label: "Hash indexing", value: "Yes" },
-      { label: "Installs and upgrades", value: "Both automatic" },
+      {
+        label: "Installs and upgrades",
+        value: AUTOMATIC_LABELS.both,
+      },
       { label: "Skip bz2", value: "No" },
       { label: "Skip content indexing", value: "No" },
     ];
@@ -81,7 +85,7 @@ describe("PublicationDetails", () => {
 
     expect(container).toHaveInfoItem(
       "Installs and upgrades",
-      "Automatic upgrades only",
+      AUTOMATIC_LABELS.upgrades,
     );
   });
 
@@ -94,7 +98,10 @@ describe("PublicationDetails", () => {
       />,
     );
 
-    expect(container).toHaveInfoItem("Installs and upgrades", "Both manual");
+    expect(container).toHaveInfoItem(
+      "Installs and upgrades",
+      AUTOMATIC_LABELS.neither,
+    );
   });
 
   it("opens republish modal", async () => {

--- a/src/features/publications/components/PublicationDetails/PublicationDetails.tsx
+++ b/src/features/publications/components/PublicationDetails/PublicationDetails.tsx
@@ -6,7 +6,7 @@ import { Button, Icon, ICONS } from "@canonical/react-components";
 import { useBoolean } from "usehooks-ts";
 import RemovePublicationModal from "../RemovePublicationModal";
 import RepublishPublicationModal from "../RepublishPublicationModal";
-import { getInstallsAndUpgradesValue, getSourceType } from "../../helpers";
+import { getInstallsAndUpgradesText, getSourceType } from "../../helpers";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import moment from "moment";
 import { NO_DATA_TEXT } from "@/components/layout/NoData/constants";
@@ -126,7 +126,7 @@ const PublicationDetails = ({
           <InfoGrid dense>
             <InfoGrid.Item
               label="Installs and upgrades"
-              value={getInstallsAndUpgradesValue(publication)}
+              value={getInstallsAndUpgradesText(publication)}
             />
 
             <InfoGrid.Item

--- a/src/features/publications/components/PublicationDetails/PublicationDetails.tsx
+++ b/src/features/publications/components/PublicationDetails/PublicationDetails.tsx
@@ -6,7 +6,7 @@ import { Button, Icon, ICONS } from "@canonical/react-components";
 import { useBoolean } from "usehooks-ts";
 import RemovePublicationModal from "../RemovePublicationModal";
 import RepublishPublicationModal from "../RepublishPublicationModal";
-import { getSourceType } from "../../helpers";
+import { getInstallsAndUpgradesValue, getSourceType } from "../../helpers";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import moment from "moment";
 import { NO_DATA_TEXT } from "@/components/layout/NoData/constants";
@@ -33,18 +33,6 @@ const PublicationDetails = ({
     setTrue: openRepublishModal,
     setFalse: closeRepublishModal,
   } = useBoolean();
-
-  const getLimitAutoInstallValue = () => {
-    if (!publication.notAutomatic) {
-      return "Both automatic";
-    }
-
-    if (publication.butAutomaticUpgrades) {
-      return "Automatic upgrades only";
-    }
-
-    return "Both manual";
-  };
 
   return (
     <>
@@ -137,13 +125,13 @@ const PublicationDetails = ({
         <Blocks.Item title="Settings">
           <InfoGrid dense>
             <InfoGrid.Item
-              label="Hash indexing"
-              value={boolToLabel(Boolean(publication.acquireByHash))}
+              label="Installs and upgrades"
+              value={getInstallsAndUpgradesValue(publication)}
             />
 
             <InfoGrid.Item
-              label="Installs and upgrades"
-              value={getLimitAutoInstallValue()}
+              label="Hash indexing"
+              value={boolToLabel(Boolean(publication.acquireByHash))}
             />
 
             <InfoGrid.Item

--- a/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.module.scss
+++ b/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.module.scss
@@ -1,8 +1,0 @@
-@import "vanilla-framework/scss/settings_spacing";
-@import "vanilla-framework/scss/settings_colors";
-
-.subCheckbox {
-  border-left: 1px solid $colors--theme--border-default;
-  margin-left: $sph--small;
-  padding-left: $sph--large;
-}

--- a/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.test.tsx
+++ b/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.test.tsx
@@ -5,44 +5,40 @@ import { describe, expect, it } from "vitest";
 import { PublicationSettingsBlock } from "../..";
 import { createFormik } from "@/tests/formik";
 import type { Publication } from "@canonical/landscape-openapi";
+import { AUTOMATIC_LABELS } from "../../constants";
 
 const createPublicationSettingsFormik = (
+  limitAutomaticInstallation = false,
   automaticUpgrades = false,
-  limitAutomaticInstallation = true,
 ) =>
   createFormik({
-    hashIndexing: false,
     limitAutomaticInstallation,
     automaticUpgrades,
+    hashIndexing: false,
     skipBz2: false,
     skipContentIndexing: false,
   });
 
-const publication = {
-  acquireByHash: true,
-  notAutomatic: true,
-  butAutomaticUpgrades: true,
-  skipBz2: true,
-  skipContents: true,
-} as unknown as Publication;
+const getPublication = (values: boolean) =>
+  ({
+    acquireByHash: values,
+    notAutomatic: values,
+    butAutomaticUpgrades: values,
+    skipBz2: values,
+    skipContents: values,
+  }) as unknown as Publication;
 
 describe("PublicationSettingsBlock", () => {
   it("renders disabled checkbox settings if no formik", () => {
     renderWithProviders(
-      <PublicationSettingsBlock
-        publication={{ ...publication, notAutomatic: false }}
-      />,
+      <PublicationSettingsBlock publication={getPublication(false)} />,
     );
 
+    expect(screen.getByText("Installs and upgrades")).toBeInTheDocument();
+    expect(screen.getByText(AUTOMATIC_LABELS.both)).toBeInTheDocument();
     expect(
       screen.getByRole("checkbox", { name: /hash based indexing/i }),
     ).toBeDisabled();
-    expect(
-      screen.getByRole("checkbox", { name: /limit automatic installation/i }),
-    ).toBeDisabled();
-    expect(
-      screen.queryByRole("checkbox", { name: /automatic upgrades/i }),
-    ).not.toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: /skip bz2/i })).toBeDisabled();
     expect(
       screen.getByRole("checkbox", {
@@ -52,61 +48,74 @@ describe("PublicationSettingsBlock", () => {
   });
 
   it("renders existing publication settings if publication is provided", () => {
-    renderWithProviders(<PublicationSettingsBlock publication={publication} />);
+    renderWithProviders(
+      <PublicationSettingsBlock publication={getPublication(true)} />,
+    );
+
+    expect(screen.getByText(AUTOMATIC_LABELS.upgrades)).toBeInTheDocument();
 
     const checkboxes = screen.getAllByRole("checkbox");
-    expect(checkboxes).toHaveLength(5);
+    expect(checkboxes).toHaveLength(3);
 
     for (const checkbox of checkboxes) {
       expect(checkbox).toBeChecked();
     }
   });
 
-  it("shows automatic upgrades if limit automatic installation is checked", async () => {
-    const formik = createPublicationSettingsFormik();
-
-    renderWithProviders(<PublicationSettingsBlock formik={formik} />);
-
-    expect(
-      screen.getByRole("checkbox", { name: /limit automatic installation/i }),
-    ).toBeChecked();
-    expect(
-      screen.getByRole("checkbox", { name: /automatic upgrades/i }),
-    ).toBeInTheDocument();
-  });
-
-  it("resets automatic upgrades when limit automatic installation is unchecked", async () => {
-    const formik = createPublicationSettingsFormik(true);
-    const user = userEvent.setup();
-
-    renderWithProviders(<PublicationSettingsBlock formik={formik} />);
-
-    const autoInstallCheckbox = screen.getByRole("checkbox", {
-      name: /limit automatic installation/i,
-    });
-
-    await user.click(autoInstallCheckbox);
-
-    expect(formik.setFieldValue).toHaveBeenCalledWith(
-      "automaticUpgrades",
-      false,
+  it("preselects manual value from publication", () => {
+    renderWithProviders(
+      <PublicationSettingsBlock
+        publication={{
+          ...getPublication(true),
+          butAutomaticUpgrades: false,
+        }}
+      />,
     );
-    expect(formik.values.automaticUpgrades).toBe(false);
+
+    expect(screen.getByText(AUTOMATIC_LABELS.neither)).toBeInTheDocument();
   });
 
-  it("does not reset automatic upgrades when limit automatic installation is checked", async () => {
-    const formik = createPublicationSettingsFormik(true, false);
+  it("preselects manual when installs are limited and upgrades disabled", () => {
+    const formik = createPublicationSettingsFormik(true);
+
+    renderWithProviders(<PublicationSettingsBlock formik={formik} />);
+
+    expect(
+      screen.getByRole("combobox", { name: /installs and upgrades/i }),
+    ).toHaveValue("manual");
+  });
+
+  it("preselects autoUpgrades when installs are limited and upgrades enabled", () => {
+    const formik = createPublicationSettingsFormik(true, true);
+
+    renderWithProviders(<PublicationSettingsBlock formik={formik} />);
+
+    expect(
+      screen.getByRole("combobox", { name: /installs and upgrades/i }),
+    ).toHaveValue("autoUpgrades");
+  });
+
+  it("selects each option in the dropdown", async () => {
+    const formik = createPublicationSettingsFormik();
     const user = userEvent.setup();
 
     renderWithProviders(<PublicationSettingsBlock formik={formik} />);
 
-    const autoInstallCheckbox = screen.getByRole("checkbox", {
-      name: /limit automatic installation/i,
+    const dropdownInput = screen.getByRole("combobox", {
+      name: /installs and upgrades/i,
     });
+    expect(dropdownInput).toHaveValue("automatic");
 
-    await user.click(autoInstallCheckbox);
+    await user.selectOptions(dropdownInput, AUTOMATIC_LABELS.neither);
+    expect(formik.values.limitAutomaticInstallation).toBe(true);
+    expect(formik.values.automaticUpgrades).toBe(false);
 
-    expect(formik.setFieldValue).not.toHaveBeenCalled();
+    await user.selectOptions(dropdownInput, AUTOMATIC_LABELS.upgrades);
+    expect(formik.values.limitAutomaticInstallation).toBe(true);
     expect(formik.values.automaticUpgrades).toBe(true);
+
+    await user.selectOptions(dropdownInput, AUTOMATIC_LABELS.both);
+    expect(formik.values.limitAutomaticInstallation).toBe(false);
+    expect(formik.values.automaticUpgrades).toBe(false);
   });
 });

--- a/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.test.tsx
+++ b/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.test.tsx
@@ -3,19 +3,28 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { PublicationSettingsBlock } from "../..";
-import { createFormik } from "@/tests/formik";
+import { useFormik } from "formik";
 import type { Publication } from "@canonical/landscape-openapi";
-import { type AUTOMATIC_KEY, AUTOMATIC_LABELS } from "../../constants";
+import { AUTOMATIC_LABELS } from "../../constants";
+import type { PublishSettingsValues } from "../../types";
 
-const createPublicationSettingsFormik = (
-  installsAndUpgrades: AUTOMATIC_KEY = "automatic",
-) =>
-  createFormik({
-    installsAndUpgrades,
-    hashIndexing: false,
-    skipBz2: false,
-    skipContentIndexing: false,
+const PublicationSettingsFormikWrapper = ({
+  installsAndUpgrades = "automatic",
+}: {
+  readonly installsAndUpgrades?: PublishSettingsValues["installsAndUpgrades"];
+}) => {
+  const formik = useFormik<PublishSettingsValues>({
+    initialValues: {
+      installsAndUpgrades,
+      hashIndexing: false,
+      skipBz2: false,
+      skipContentIndexing: false,
+    },
+    onSubmit: () => undefined,
   });
+
+  return <PublicationSettingsBlock formik={formik} />;
+};
 
 const getPublication = (values: boolean) =>
   ({
@@ -74,10 +83,9 @@ describe("PublicationSettingsBlock", () => {
   });
 
   it("selects each option in the dropdown", async () => {
-    const formik = createPublicationSettingsFormik();
     const user = userEvent.setup();
 
-    renderWithProviders(<PublicationSettingsBlock formik={formik} />);
+    renderWithProviders(<PublicationSettingsFormikWrapper />);
 
     const dropdownInput = screen.getByRole("combobox", {
       name: /installs and upgrades/i,
@@ -85,12 +93,12 @@ describe("PublicationSettingsBlock", () => {
     expect(dropdownInput).toHaveValue("automatic");
 
     await user.selectOptions(dropdownInput, "manual");
-    expect(formik.values.installsAndUpgrades).toBe("manual");
+    expect(dropdownInput).toHaveValue("manual");
 
     await user.selectOptions(dropdownInput, "autoUpgrades");
-    expect(formik.values.installsAndUpgrades).toBe("autoUpgrades");
+    expect(dropdownInput).toHaveValue("autoUpgrades");
 
     await user.selectOptions(dropdownInput, "automatic");
-    expect(formik.values.installsAndUpgrades).toBe("automatic");
+    expect(dropdownInput).toHaveValue("automatic");
   });
 });

--- a/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.test.tsx
+++ b/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.test.tsx
@@ -84,13 +84,13 @@ describe("PublicationSettingsBlock", () => {
     });
     expect(dropdownInput).toHaveValue("automatic");
 
-    await user.selectOptions(dropdownInput, AUTOMATIC_LABELS.manual);
-    expect(screen.getByText(AUTOMATIC_LABELS.manual)).toBeInTheDocument();
+    await user.selectOptions(dropdownInput, "manual");
+    expect(formik.values.installsAndUpgrades).toBe("manual");
 
-    await user.selectOptions(dropdownInput, AUTOMATIC_LABELS.autoUpgrades);
-    expect(screen.getByText(AUTOMATIC_LABELS.autoUpgrades)).toBeInTheDocument();
+    await user.selectOptions(dropdownInput, "autoUpgrades");
+    expect(formik.values.installsAndUpgrades).toBe("autoUpgrades");
 
-    await user.selectOptions(dropdownInput, AUTOMATIC_LABELS.automatic);
-    expect(screen.getByText(AUTOMATIC_LABELS.automatic)).toBeInTheDocument();
+    await user.selectOptions(dropdownInput, "automatic");
+    expect(formik.values.installsAndUpgrades).toBe("automatic");
   });
 });

--- a/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.test.tsx
+++ b/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.test.tsx
@@ -87,18 +87,33 @@ describe("PublicationSettingsBlock", () => {
 
     renderWithProviders(<PublicationSettingsFormikWrapper />);
 
-    const dropdownInput = screen.getByRole("combobox", {
+    const dropdownButton = screen.getByRole("button", {
       name: /installs and upgrades/i,
     });
-    expect(dropdownInput).toHaveValue("automatic");
+    expect(dropdownButton).toHaveTextContent(AUTOMATIC_LABELS.automatic);
 
-    await user.selectOptions(dropdownInput, "manual");
-    expect(dropdownInput).toHaveValue("manual");
+    await user.click(dropdownButton);
+    await user.click(
+      await screen.findByRole("option", {
+        name: new RegExp(AUTOMATIC_LABELS.manual, "i"),
+      }),
+    );
+    expect(dropdownButton).toHaveTextContent(AUTOMATIC_LABELS.manual);
 
-    await user.selectOptions(dropdownInput, "autoUpgrades");
-    expect(dropdownInput).toHaveValue("autoUpgrades");
+    await user.click(dropdownButton);
+    await user.click(
+      await screen.findByRole("option", {
+        name: new RegExp(AUTOMATIC_LABELS.autoUpgrades, "i"),
+      }),
+    );
+    expect(dropdownButton).toHaveTextContent(AUTOMATIC_LABELS.autoUpgrades);
 
-    await user.selectOptions(dropdownInput, "automatic");
-    expect(dropdownInput).toHaveValue("automatic");
+    await user.click(dropdownButton);
+    await user.click(
+      await screen.findByRole("option", {
+        name: new RegExp(AUTOMATIC_LABELS.automatic, "i"),
+      }),
+    );
+    expect(dropdownButton).toHaveTextContent(AUTOMATIC_LABELS.automatic);
   });
 });

--- a/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.test.tsx
+++ b/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.test.tsx
@@ -5,15 +5,13 @@ import { describe, expect, it } from "vitest";
 import { PublicationSettingsBlock } from "../..";
 import { createFormik } from "@/tests/formik";
 import type { Publication } from "@canonical/landscape-openapi";
-import { AUTOMATIC_LABELS } from "../../constants";
+import { type AUTOMATIC_KEY, AUTOMATIC_LABELS } from "../../constants";
 
 const createPublicationSettingsFormik = (
-  limitAutomaticInstallation = false,
-  automaticUpgrades = false,
+  installsAndUpgrades: AUTOMATIC_KEY = "automatic",
 ) =>
   createFormik({
-    limitAutomaticInstallation,
-    automaticUpgrades,
+    installsAndUpgrades,
     hashIndexing: false,
     skipBz2: false,
     skipContentIndexing: false,
@@ -35,7 +33,7 @@ describe("PublicationSettingsBlock", () => {
     );
 
     expect(screen.getByText("Installs and upgrades")).toBeInTheDocument();
-    expect(screen.getByText(AUTOMATIC_LABELS.both)).toBeInTheDocument();
+    expect(screen.getByText(AUTOMATIC_LABELS.automatic)).toBeInTheDocument();
     expect(
       screen.getByRole("checkbox", { name: /hash based indexing/i }),
     ).toBeDisabled();
@@ -47,12 +45,12 @@ describe("PublicationSettingsBlock", () => {
     ).toBeDisabled();
   });
 
-  it("renders existing publication settings if publication is provided", () => {
+  it("renders existing publication settings if provided", () => {
     renderWithProviders(
       <PublicationSettingsBlock publication={getPublication(true)} />,
     );
 
-    expect(screen.getByText(AUTOMATIC_LABELS.upgrades)).toBeInTheDocument();
+    expect(screen.getByText(AUTOMATIC_LABELS.autoUpgrades)).toBeInTheDocument();
 
     const checkboxes = screen.getAllByRole("checkbox");
     expect(checkboxes).toHaveLength(3);
@@ -62,7 +60,7 @@ describe("PublicationSettingsBlock", () => {
     }
   });
 
-  it("preselects manual value from publication", () => {
+  it("renders manual value from existing publication", () => {
     renderWithProviders(
       <PublicationSettingsBlock
         publication={{
@@ -72,27 +70,7 @@ describe("PublicationSettingsBlock", () => {
       />,
     );
 
-    expect(screen.getByText(AUTOMATIC_LABELS.neither)).toBeInTheDocument();
-  });
-
-  it("preselects manual when installs are limited and upgrades disabled", () => {
-    const formik = createPublicationSettingsFormik(true);
-
-    renderWithProviders(<PublicationSettingsBlock formik={formik} />);
-
-    expect(
-      screen.getByRole("combobox", { name: /installs and upgrades/i }),
-    ).toHaveValue("manual");
-  });
-
-  it("preselects autoUpgrades when installs are limited and upgrades enabled", () => {
-    const formik = createPublicationSettingsFormik(true, true);
-
-    renderWithProviders(<PublicationSettingsBlock formik={formik} />);
-
-    expect(
-      screen.getByRole("combobox", { name: /installs and upgrades/i }),
-    ).toHaveValue("autoUpgrades");
+    expect(screen.getByText(AUTOMATIC_LABELS.manual)).toBeInTheDocument();
   });
 
   it("selects each option in the dropdown", async () => {
@@ -106,16 +84,13 @@ describe("PublicationSettingsBlock", () => {
     });
     expect(dropdownInput).toHaveValue("automatic");
 
-    await user.selectOptions(dropdownInput, AUTOMATIC_LABELS.neither);
-    expect(formik.values.limitAutomaticInstallation).toBe(true);
-    expect(formik.values.automaticUpgrades).toBe(false);
+    await user.selectOptions(dropdownInput, AUTOMATIC_LABELS.manual);
+    expect(screen.getByText(AUTOMATIC_LABELS.manual)).toBeInTheDocument();
 
-    await user.selectOptions(dropdownInput, AUTOMATIC_LABELS.upgrades);
-    expect(formik.values.limitAutomaticInstallation).toBe(true);
-    expect(formik.values.automaticUpgrades).toBe(true);
+    await user.selectOptions(dropdownInput, AUTOMATIC_LABELS.autoUpgrades);
+    expect(screen.getByText(AUTOMATIC_LABELS.autoUpgrades)).toBeInTheDocument();
 
-    await user.selectOptions(dropdownInput, AUTOMATIC_LABELS.both);
-    expect(formik.values.limitAutomaticInstallation).toBe(false);
-    expect(formik.values.automaticUpgrades).toBe(false);
+    await user.selectOptions(dropdownInput, AUTOMATIC_LABELS.automatic);
+    expect(screen.getByText(AUTOMATIC_LABELS.automatic)).toBeInTheDocument();
   });
 });

--- a/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.tsx
+++ b/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.tsx
@@ -8,7 +8,7 @@ import CheckboxInputWithHelp from "@/components/form/CheckboxInputWithHelp";
 import type { JSX } from "react";
 import type { SelectOption } from "@/types/SelectOption";
 import ReadOnlyField from "@/components/form/ReadOnlyField";
-import { getInstallsAndUpgradesValue } from "../../helpers";
+import { getInstallsAndUpgradesText } from "../../helpers";
 import { AUTOMATIC_LABELS } from "../../constants";
 
 type PublicationSettingsBlockProps<T extends PublishSettingsValues> =
@@ -44,22 +44,10 @@ const PublicationSettingsBlock = <T extends PublishSettingsValues>({
   const checkboxProps = getCheckboxProps();
 
   const automaticOptions: SelectOption[] = [
-    { label: AUTOMATIC_LABELS.both, value: "automatic" },
-    { label: AUTOMATIC_LABELS.upgrades, value: "autoUpgrades" },
-    { label: AUTOMATIC_LABELS.neither, value: "manual" },
+    { label: AUTOMATIC_LABELS.automatic, value: "automatic" },
+    { label: AUTOMATIC_LABELS.autoUpgrades, value: "autoUpgrades" },
+    { label: AUTOMATIC_LABELS.manual, value: "manual" },
   ];
-
-  const getAutomaticOptionValue = (values: PublishSettingsValues) => {
-    if (!values.limitAutomaticInstallation) {
-      return "automatic";
-    }
-
-    if (values.automaticUpgrades) {
-      return "autoUpgrades";
-    }
-
-    return "manual";
-  };
 
   return (
     <Blocks.Item title="Settings">
@@ -67,25 +55,12 @@ const PublicationSettingsBlock = <T extends PublishSettingsValues>({
         <Select
           label="Installs and upgrades"
           options={automaticOptions}
-          onChange={async (e) => {
-            const { value } = e.target;
-            if (value === "automatic") {
-              await formik.setFieldValue("limitAutomaticInstallation", false);
-              await formik.setFieldValue("automaticUpgrades", false);
-            } else if (value === "autoUpgrades") {
-              await formik.setFieldValue("limitAutomaticInstallation", true);
-              await formik.setFieldValue("automaticUpgrades", true);
-            } else {
-              await formik.setFieldValue("limitAutomaticInstallation", true);
-              await formik.setFieldValue("automaticUpgrades", false);
-            }
-          }}
-          value={getAutomaticOptionValue(formik.values)}
+          {...formik.getFieldProps("installsAndUpgrades")}
         />
       ) : (
         <ReadOnlyField
           label="Installs and upgrades"
-          value={getInstallsAndUpgradesValue(publication)}
+          value={getInstallsAndUpgradesText(publication)}
         />
       )}
 

--- a/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.tsx
+++ b/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.tsx
@@ -1,12 +1,15 @@
 import Blocks from "@/components/layout/Blocks";
-import { Input } from "@canonical/react-components";
+import { Input, Select } from "@canonical/react-components";
 import { PUBLICATION_SETTINGS_HELP_TEXT } from "./constants";
-import classes from "./PublicationSettingsBlock.module.scss";
 import type { Publication } from "@canonical/landscape-openapi";
 import type { FormikContextType } from "formik";
 import type { PublishSettingsValues } from "../../types";
-import type { ChangeEvent, JSX } from "react";
 import CheckboxInputWithHelp from "@/components/form/CheckboxInputWithHelp";
+import type { JSX } from "react";
+import type { SelectOption } from "@/types/SelectOption";
+import ReadOnlyField from "@/components/form/ReadOnlyField";
+import { getInstallsAndUpgradesValue } from "../../helpers";
+import { AUTOMATIC_LABELS } from "../../constants";
 
 type PublicationSettingsBlockProps<T extends PublishSettingsValues> =
   | {
@@ -22,105 +25,86 @@ const PublicationSettingsBlock = <T extends PublishSettingsValues>({
   formik,
   publication,
 }: PublicationSettingsBlockProps<T>): JSX.Element => {
-  const getInputProps = () => {
+  const getCheckboxProps = () => {
     if (formik) {
       return {
-        hashIndexing: {
-          ...formik.getFieldProps("hashIndexing"),
-          checked: formik.values.hashIndexing,
-        },
-        limitAutoInstall: {
-          ...formik.getFieldProps("limitAutomaticInstallation"),
-          checked: formik.values.limitAutomaticInstallation,
-          onChange: (e: ChangeEvent<HTMLInputElement>) => {
-            if (!e.target.checked) {
-              void formik.setFieldValue("automaticUpgrades", false);
-            }
-            formik.getFieldProps("limitAutomaticInstallation").onChange(e);
-          },
-        },
-        automaticUpgrades: {
-          ...formik.getFieldProps("automaticUpgrades"),
-          checked: formik.values.automaticUpgrades,
-        },
-        skipBz2: {
-          ...formik.getFieldProps("skipBz2"),
-          checked: formik.values.skipBz2,
-        },
-        skipContents: {
-          ...formik.getFieldProps("skipContentIndexing"),
-          checked: formik.values.skipContentIndexing,
-        },
+        hashIndexing: formik.getFieldProps({ name: "hashIndexing", type: "checkbox" }),
+        skipBz2: formik.getFieldProps({ name: "skipBz2", type: "checkbox" }),
+        skipContents: formik.getFieldProps({ name: "skipContentIndexing", type: "checkbox" }),
       };
     }
 
     return {
-      hashIndexing: {
-        checked: Boolean(publication.acquireByHash),
-        disabled: true,
-      },
-      limitAutoInstall: {
-        checked: Boolean(publication.notAutomatic),
-        disabled: true,
-      },
-      automaticUpgrades: {
-        checked: Boolean(publication.butAutomaticUpgrades),
-        disabled: true,
-      },
-      skipBz2: { checked: Boolean(publication.skipBz2), disabled: true },
-      skipContents: {
-        checked: Boolean(publication.skipContents),
-        disabled: true,
-      },
+      hashIndexing: { checked: !!publication.acquireByHash, disabled: true },
+      skipBz2: { checked: !!publication.skipBz2, disabled: true },
+      skipContents: { checked: !!publication.skipContents, disabled: true },
     };
   };
 
-  const inputProps = getInputProps();
-  const isLimitAutoInstallChecked = formik
-    ? formik.values.limitAutomaticInstallation
-    : !!publication.notAutomatic;
+  const checkboxProps = getCheckboxProps();
+
+  const automaticOptions: SelectOption[] = [
+    { label: AUTOMATIC_LABELS.both, value: "automatic" },
+    { label: AUTOMATIC_LABELS.upgrades, value: "autoUpgrades" },
+    { label: AUTOMATIC_LABELS.neither, value: "manual" },
+  ];
+
+  const getAutomaticOptionValue = (values: PublishSettingsValues) => {
+    if (!values.limitAutomaticInstallation) {
+      return "automatic";
+    }
+
+    if (values.automaticUpgrades) {
+      return "autoUpgrades";
+    }
+
+    return "manual";
+  };
 
   return (
     <Blocks.Item title="Settings">
+      {formik ? (
+        <Select
+          label="Installs and upgrades"
+          options={automaticOptions}
+          onChange={async (e) => {
+            const { value } = e.target;
+            if (value === "automatic") {
+              await formik.setFieldValue("limitAutomaticInstallation", false);
+              await formik.setFieldValue("automaticUpgrades", false);
+            } else if (value === "autoUpgrades") {
+              await formik.setFieldValue("limitAutomaticInstallation", true);
+              await formik.setFieldValue("automaticUpgrades", true);
+            } else {
+              await formik.setFieldValue("limitAutomaticInstallation", true);
+              await formik.setFieldValue("automaticUpgrades", false);
+            }
+          }}
+          value={getAutomaticOptionValue(formik.values)}
+        />
+      ) : (
+        <ReadOnlyField
+          label="Installs and upgrades"
+          value={getInstallsAndUpgradesValue(publication)}
+        />
+      )}
+
       <CheckboxInputWithHelp
         label="Hash based indexing"
         tooltipMessage={PUBLICATION_SETTINGS_HELP_TEXT.hashIndexing}
-        {...inputProps.hashIndexing}
+        {...checkboxProps.hashIndexing}
       />
-
-      <CheckboxInputWithHelp
-        label="Limit automatic installation"
-        tooltipMessage={PUBLICATION_SETTINGS_HELP_TEXT.limitAutomaticInstall}
-        {...inputProps.limitAutoInstall}
-      />
-
-      <div aria-live="polite" aria-relevant="all">
-        {isLimitAutoInstallChecked && (
-          <>
-            <span className="u-off-screen">
-              Selecting &quot;Limit automatic installation&quot; has opened a
-              new option
-            </span>
-            <CheckboxInputWithHelp
-              label="Automatic upgrades"
-              tooltipMessage={PUBLICATION_SETTINGS_HELP_TEXT.automaticUpgrades}
-              wrapperClassName={classes.subCheckbox}
-              {...inputProps.automaticUpgrades}
-            />
-          </>
-        )}
-      </div>
 
       <Input
         type="checkbox"
         label="Skip bz2 compression for index files"
-        {...inputProps.skipBz2}
+        {...checkboxProps.skipBz2}
       />
 
       <Input
         type="checkbox"
         label="Skip generating content indexes"
-        {...inputProps.skipContents}
+        {...checkboxProps.skipContents}
       />
     </Blocks.Item>
   );

--- a/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.tsx
+++ b/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.tsx
@@ -28,9 +28,15 @@ const PublicationSettingsBlock = <T extends PublishSettingsValues>({
   const getCheckboxProps = () => {
     if (formik) {
       return {
-        hashIndexing: formik.getFieldProps({ name: "hashIndexing", type: "checkbox" }),
+        hashIndexing: formik.getFieldProps({
+          name: "hashIndexing",
+          type: "checkbox",
+        }),
         skipBz2: formik.getFieldProps({ name: "skipBz2", type: "checkbox" }),
-        skipContents: formik.getFieldProps({ name: "skipContentIndexing", type: "checkbox" }),
+        skipContents: formik.getFieldProps({
+          name: "skipContentIndexing",
+          type: "checkbox",
+        }),
       };
     }
 

--- a/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.tsx
+++ b/src/features/publications/components/PublicationSettingsBlock/PublicationSettingsBlock.tsx
@@ -1,15 +1,19 @@
 import Blocks from "@/components/layout/Blocks";
-import { Input, Select } from "@canonical/react-components";
-import { PUBLICATION_SETTINGS_HELP_TEXT } from "./constants";
+import {
+  CustomSelect,
+  type CustomSelectOption,
+  Input,
+} from "@canonical/react-components";
+import { AUTOMATIC_DESCRIPTIONS, HASH_INDEXING_HELP_TEXT } from "./constants";
 import type { Publication } from "@canonical/landscape-openapi";
 import type { FormikContextType } from "formik";
 import type { PublishSettingsValues } from "../../types";
 import CheckboxInputWithHelp from "@/components/form/CheckboxInputWithHelp";
 import type { JSX } from "react";
-import type { SelectOption } from "@/types/SelectOption";
 import ReadOnlyField from "@/components/form/ReadOnlyField";
 import { getInstallsAndUpgradesText } from "../../helpers";
 import { AUTOMATIC_LABELS } from "../../constants";
+import LabelWithDescription from "@/components/layout/LabelWithDescription";
 
 type PublicationSettingsBlockProps<T extends PublishSettingsValues> =
   | {
@@ -49,30 +53,64 @@ const PublicationSettingsBlock = <T extends PublishSettingsValues>({
 
   const checkboxProps = getCheckboxProps();
 
-  const automaticOptions: SelectOption[] = [
-    { label: AUTOMATIC_LABELS.automatic, value: "automatic" },
-    { label: AUTOMATIC_LABELS.autoUpgrades, value: "autoUpgrades" },
-    { label: AUTOMATIC_LABELS.manual, value: "manual" },
+  const automaticOptions: CustomSelectOption[] = [
+    {
+      label: (
+        <LabelWithDescription
+          className="u-no-padding--top"
+          label={AUTOMATIC_LABELS.automatic}
+          description={AUTOMATIC_DESCRIPTIONS.automatic}
+        />
+      ),
+      text: AUTOMATIC_LABELS.automatic,
+      value: "automatic",
+    },
+    {
+      label: (
+        <LabelWithDescription
+          className="u-no-padding--top"
+          label={AUTOMATIC_LABELS.autoUpgrades}
+          description={AUTOMATIC_DESCRIPTIONS.autoUpgrades}
+        />
+      ),
+      text: AUTOMATIC_LABELS.autoUpgrades,
+      value: "autoUpgrades",
+    },
+    {
+      label: (
+        <LabelWithDescription
+          className="u-no-padding--top"
+          label={AUTOMATIC_LABELS.manual}
+          description={AUTOMATIC_DESCRIPTIONS.manual}
+        />
+      ),
+      text: AUTOMATIC_LABELS.manual,
+      value: "manual",
+    },
   ];
 
   return (
     <Blocks.Item title="Settings">
       {formik ? (
-        <Select
+        <CustomSelect
           label="Installs and upgrades"
           options={automaticOptions}
           {...formik.getFieldProps("installsAndUpgrades")}
+          onChange={async (value) => {
+            await formik.setFieldValue("installsAndUpgrades", value);
+          }}
         />
       ) : (
         <ReadOnlyField
           label="Installs and upgrades"
           value={getInstallsAndUpgradesText(publication)}
+          tooltipMessage="You can't change the settings of an existing publication."
         />
       )}
 
       <CheckboxInputWithHelp
         label="Hash based indexing"
-        tooltipMessage={PUBLICATION_SETTINGS_HELP_TEXT.hashIndexing}
+        tooltipMessage={HASH_INDEXING_HELP_TEXT}
         {...checkboxProps.hashIndexing}
       />
 

--- a/src/features/publications/components/PublicationSettingsBlock/constants.ts
+++ b/src/features/publications/components/PublicationSettingsBlock/constants.ts
@@ -1,5 +1,10 @@
-export const PUBLICATION_SETTINGS_HELP_TEXT = {
-  hashIndexing: `Provides repository index files (like Packages and Sources) via their hash sums instead of just their names. This prevents "Hash Sum Mismatch" errors on client machines if the repository is updated during an active apt-get update session.`,
-  limitAutomaticInstall: `This tells apt that packages in this repository should not be installed or upgraded automatically. Users must explicitly target this repository or specific package versions to install them.`,
-  automaticUpgrades: `This creates an exception to the "Limit automatic installation" rule. While new packages from this repository won't be installed automatically, any package already installed on a system will be upgraded whenever a newer version is published to this repository.`,
+export const HASH_INDEXING_HELP_TEXT = `Provides repository index files (like Packages and Sources) via their hash sums instead of just their names. This prevents "Hash Sum Mismatch" errors on client machines if the repository is updated during an active apt-get update session.`;
+
+export const AUTOMATIC_DESCRIPTIONS = {
+  automatic:
+    "Allows packages to install and update seamlessly during standard OS runs.",
+  autoUpgrades:
+    "Lets packages upgrade automatically but forces new installations to be triggered manually.",
+  manual:
+    "Requires explicit admin intervention for both initial installation and any subsequent updates.",
 };

--- a/src/features/publications/constants.ts
+++ b/src/features/publications/constants.ts
@@ -8,8 +8,6 @@ export const AUTOMATIC_LABELS = {
   manual: "Manual installs and upgrades",
 } as const;
 
-export type AUTOMATIC_KEY = keyof typeof AUTOMATIC_LABELS;
-
 export const VALIDATION_SCHEMA_NEW = Yup.object().shape({
   name: Yup.string().required(REQUIRED_FIELD_MESSAGE),
   publicationTarget: Yup.string().required(REQUIRED_FIELD_MESSAGE),

--- a/src/features/publications/constants.ts
+++ b/src/features/publications/constants.ts
@@ -2,13 +2,20 @@ import * as Yup from "yup";
 
 export const REQUIRED_FIELD_MESSAGE = "This field is required";
 
+export const AUTOMATIC_LABELS = {
+  automatic: "Automatic installs and upgrades",
+  autoUpgrades: "Automatic upgrades only",
+  manual: "Manual installs and upgrades",
+} as const;
+
+export type AUTOMATIC_KEY = keyof typeof AUTOMATIC_LABELS;
+
 export const VALIDATION_SCHEMA_NEW = Yup.object().shape({
   name: Yup.string().required(REQUIRED_FIELD_MESSAGE),
   publicationTarget: Yup.string().required(REQUIRED_FIELD_MESSAGE),
   signingKey: Yup.string(),
   hashIndexing: Yup.boolean(),
-  automaticUpgrades: Yup.boolean(),
-  limitAutomaticInstallation: Yup.boolean(),
+  installsAndUpgrades: Yup.string().oneOf(Object.keys(AUTOMATIC_LABELS)),
   skipBz2: Yup.boolean(),
   skipContentIndexing: Yup.boolean(),
 });
@@ -16,9 +23,3 @@ export const VALIDATION_SCHEMA_NEW = Yup.object().shape({
 export const VALIDATION_SCHEMA_EXISTING = Yup.object().shape({
   name: Yup.string().required(REQUIRED_FIELD_MESSAGE),
 });
-
-export const AUTOMATIC_LABELS = {
-  both: "Automatic installs and upgrades",
-  upgrades: "Automatic upgrades only",
-  neither: "Manual installs and upgrades",
-};

--- a/src/features/publications/constants.ts
+++ b/src/features/publications/constants.ts
@@ -16,3 +16,9 @@ export const VALIDATION_SCHEMA_NEW = Yup.object().shape({
 export const VALIDATION_SCHEMA_EXISTING = Yup.object().shape({
   name: Yup.string().required(REQUIRED_FIELD_MESSAGE),
 });
+
+export const AUTOMATIC_LABELS = {
+  both: "Automatic installs and upgrades",
+  upgrades: "Automatic upgrades only",
+  neither: "Manual installs and upgrades",
+};

--- a/src/features/publications/helpers.ts
+++ b/src/features/publications/helpers.ts
@@ -1,5 +1,6 @@
 import type { Publication } from "@canonical/landscape-openapi";
 import { AUTOMATIC_LABELS } from "./constants";
+import type { PublishNewFormValues } from "./types";
 
 export const getSourceType = (source: string) => {
   if (source.startsWith("mirrors/")) {
@@ -23,14 +24,48 @@ export const getPublicationTargetName = (publicationTarget: string) => {
   return parts.length > 1 ? (parts[1] ?? publicationTarget) : publicationTarget;
 };
 
-export const getInstallsAndUpgradesValue = (publication: Publication) => {
+export const getInitialValues = (publicationTarget = ""): PublishNewFormValues => {
+  return {
+    name: "",
+    publicationTarget,
+    signingKey: "",
+    hashIndexing: false,
+    installsAndUpgrades: "automatic",
+    skipBz2: false,
+    skipContentIndexing: false,
+  };
+};
+
+export const getInstallsAndUpgradesText = (publication: Publication) => {
   if (!publication.notAutomatic) {
-    return AUTOMATIC_LABELS.both;
+    return AUTOMATIC_LABELS.automatic;
   }
 
   if (publication.butAutomaticUpgrades) {
-    return AUTOMATIC_LABELS.upgrades;
+    return AUTOMATIC_LABELS.autoUpgrades;
   }
 
-  return AUTOMATIC_LABELS.neither;
+  return AUTOMATIC_LABELS.manual;
+};
+
+export const getInstallsAndUpgradesValues = (
+  installsAndUpgrades: PublishNewFormValues["installsAndUpgrades"]
+) => {
+  switch (installsAndUpgrades) {
+    case "automatic":
+      return {
+        notAutomatic: false,
+        butAutomaticUpgrades: false,
+      };
+    case "manual":
+      return {
+        notAutomatic: true,
+        butAutomaticUpgrades: false,
+      };
+    case "autoUpgrades":
+      return {
+        notAutomatic: true,
+        butAutomaticUpgrades: true,
+      };
+  }
 };

--- a/src/features/publications/helpers.ts
+++ b/src/features/publications/helpers.ts
@@ -24,7 +24,9 @@ export const getPublicationTargetName = (publicationTarget: string) => {
   return parts.length > 1 ? (parts[1] ?? publicationTarget) : publicationTarget;
 };
 
-export const getInitialValues = (publicationTarget = ""): PublishNewFormValues => {
+export const getInitialValues = (
+  publicationTarget = "",
+): PublishNewFormValues => {
   return {
     name: "",
     publicationTarget,
@@ -49,7 +51,7 @@ export const getInstallsAndUpgradesText = (publication: Publication) => {
 };
 
 export const getInstallsAndUpgradesValues = (
-  installsAndUpgrades: PublishNewFormValues["installsAndUpgrades"]
+  installsAndUpgrades: PublishNewFormValues["installsAndUpgrades"],
 ) => {
   switch (installsAndUpgrades) {
     case "automatic":

--- a/src/features/publications/helpers.ts
+++ b/src/features/publications/helpers.ts
@@ -1,3 +1,6 @@
+import type { Publication } from "@canonical/landscape-openapi";
+import { AUTOMATIC_LABELS } from "./constants";
+
 export const getSourceType = (source: string) => {
   if (source.startsWith("mirrors/")) {
     return "Mirror";
@@ -18,4 +21,16 @@ export const getSourceName = (source: string) => {
 export const getPublicationTargetName = (publicationTarget: string) => {
   const parts = publicationTarget.split("/");
   return parts.length > 1 ? (parts[1] ?? publicationTarget) : publicationTarget;
+};
+
+export const getInstallsAndUpgradesValue = (publication: Publication) => {
+  if (!publication.notAutomatic) {
+    return AUTOMATIC_LABELS.both;
+  }
+
+  if (publication.butAutomaticUpgrades) {
+    return AUTOMATIC_LABELS.upgrades;
+  }
+
+  return AUTOMATIC_LABELS.neither;
 };

--- a/src/features/publications/index.ts
+++ b/src/features/publications/index.ts
@@ -11,6 +11,6 @@ export { default as PublicationDetails } from "./components/PublicationDetails";
 export { default as PublicationDetailsSidePanel } from "./components/PublicationDetailsSidePanel";
 export { default as AssociatedPublicationsList } from "./components/AssociatedPublicationsList";
 export { default as PublicationSettingsBlock } from "./components/PublicationSettingsBlock";
-export { getSourceName, getSourceType } from "./helpers";
+export { getSourceName, getSourceType, getInstallsAndUpgradesValues, getInitialValues } from "./helpers";
 export { VALIDATION_SCHEMA_NEW, VALIDATION_SCHEMA_EXISTING } from "./constants";
 export type { PublishNewFormValues } from "./types";

--- a/src/features/publications/index.ts
+++ b/src/features/publications/index.ts
@@ -11,6 +11,11 @@ export { default as PublicationDetails } from "./components/PublicationDetails";
 export { default as PublicationDetailsSidePanel } from "./components/PublicationDetailsSidePanel";
 export { default as AssociatedPublicationsList } from "./components/AssociatedPublicationsList";
 export { default as PublicationSettingsBlock } from "./components/PublicationSettingsBlock";
-export { getSourceName, getSourceType, getInstallsAndUpgradesValues, getInitialValues } from "./helpers";
+export {
+  getSourceName,
+  getSourceType,
+  getInstallsAndUpgradesValues,
+  getInitialValues,
+} from "./helpers";
 export { VALIDATION_SCHEMA_NEW, VALIDATION_SCHEMA_EXISTING } from "./constants";
 export type { PublishNewFormValues } from "./types";

--- a/src/features/publications/types/PublishValues.ts
+++ b/src/features/publications/types/PublishValues.ts
@@ -1,8 +1,8 @@
-import type { AUTOMATIC_KEY } from "../constants";
+import type { AUTOMATIC_LABELS } from "../constants";
 
 export interface PublishSettingsValues {
   hashIndexing: boolean;
-  installsAndUpgrades: AUTOMATIC_KEY;
+  installsAndUpgrades: keyof typeof AUTOMATIC_LABELS;
   skipBz2: boolean;
   skipContentIndexing: boolean;
 }

--- a/src/features/publications/types/PublishValues.ts
+++ b/src/features/publications/types/PublishValues.ts
@@ -1,7 +1,8 @@
+import type { AUTOMATIC_KEY } from "../constants";
+
 export interface PublishSettingsValues {
   hashIndexing: boolean;
-  limitAutomaticInstallation: boolean;
-  automaticUpgrades: boolean;
+  installsAndUpgrades: AUTOMATIC_KEY;
   skipBz2: boolean;
   skipContentIndexing: boolean;
 }

--- a/src/features/repositories/constants.ts
+++ b/src/features/repositories/constants.ts
@@ -1,2 +1,2 @@
 export const DEBARCHIVE_DOCUMENTATION_URL =
-  "https://documentation.ubuntu.com/landscape/explanation/features/repository-mirroring";
+  "https://documentation.ubuntu.com/landscape/explanation/features/repository-mirroring-2604/";

--- a/src/tests/formik.ts
+++ b/src/tests/formik.ts
@@ -12,15 +12,29 @@ export const createFormik = <T extends object>(
     },
   );
 
+  const handleChange = vi.fn(
+    (e: {
+      target: {
+        name: string;
+        value?: unknown;
+        type?: string;
+        checked?: boolean;
+      };
+    }) => {
+      const { name, value, type, checked } = e.target;
+      mutableValues[name] = type === "checkbox" ? checked : value;
+    },
+  );
+
   return {
-    values: values as T,
+    values: mutableValues as T,
     touched: {},
     errors: {},
     setFieldValue,
     getFieldProps: vi.fn((field: keyof T) => ({
       name: field,
       value: mutableValues[String(field)],
-      onChange: vi.fn(),
+      onChange: handleChange,
       onBlur: vi.fn(),
     })),
   } as unknown as FormikContextType<T>;

--- a/src/tests/formik.ts
+++ b/src/tests/formik.ts
@@ -12,29 +12,15 @@ export const createFormik = <T extends object>(
     },
   );
 
-  const handleChange = vi.fn(
-    (e: {
-      target: {
-        name: string;
-        value?: unknown;
-        type?: string;
-        checked?: boolean;
-      };
-    }) => {
-      const { name, value, type, checked } = e.target;
-      mutableValues[name] = type === "checkbox" ? checked : value;
-    },
-  );
-
   return {
-    values: mutableValues as T,
+    values: values as T,
     touched: {},
     errors: {},
     setFieldValue,
     getFieldProps: vi.fn((field: keyof T) => ({
       name: field,
       value: mutableValues[String(field)],
-      onChange: handleChange,
+      onChange: vi.fn(),
       onBlur: vi.fn(),
     })),
   } as unknown as FormikContextType<T>;


### PR DESCRIPTION
## Summary


## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
