### PR TITLE
fix: move account name from API credentials to organization settings [LNDENG-3798]

### DIFF
--- a/.changeset/brave-pugs-search.md
+++ b/.changeset/brave-pugs-search.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Move account name from API credentials to organization settings as a read-only field

--- a/src/features/api-credentials/components/ApiCredentialsTables/ApiCredentialsTables.test.tsx
+++ b/src/features/api-credentials/components/ApiCredentialsTables/ApiCredentialsTables.test.tsx
@@ -64,7 +64,7 @@ describe("ApiCredentialsTables", () => {
 
     expect(screen.getAllByRole("table")).toHaveLength(mockUser.accounts.length);
     mockUser.accounts.forEach((account) => {
-      expect(screen.getByText(account.name)).toBeInTheDocument();
+      expect(screen.queryByText(account.name)).not.toBeInTheDocument();
       expect(screen.getByText(account.roles.join(", "))).toBeInTheDocument();
     });
   });
@@ -80,7 +80,7 @@ describe("ApiCredentialsTables", () => {
     expect(tables).toHaveLength(0);
 
     mockUser.accounts.forEach((account) => {
-      expect(screen.getByText(account.name)).toBeInTheDocument();
+      expect(screen.queryByText(account.name)).not.toBeInTheDocument();
       expect(screen.getByText(account.roles.join(", "))).toBeInTheDocument();
     });
   });

--- a/src/features/api-credentials/components/ApiCredentialsTables/ApiCredentialsTables.tsx
+++ b/src/features/api-credentials/components/ApiCredentialsTables/ApiCredentialsTables.tsx
@@ -66,7 +66,6 @@ const ApiCredentialsTables: FC<ApiCredentialsTablesProps> = ({
     );
 
     const data = [
-      { label: "Name", value: accountCredentials?.account_name },
       { label: "Title", value: accountCredentials?.account_title },
       { label: "Identity", value: <code>{user.identity}</code> },
       {

--- a/src/features/organisation-settings/components/EditOrganisationPreferencesForm/EditOrganisationPreferencesForm.test.tsx
+++ b/src/features/organisation-settings/components/EditOrganisationPreferencesForm/EditOrganisationPreferencesForm.test.tsx
@@ -39,9 +39,12 @@ describe("EditOrganisationPreferencesForm", () => {
     );
 
     expect(container).toHaveTexts([
+      "Account name",
       "Organization's name",
       "Use registration key",
     ]);
+
+    expect(screen.getByText(authUser.current_account)).toBeInTheDocument();
 
     const saveButton = screen.getByRole("button", { name: /save changes/i });
     expect(saveButton).toBeInTheDocument();

--- a/src/features/organisation-settings/components/EditOrganisationPreferencesForm/EditOrganisationPreferencesForm.tsx
+++ b/src/features/organisation-settings/components/EditOrganisationPreferencesForm/EditOrganisationPreferencesForm.tsx
@@ -108,7 +108,7 @@ const EditOrganisationPreferencesForm: FC<
       <ReadOnlyField
         label="Account name"
         value={currentAccount.name}
-        tooltipMessage="The account name is assigned when the account is created and can't be changed. It is used to register clients with Landscape."
+        tooltipMessage="The account name is set when the account is created and can't be changed later. It's used when registering clients with Landscape."
       />
 
       <Input

--- a/src/features/organisation-settings/components/EditOrganisationPreferencesForm/EditOrganisationPreferencesForm.tsx
+++ b/src/features/organisation-settings/components/EditOrganisationPreferencesForm/EditOrganisationPreferencesForm.tsx
@@ -1,5 +1,7 @@
 import buttonClasses from "@/components/form/SidePanelFormButtons/SidePanelFormButtons.module.scss";
+import ReadOnlyField from "@/components/form/ReadOnlyField";
 import useAuth from "@/hooks/useAuth";
+import useAuthAccounts from "@/hooks/useAuthAccounts";
 import useDebug from "@/hooks/useDebug";
 import useNotify from "@/hooks/useNotify";
 import type { Preferences } from "@/types/Preferences";
@@ -26,6 +28,7 @@ const EditOrganisationPreferencesForm: FC<
   EditOrganisationPreferencesFormProps
 > = ({ organisationPreferences }) => {
   const { setUser, user } = useAuth();
+  const { currentAccount } = useAuthAccounts();
   const debug = useDebug();
   const { notify } = useNotify();
   const { changeOrganisationPreferences } = useOrgSettings();
@@ -102,6 +105,12 @@ const EditOrganisationPreferencesForm: FC<
 
   return (
     <Form noValidate onSubmit={formik.handleSubmit}>
+      <ReadOnlyField
+        label="Account name"
+        value={currentAccount.name}
+        tooltipMessage="The account name is assigned when the account is created and can't be changed. It is used to register clients with Landscape."
+      />
+
       <Input
         label="Organization's name"
         type="text"

--- a/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.test.tsx
+++ b/src/pages/auth/handle/ubuntu-one/UbuntuOneAuthPage/UbuntuOneAuthPage.test.tsx
@@ -213,12 +213,13 @@ describe("UbuntuOneAuthPage", () => {
     beforeEach(() => {
       vi.resetModules();
       vi.mocked(useEnv).mockReturnValue(mockSelfHosted);
-      vi.doMock("@/features/account-creation", () => ({
-        useGetStandaloneAccount: () => ({ accountExists: false }),
-      }));
     });
 
     it("should redirect to create-account when user has no accounts and accountExists is false", async () => {
+      vi.doMock("@/features/account-creation", () => ({
+        useGetStandaloneAccount: () => ({ accountExists: false }),
+      }));
+
       mockTestParams({
         ...authUser,
         accounts: [],
@@ -235,7 +236,6 @@ describe("UbuntuOneAuthPage", () => {
     });
 
     it("should redirect to no-access when accountExists is true", async () => {
-      vi.resetModules();
       vi.doMock("@/features/account-creation", () => ({
         useGetStandaloneAccount: () => ({ accountExists: true }),
       }));


### PR DESCRIPTION
## Summary

Jira: [LNDENG-3798](https://warthogs.atlassian.net/browse/LNDENG-3798)

Our documentation uses the term "Account Name", so the API credentials view should not display it as "Name". Since the account name is an organization property (not a user property) and is not needed on the API credentials view, it has been moved to a more intuitive location:

- Removed the "Name" row (`account_name`) from the Organization table in **Account settings → API credentials**.
- Added a read-only "Account name" field to **Org. settings → General**, above "Organization's name", using the existing `ReadOnlyField` component. The account name is not changeable, and the tooltip explains that it is assigned at account creation and used to register clients with Landscape.
- Updated the affected tests.

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [ ] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

[LNDENG-3798]: https://warthogs.atlassian.net/browse/LNDENG-3798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ