### PR TITLE
chore(ci): remove Client-mode TICS job from Validate workflow

### DIFF
--- a/.changeset/remove-tics-client-job.md
+++ b/.changeset/remove-tics-client-job.md
@@ -1,0 +1,4 @@
+---
+---
+
+Remove the lightweight Client-mode TICS job from the Validate workflow.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -208,44 +208,6 @@ jobs:
           path: ${{ github.workspace }}/reports
           retention-days: 30
 
-  tics-report:
-    name: TICS
-    runs-on: ubuntu-latest
-    needs: unit-tests
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Download coverage report artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: vitest-report
-          path: ${{ github.workspace }}/reports
-
-      - name: TICS report
-        uses: tiobe/tics-github-action@v3
-        with:
-          project: landscape-ui
-          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
-          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
-          installTics: true
-
   verify:
     name: Changeset
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Removes the lightweight Client-mode TICS job (`tics-report`) from the `Validate` workflow (`.github/workflows/validate.yml`).

## Why

The per-PR TICS Client-mode warnings add a lot of noise and aren't being acted on. Dropping the job declutters PR checks.

## Notes

- The manual `Full TICS report` workflow (`tics-full.yml`, `workflow_dispatch`) is **kept** for on-demand qserver analysis.
- The `unit-tests` job still runs Vitest with coverage and enforces coverage thresholds, so PR coverage gating is unaffected.
- Includes an empty changeset (CI-only change, no CHANGELOG entry).