### PR TITLE
Fix external link icon styling

### DIFF
--- a/.changeset/khaki-clocks-push.md
+++ b/.changeset/khaki-clocks-push.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Fix external link icon styling

--- a/src/styles/partials/base.scss
+++ b/src/styles/partials/base.scss
@@ -1,26 +1,30 @@
 a[target="_blank"] {
   &::after {
     content: "";
-    position: initial;
+    vertical-align: middle;
 
     @extend %icon;
-    @include vf-icon-external-link($color-focus);
-  }
+    @include vf-icon-external-link($colors--light-theme--link-default);
 
-  .is-dark & {
-    &::after {
-      @include vf-icon-external-link($color-focus-dark);
+    .is-dark & {
+      @include vf-icon-external-link($colors--dark-theme--focus);
+    }
+
+    // The CustomSelect highlight background color is the default link color so
+    // we make the text white instead
+    .highlight & {
+      @include vf-icon-external-link($colors--dark-theme--text-default);
     }
   }
 }
 
 body:not(.is-dark) {
-  --vf-color-link-visited: #06c;
+  --vf-color-link-visited: #{$colors--light-theme--link-default};
 }
 
 body.is-dark {
-  --vf-color-link-default: #9cf;
-  --vf-color-link-visited: #9cf;
+  --vf-color-link-default: #{$colors--dark-theme--focus};
+  --vf-color-link-visited: #{$colors--dark-theme--focus};
 }
 
 input:-webkit-autofill,

--- a/src/templates/dashboard/LandscapeActions/LandscapeActions.module.scss
+++ b/src/templates/dashboard/LandscapeActions/LandscapeActions.module.scss
@@ -25,17 +25,3 @@
   font-weight: 550;
   margin-right: $spv--x-small;
 }
-
-.feedbackLink {
-  &:visited {
-    color: $color-link-dark;
-  }
-
-  :global(.is-dark) & {
-    &[target="_blank"] {
-      &::after {
-        @include vf-icon-external-link($color-link-dark);
-      }
-    }
-  }
-}

--- a/src/templates/dashboard/LandscapeActions/LandscapeActions.tsx
+++ b/src/templates/dashboard/LandscapeActions/LandscapeActions.tsx
@@ -37,7 +37,6 @@ const LandscapeActions: FC = () => {
             href={FEEDBACK_LINK}
             target="_blank"
             rel="noreferrer noopener nofollow"
-            className={classes.feedbackLink}
           >
             Share your feedback
           </a>

--- a/src/templates/dashboard/Navigation/Navigation.module.scss
+++ b/src/templates/dashboard/Navigation/Navigation.module.scss
@@ -32,7 +32,7 @@
     background-image: vf-icon-external-link-url(
       $colors--dark-theme--icon
     ) !important;
-    margin-top: $spv--x-small !important;
+    margin-top: 0.375rem !important;
   }
 }
 


### PR DESCRIPTION
## Summary

Befores and Afters
<img width="194" height="46" alt="image" src="https://github.com/user-attachments/assets/6d89b89d-c1c0-42ed-a7f8-794aa04bb353" /> <img width="194" height="46" alt="image" src="https://github.com/user-attachments/assets/2c23c5f8-676a-4365-bce9-0e0832ecc4f3" />
<br />
<img width="233" height="46" alt="image" src="https://github.com/user-attachments/assets/d358bea5-2de7-426c-b039-8f3717de0065" /> <img width="233" height="46" alt="image" src="https://github.com/user-attachments/assets/f63a7d97-537e-4408-83e6-404b544b5576" />
<br />
<img width="233" height="94" alt="image" src="https://github.com/user-attachments/assets/0d1a8d32-203e-4acd-abcc-3fb3cc716cea" /> <img width="233" height="94" alt="image" src="https://github.com/user-attachments/assets/0a6eb5af-7c22-4ebf-baa3-bea06b064f6d" />

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
