### PR TITLE
Auto publish publications and add cleanup

### DIFF
--- a/.changeset/some-foxes-cheat.md
+++ b/.changeset/some-foxes-cheat.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Automatically publishes a new publication and adds cleanup of older packages on publishing

--- a/src/features/local-repositories/components/PublishLocalRepositorySidePanel/components/PublishRepositoryExistingForm/PublishRepositoryExistingForm.tsx
+++ b/src/features/local-repositories/components/PublishLocalRepositorySidePanel/components/PublishRepositoryExistingForm/PublishRepositoryExistingForm.tsx
@@ -34,10 +34,7 @@ const PublishRepositoryExistingForm: FC<PublishRepositoryExistingFormProps> = ({
 
   const handleSubmit = async (values: { name: string }) => {
     try {
-      await publishPublication({
-        publicationName: values.name,
-        body: { forceOverwrite: true },
-      });
+      await publishPublication({ name: values.name });
 
       closeSidePanel();
 

--- a/src/features/local-repositories/components/PublishLocalRepositorySidePanel/components/PublishRepositoryNewForm/PublishRepositoryNewForm.tsx
+++ b/src/features/local-repositories/components/PublishLocalRepositorySidePanel/components/PublishRepositoryNewForm/PublishRepositoryNewForm.tsx
@@ -54,10 +54,7 @@ const PublishRepositoryNewForm: FC<PublishRepositoryNewFormProps> = ({
         body: valuesforCreation,
       });
 
-      await publishPublication({
-        publicationName: publication.name ?? "", // TODO change to use non-null assertion after fixing the API to return the publication name in the response
-        body: { forceOverwrite: true },
-      });
+      await publishPublication({ name: publication.name ?? "" });
 
       closeSidePanel();
 

--- a/src/features/mirrors/components/PublishMirrorForm/PublishMirrorForm.test.tsx
+++ b/src/features/mirrors/components/PublishMirrorForm/PublishMirrorForm.test.tsx
@@ -79,11 +79,9 @@ describe("PublishMirrorForm", () => {
     });
 
     await waitFor(() => {
-      expect(mockPublishPublication).toHaveBeenCalledExactlyOnceWith(
-        expect.objectContaining({
-          publicationName: mockPublicationName,
-        }),
-      );
+      expect(mockPublishPublication).toHaveBeenCalledExactlyOnceWith({
+        name: mockPublicationName,
+      });
     });
   });
 
@@ -106,11 +104,9 @@ describe("PublishMirrorForm", () => {
     await user.click(screen.getByRole("button", { name: "Publish mirror" }));
 
     await waitFor(() => {
-      expect(mockPublishPublication).toHaveBeenCalledExactlyOnceWith(
-        expect.objectContaining({
-          publicationName: publications[0].name,
-        }),
-      );
+      expect(mockPublishPublication).toHaveBeenCalledExactlyOnceWith({
+        name: publications[0].name,
+      });
     });
 
     expect(mockCreatePublication).not.toHaveBeenCalled();

--- a/src/features/mirrors/components/PublishMirrorForm/components/PublishMirrorExistingForm/PublishMirrorExistingForm.tsx
+++ b/src/features/mirrors/components/PublishMirrorForm/components/PublishMirrorExistingForm/PublishMirrorExistingForm.tsx
@@ -38,10 +38,7 @@ const PublishMirrorExistingForm: FC<PublishMirrorExistingFormProps> = ({
 
     onSubmit: async (values) => {
       try {
-        await publishPublication({
-          publicationName: values.name,
-          body: { forceOverwrite: true },
-        });
+        await publishPublication({ name: values.name ?? "" });
 
         closeSidePanel();
 

--- a/src/features/mirrors/components/PublishMirrorForm/components/PublishMirrorNewForm/PublishMirrorNewForm.tsx
+++ b/src/features/mirrors/components/PublishMirrorForm/components/PublishMirrorNewForm/PublishMirrorNewForm.tsx
@@ -68,10 +68,7 @@ const PublishMirrorNewForm: FC<PublishMirrorNewFormProps> = ({
           },
         });
 
-        await publishPublication({
-          publicationName: publication.name ?? "",
-          body: { forceOverwrite: true },
-        });
+        await publishPublication({ name: publication.name ?? "" });
 
         closeSidePanel();
 

--- a/src/features/publications/api/usePublishPublication.ts
+++ b/src/features/publications/api/usePublishPublication.ts
@@ -3,27 +3,27 @@ import type {
   PublishPublicationData,
   PublishPublicationError,
   PublishPublicationResponse,
+  PublicationServicePublishPublicationBody,
 } from "@canonical/landscape-openapi";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { AxiosError, AxiosResponse } from "axios";
 
-interface PublishPublicationParams {
-  publicationName: PublishPublicationData["path"]["name"];
-  body: PublishPublicationData["body"];
-}
-
 export const usePublishPublication = () => {
   const authFetchDebArchive = useFetchDebArchive();
   const queryClient = useQueryClient();
+  const body: PublicationServicePublishPublicationBody = {
+    forceOverwrite: true,
+    forceCleanup: true,
+  };
 
   const { mutateAsync, isPending } = useMutation<
     AxiosResponse<PublishPublicationResponse>,
     AxiosError<PublishPublicationError>,
-    PublishPublicationParams
+    PublishPublicationData["path"]
   >({
     mutationKey: ["publications", "publish"],
-    mutationFn: async ({ publicationName, body }) =>
-      authFetchDebArchive.post(`${publicationName}:publish`, body),
+    mutationFn: async ({ name }) =>
+      authFetchDebArchive.post(`${name}:publish`, body),
     onSuccess: async () =>
       queryClient.invalidateQueries({ queryKey: ["publications"] }),
   });

--- a/src/features/publications/components/AddPublicationForm/AddPublicationForm.tsx
+++ b/src/features/publications/components/AddPublicationForm/AddPublicationForm.tsx
@@ -20,7 +20,7 @@ import {
 import { useFormik } from "formik";
 import type { FC } from "react";
 import { useMemo } from "react";
-import { useCreatePublication } from "../../api";
+import { useCreatePublication, usePublishPublication } from "../../api";
 import {
   INITIAL_VALUES,
   SOURCE_TYPE_LOCAL_REPOSITORY,
@@ -42,6 +42,8 @@ const AddPublicationForm: FC = () => {
   const { publicationTargets, isGettingPublicationTargets } =
     useGetPublicationTargets();
   const { createPublication, isCreatingPublication } = useCreatePublication();
+  const { publishPublication, isPublishingPublication } =
+    usePublishPublication();
 
   const formik = useFormik<FormProps>({
     initialValues: INITIAL_VALUES,
@@ -49,7 +51,8 @@ const AddPublicationForm: FC = () => {
     onSubmit: async (values) => {
       try {
         const payload = getPublicationPayload(values);
-        await createPublication(payload);
+        const { data: publication } = await createPublication(payload);
+        await publishPublication({ name: publication.name ?? "" });
 
         closeSidePanel();
 
@@ -280,7 +283,11 @@ const AddPublicationForm: FC = () => {
       </Blocks>
 
       <SidePanelFormButtons
-        submitButtonDisabled={formik.isSubmitting || isCreatingPublication}
+        submitButtonDisabled={
+          formik.isSubmitting ||
+          isCreatingPublication ||
+          isPublishingPublication
+        }
         submitButtonText="Add publication"
         onCancel={closeSidePanel}
       />

--- a/src/features/publications/components/AddPublicationForm/AddPublicationForm.tsx
+++ b/src/features/publications/components/AddPublicationForm/AddPublicationForm.tsx
@@ -283,7 +283,7 @@ const AddPublicationForm: FC = () => {
       </Blocks>
 
       <SidePanelFormButtons
-        submitButtonDisabled={
+        submitButtonLoading={
           formik.isSubmitting ||
           isCreatingPublication ||
           isPublishingPublication

--- a/src/features/publications/components/RepublishPublicationModal/RepublishPublicationModal.tsx
+++ b/src/features/publications/components/RepublishPublicationModal/RepublishPublicationModal.tsx
@@ -25,10 +25,7 @@ const RepublishPublicationModal: FC<RepublishPublicationModalProps> = ({
 
   const handleRepublishPublication = async () => {
     try {
-      await publishPublication({
-        publicationName: publication.name ?? "", // TODO: change when the api is updated
-        body: { forceOverwrite: true },
-      });
+      await publishPublication({ name: publication.name ?? "" });
 
       notify.success({
         title: `You have marked ${publication.displayName} to be republished`,


### PR DESCRIPTION
## Summary

Summarize the changes made in this pull request. Include any relevant context or background information that would help reviewers understand the purpose and scope of the changes.

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
