### PR TITLE
Update success notifications for debarchive

### DIFF
--- a/.changeset/tiny-parents-go.md
+++ b/.changeset/tiny-parents-go.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Make repositories success notifications consistent and add link to update mirror from creation

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.test.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.test.tsx
@@ -10,10 +10,12 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UBUNTU_ARCHIVE_HOST, UBUNTU_SNAPSHOTS_HOST } from "../../constants";
 import type { CreateMirrorData } from "@canonical/landscape-openapi";
+import { useLocation } from "react-router";
+import { mirrors } from "@/tests/mocks/mirrors";
 
 const PULLING_NOTE = /pulling and parsing repository data/i;
 
-const mockCreateMirror = vi.fn();
+const mockCreateMirror = vi.fn(() => ({ data: mirrors[0] }));
 
 vi.mock("../../api", async () => {
   const actual = await vi.importActual("../../api");
@@ -26,13 +28,23 @@ vi.mock("../../api", async () => {
   };
 });
 
+const LocationDisplay = () => {
+  const { search } = useLocation();
+  return <div data-testid="location">{search}</div>;
+};
+
 describe("AddMirrorForm", () => {
   const user = userEvent.setup();
 
   beforeEach(async () => {
     mockCreateMirror.mockClear();
 
-    renderWithProviders(<AddMirrorForm />);
+    renderWithProviders(
+      <>
+        <AddMirrorForm />
+        <LocationDisplay />
+      </>,
+    );
 
     // The form renders immediately; wait for the "pulling…" note in the
     // Mirror contents block to disappear so the data-dependent dropdowns are
@@ -41,6 +53,22 @@ describe("AddMirrorForm", () => {
       timeout: 2000,
     });
     await user.type(screen.getByLabelText("Name"), "Name");
+  });
+
+  it("shows success notification with Update mirror action", async () => {
+    await user.click(screen.getByRole("button", { name: "Add mirror" }));
+
+    expect(
+      screen.getByText(`You have successfully added Name`),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Update mirror" }));
+
+    const location = screen.getByTestId("location");
+    expect(location).toHaveTextContent("sidePath=view");
+    expect(location).toHaveTextContent(
+      `name=${mirrors[0].name.replace("/", "%2F")}`,
+    );
+    expect(location).toHaveTextContent("updateModal=true");
   });
 
   it("submits an ubuntu archive mirror with the default https URL", async () => {

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
@@ -116,6 +116,8 @@ const AddMirrorForm: FC = () => {
             : undefined,
         });
 
+        closeSidePanel();
+
         notify.success({
           title: `You have successfully added ${values.name}`,
           message:
@@ -133,8 +135,6 @@ const AddMirrorForm: FC = () => {
         });
       } catch (error) {
         debug(error);
-      } finally {
-        closeSidePanel();
       }
     },
   });

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
@@ -36,7 +36,7 @@ import MirrorFilterHelpButton from "../MirrorFilterHelpButton";
 const AddMirrorForm: FC = () => {
   const debug = useDebug();
   const { notify } = useNotify();
-  const { closeSidePanel } = usePageParams();
+  const { closeSidePanel, createPageParamsSetter } = usePageParams();
 
   const ubuntuArchiveQuery = useGetUbuntuArchiveInfo();
   const ubuntuEsmQuery = useGetUbuntuEsmInfo();
@@ -93,7 +93,7 @@ const AddMirrorForm: FC = () => {
             ? `https://${UBUNTU_SNAPSHOTS_HOST}/ubuntu/${values.snapshotDate}`
             : values.sourceUrl;
 
-        await createMirror({
+        const { data: newMirror } = await createMirror({
           archiveRoot,
           components: values.components.map((component) => component.trim()),
           displayName: values.name,
@@ -116,14 +116,25 @@ const AddMirrorForm: FC = () => {
             : undefined,
         });
 
-        closeSidePanel();
-
         notify.success({
-          title: `You have successfully added ${values.name}.`,
-          message: "The mirror has been created.",
+          title: `You have successfully added ${values.name}`,
+          message:
+            "The mirror has been created and is now available to update.",
+          actions: [
+            {
+              label: "Update mirror",
+              onClick: createPageParamsSetter({
+                sidePath: ["view"],
+                name: newMirror.name,
+                updateModal: true,
+              }),
+            },
+          ],
         });
       } catch (error) {
         debug(error);
+      } finally {
+        closeSidePanel();
       }
     },
   });

--- a/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
+++ b/src/features/mirrors/components/EditMirrorForm/EditMirrorForm.tsx
@@ -79,7 +79,7 @@ const EditMirrorForm: FC = () => {
         closeSidePanel();
 
         notify.success({
-          title: `You have successfully edited ${mirror.displayName}.`,
+          title: `You have successfully edited ${values.name}`,
           message: "The mirror details have been updated.",
         });
       } catch (error) {

--- a/src/features/mirrors/components/MirrorDetails/MirrorDetails.test.tsx
+++ b/src/features/mirrors/components/MirrorDetails/MirrorDetails.test.tsx
@@ -96,4 +96,20 @@ describe("MirrorDetails", () => {
     expect(label).toBeInTheDocument();
     expect(label.closest("div")?.nextSibling?.textContent).toBe("Yes");
   });
+
+  it("opens UpdateMirrorModal if updateModal param is true", async () => {
+    renderWithProviders(
+      <Suspense fallback={<LoadingState />}>
+        <MirrorDetails />
+      </Suspense>,
+      undefined,
+      `?name=${mirrors[0].name}&updateModal=true`,
+    );
+
+    expect(
+      await screen.findByRole("heading", {
+        name: `Update ${mirrors[0].displayName}`,
+      }),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/features/mirrors/components/MirrorDetails/MirrorDetails.tsx
+++ b/src/features/mirrors/components/MirrorDetails/MirrorDetails.tsx
@@ -1,4 +1,4 @@
-import { useState, type FC } from "react";
+import { useEffect, useState, type FC } from "react";
 import SidePanel from "@/components/layout/SidePanel/SidePanel";
 import { Button, Icon, ICONS, Tabs } from "@canonical/react-components";
 import Blocks from "@/components/layout/Blocks";
@@ -28,7 +28,7 @@ import {
 } from "../../constants";
 
 const MirrorDetails: FC = () => {
-  const { name, createSidePathPusher, sidePath, setPageParams } =
+  const { name, updateModal, createSidePathPusher, sidePath, setPageParams } =
     usePageParams();
 
   const {
@@ -86,6 +86,19 @@ const MirrorDetails: FC = () => {
       setTabId(id);
     },
   }));
+
+  useEffect(() => {
+    if (updateModal) {
+      openUpdateModal();
+    }
+  }, [openUpdateModal, updateModal]);
+
+  const closeAndClearUpdateModal = () => {
+    closeUpdateModal();
+    setPageParams({
+      updateModal: false,
+    });
+  };
 
   return (
     <>
@@ -246,7 +259,7 @@ const MirrorDetails: FC = () => {
       </SidePanel.Content>
       <UpdateMirrorModal
         isOpen={isUpdateModalOpen}
-        close={closeUpdateModal}
+        close={closeAndClearUpdateModal}
         mirrorDisplayName={mirror.displayName}
         mirrorName={name}
       />

--- a/src/features/mirrors/components/PublishMirrorForm/components/PublishMirrorExistingForm/PublishMirrorExistingForm.tsx
+++ b/src/features/mirrors/components/PublishMirrorForm/components/PublishMirrorExistingForm/PublishMirrorExistingForm.tsx
@@ -46,9 +46,9 @@ const PublishMirrorExistingForm: FC<PublishMirrorExistingFormProps> = ({
         closeSidePanel();
 
         notify.success({
-          title: `You have marked ${mirror.displayName} to be published.`,
+          title: `You have marked ${mirror.displayName} to be published`,
           message:
-            "An activity has been queued to publish it to the designated target.",
+            "An activity has been queued to publish the selected publication to the designated target.",
         });
       } catch (error) {
         debug(error);

--- a/src/features/mirrors/components/PublishMirrorForm/components/PublishMirrorNewForm/PublishMirrorNewForm.tsx
+++ b/src/features/mirrors/components/PublishMirrorForm/components/PublishMirrorNewForm/PublishMirrorNewForm.tsx
@@ -76,7 +76,7 @@ const PublishMirrorNewForm: FC<PublishMirrorNewFormProps> = ({
         closeSidePanel();
 
         notify.success({
-          title: `You have marked ${mirror.displayName} to be published.`,
+          title: `You have marked ${mirror.displayName} to be published`,
           message:
             "A publication has been created and an activity has been queued to publish it to the designated target.",
         });

--- a/src/features/mirrors/components/RemoveMirrorModal/RemoveMirrorModal.tsx
+++ b/src/features/mirrors/components/RemoveMirrorModal/RemoveMirrorModal.tsx
@@ -38,7 +38,7 @@ const RemoveMirrorModal: FC<RemoveMirrorModalProps> = ({
       closeSidePanel();
 
       notify.success({
-        title: `You have successfully removed ${mirrorDisplayName}.`,
+        title: `You have successfully removed ${mirrorDisplayName}`,
         message: "The mirror has been removed from Landscape.",
       });
     } catch (error) {

--- a/src/features/mirrors/components/UpdateMirrorModal/UpdateMirrorModal.tsx
+++ b/src/features/mirrors/components/UpdateMirrorModal/UpdateMirrorModal.tsx
@@ -51,7 +51,7 @@ const UpdateMirrorModal: FC<UpdateMirrorModalProps> = ({
       close();
 
       notify.success({
-        title: `You have marked ${mirrorDisplayName} to be updated.`,
+        title: `You have marked ${mirrorDisplayName} to be updated`,
         message: "An activity has been queued to update the mirror contents.",
       });
     } catch (error) {

--- a/src/features/publication-targets/components/AddPublicationTargetForm/AddPublicationTargetForm.test.tsx
+++ b/src/features/publication-targets/components/AddPublicationTargetForm/AddPublicationTargetForm.test.tsx
@@ -124,7 +124,7 @@ describe("AddPublicationTargetForm", () => {
 
     await vi.waitFor(() => {
       expect(
-        screen.getByText("Publication target created"),
+        screen.getByText(/You have successfully added My S3 Target/i),
       ).toBeInTheDocument();
     });
   });
@@ -148,7 +148,7 @@ describe("AddPublicationTargetForm", () => {
 
     await vi.waitFor(() => {
       expect(
-        screen.getByText("Publication target created"),
+        screen.getByText(/You have successfully added My Swift Target/i),
       ).toBeInTheDocument();
     });
   });
@@ -169,7 +169,7 @@ describe("AddPublicationTargetForm", () => {
 
     await vi.waitFor(() => {
       expect(
-        screen.getByText("Publication target created"),
+        screen.getByText(/You have successfully added My Filesystem Target/i),
       ).toBeInTheDocument();
     });
   });
@@ -350,7 +350,7 @@ describe("AddPublicationTargetForm", () => {
 
     await vi.waitFor(() => {
       expect(
-        screen.getByText("Publication target created"),
+        screen.getByText(/You have successfully added/i),
       ).toBeInTheDocument();
     });
   });
@@ -387,7 +387,7 @@ describe("AddPublicationTargetForm", () => {
 
     await vi.waitFor(() => {
       expect(
-        screen.getByText("Publication target created"),
+        screen.getByText(/You have successfully added/i),
       ).toBeInTheDocument();
     });
   });
@@ -406,7 +406,7 @@ describe("AddPublicationTargetForm", () => {
 
     await vi.waitFor(() => {
       expect(
-        screen.getByText("Publication target created"),
+        screen.getByText(/You have successfully added/i),
       ).toBeInTheDocument();
     });
   });
@@ -488,7 +488,7 @@ describe("AddPublicationTargetForm", () => {
 
       await vi.waitFor(() => {
         expect(
-          screen.getByText("Publication target created"),
+          screen.getByText(/You have successfully added/i),
         ).toBeInTheDocument();
       });
 
@@ -533,7 +533,7 @@ describe("AddPublicationTargetForm", () => {
 
       await vi.waitFor(() => {
         expect(
-          screen.getByText("Publication target created"),
+          screen.getByText(/You have successfully added/i),
         ).toBeInTheDocument();
       });
 
@@ -572,7 +572,7 @@ describe("AddPublicationTargetForm", () => {
 
       await vi.waitFor(() => {
         expect(
-          screen.getByText("Publication target created"),
+          screen.getByText(/You have successfully added/i),
         ).toBeInTheDocument();
       });
 
@@ -613,7 +613,7 @@ describe("AddPublicationTargetForm", () => {
 
       await vi.waitFor(() => {
         expect(
-          screen.getByText("Publication target created"),
+          screen.getByText(/You have successfully added/i),
         ).toBeInTheDocument();
       });
 

--- a/src/features/publication-targets/components/AddPublicationTargetForm/AddPublicationTargetForm.tsx
+++ b/src/features/publication-targets/components/AddPublicationTargetForm/AddPublicationTargetForm.tsx
@@ -127,8 +127,9 @@ const AddPublicationTargetForm: FC = () => {
         closeSidePanel();
 
         notify.success({
-          title: "Publication target created",
-          message: `You have successfully added ${values.displayName}`,
+          title: `You have successfully added ${values.displayName}`,
+          message:
+            "The publication target has been created and is now available to be used.",
         });
       } catch (error) {
         debug(error);

--- a/src/features/publication-targets/components/EditTargetForm/EditTargetForm.test.tsx
+++ b/src/features/publication-targets/components/EditTargetForm/EditTargetForm.test.tsx
@@ -97,7 +97,9 @@ describe("EditTargetForm", () => {
       await user.click(screen.getByRole("button", { name: /save/i }));
 
       expect(
-        await screen.findByText(/publication target edited/i),
+        await screen.findByText(
+          `You have successfully edited ${s3TargetFull.displayName}`,
+        ),
       ).toBeInTheDocument();
     });
   });
@@ -145,7 +147,9 @@ describe("EditTargetForm", () => {
       await user.click(screen.getByRole("button", { name: /save/i }));
 
       expect(
-        await screen.findByText(/publication target edited/i),
+        await screen.findByText(
+          `You have successfully edited ${swiftTarget.displayName}`,
+        ),
       ).toBeInTheDocument();
     });
 
@@ -158,7 +162,7 @@ describe("EditTargetForm", () => {
       await user.click(screen.getByRole("button", { name: /save/i }));
 
       expect(
-        await screen.findByText(/publication target edited/i),
+        await screen.findByText(/You have successfully edited/i),
       ).toBeInTheDocument();
     });
 
@@ -199,7 +203,7 @@ describe("EditTargetForm", () => {
       await user.click(screen.getByRole("button", { name: /save/i }));
 
       expect(
-        await screen.findByText(/publication target edited/i),
+        await screen.findByText(/You have successfully edited/i),
       ).toBeInTheDocument();
     });
 
@@ -271,7 +275,7 @@ describe("EditTargetForm", () => {
       await user.click(screen.getByRole("button", { name: /save/i }));
 
       expect(
-        await screen.findByText(/publication target edited/i),
+        await screen.findByText(/You have successfully edited/i),
       ).toBeInTheDocument();
     });
   });
@@ -292,7 +296,7 @@ describe("EditTargetForm", () => {
       await user.click(screen.getByRole("button", { name: /save/i }));
 
       expect(
-        await screen.findByText(/publication target edited/i),
+        await screen.findByText(/You have successfully edited/i),
       ).toBeInTheDocument();
     });
   });

--- a/src/features/publication-targets/components/EditTargetForm/EditTargetForm.tsx
+++ b/src/features/publication-targets/components/EditTargetForm/EditTargetForm.tsx
@@ -159,8 +159,8 @@ const EditTargetForm: FC<EditTargetFormProps> = ({ target }) => {
         closeSidePanel();
 
         notify.success({
-          title: "Publication target edited",
-          message: `You have successfully edited ${values.displayName}`,
+          title: `You have successfully edited ${values.displayName}`,
+          message: "The publication target details have been updated.",
         });
       } catch (error) {
         debug(error);

--- a/src/features/publication-targets/components/RemoveTargetModal/RemoveTargetModal.tsx
+++ b/src/features/publication-targets/components/RemoveTargetModal/RemoveTargetModal.tsx
@@ -43,8 +43,8 @@ const RemoveTargetModal: FC<RemoveTargetModalProps> = ({
       await removeTarget({ name: target.name });
 
       notify.success({
-        message: `You have successfully removed ${target.displayName}`,
-        title: "Publication target removed",
+        title: `You have successfully removed ${target.displayName}`,
+        message: "The publication target has been removed from Landscape.",
       });
     } catch (error) {
       debug(error);

--- a/src/features/publications/components/AddPublicationForm/AddPublicationForm.test.tsx
+++ b/src/features/publications/components/AddPublicationForm/AddPublicationForm.test.tsx
@@ -254,7 +254,7 @@ describe("AddPublicationForm", () => {
 
     expect(
       await screen.findByText(
-        'Publication "new-local-publication" has been created.',
+        "You have successfully added new-local-publication",
       ),
     ).toBeInTheDocument();
   });
@@ -296,7 +296,7 @@ describe("AddPublicationForm", () => {
 
     expect(
       await screen.findByText(
-        'Publication "new-mirror-publication" has been created.',
+        "You have successfully added new-mirror-publication",
       ),
     ).toBeInTheDocument();
   });

--- a/src/features/publications/components/AddPublicationForm/AddPublicationForm.tsx
+++ b/src/features/publications/components/AddPublicationForm/AddPublicationForm.tsx
@@ -54,8 +54,9 @@ const AddPublicationForm: FC = () => {
         closeSidePanel();
 
         notify.success({
-          title: "Publication created",
-          message: `Publication "${values.name}" has been created.`,
+          title: `You have successfully added ${values.name}`,
+          message:
+            "The publication has been created and is now available to be published.",
         });
       } catch (error) {
         debug(error);

--- a/src/features/publications/components/RepublishPublicationModal/RepublishPublicationModal.test.tsx
+++ b/src/features/publications/components/RepublishPublicationModal/RepublishPublicationModal.test.tsx
@@ -46,7 +46,7 @@ describe("RepublishPublicationModal", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "This publication has been queued for republishing to the designated target.",
+        "An activity has been queued to republish it to the designated target.",
       ),
     ).toBeInTheDocument();
   });

--- a/src/features/publications/components/RepublishPublicationModal/RepublishPublicationModal.tsx
+++ b/src/features/publications/components/RepublishPublicationModal/RepublishPublicationModal.tsx
@@ -33,7 +33,7 @@ const RepublishPublicationModal: FC<RepublishPublicationModalProps> = ({
       notify.success({
         title: `You have marked ${publication.displayName} to be republished`,
         message:
-          "This publication has been queued for republishing to the designated target.",
+          "An activity has been queued to republish it to the designated target.",
       });
     } catch (error) {
       debug(error);

--- a/src/libs/pageParamsManager/constants.ts
+++ b/src/libs/pageParamsManager/constants.ts
@@ -145,4 +145,9 @@ export const PARAMS_CONFIG: ParamsConfig = [
     shouldResetPage: false,
     defaultValue: DEFAULT_EMPTY_ARRAY,
   },
+  {
+    urlParam: "updateModal",
+    shouldResetPage: false,
+    defaultValue: false,
+  },
 ];

--- a/src/libs/pageParamsManager/types.ts
+++ b/src/libs/pageParamsManager/types.ts
@@ -34,6 +34,7 @@ export interface PageParams {
   sidePath: string[];
   name: string;
   mirror: string;
+  updateModal: boolean;
 }
 
 /**

--- a/src/tests/server/handlers/mirrors.ts
+++ b/src/tests/server/handlers/mirrors.ts
@@ -81,14 +81,14 @@ export default [
 
       const requestBody = await request.json();
       const mirrorId = requestBody.displayName.toLowerCase();
-
-      mirrors.push({
-        name: `mirrors/${mirrorId}`,
+      const newMirror: Mirror = {
         mirrorId,
+        name: `mirrors/${mirrorId}`,
         ...requestBody,
-      });
+      };
+      mirrors.push(newMirror);
 
-      return HttpResponse.json<CreateMirrorResponse>();
+      return HttpResponse.json<CreateMirrorResponse>(newMirror);
     },
   ),
 


### PR DESCRIPTION
## Summary

- Make the phrasing of the debarchive success notifications consistent
- Add `Update mirror` action to the notification after creating a mirror

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
