### PR TITLE
Fix Ubuntu Pro mirror archive root [LNDENG-4627] [FEBUGS-287]

### DIFF
--- a/.changeset/slick-guests-rest.md
+++ b/.changeset/slick-guests-rest.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Fix Ubuntu Pro mirror archive root

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.test.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.test.tsx
@@ -146,7 +146,9 @@ describe("AddMirrorForm", () => {
     await user.click(screen.getByRole("button", { name: "Add mirror" }));
 
     expect(mockCreateMirror).toHaveBeenCalledExactlyOnceWith(
-      expect.objectContaining({}),
+      expect.objectContaining({
+        archiveRoot: `https://bearer:${token}@esm.ubuntu.com/infra/ubuntu/`,
+      }),
     );
   });
 

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
@@ -49,6 +49,23 @@ const AddMirrorForm: FC = () => {
   const isMirrorContentsLoading =
     ubuntuArchiveQuery.isPending || ubuntuEsmQuery.isPending;
 
+  const getArchiveRoot = (values: FormProps) => {
+    switch (values.sourceType) {
+      case "ubuntu-snapshots":
+        return `https://${UBUNTU_SNAPSHOTS_HOST}/ubuntu/${values.snapshotDate}`;
+
+      case "ubuntu-pro": {
+        const archiveRoot = new URL(values.proService);
+        archiveRoot.username = "bearer";
+        archiveRoot.password = values.token;
+        return archiveRoot.href;
+      }
+
+      default:
+        return values.sourceUrl;
+    }
+  };
+
   const formik = useFormik<FormProps>({
     initialValues: getInitialValues({
       ubuntuArchiveInfo,
@@ -86,13 +103,8 @@ const AddMirrorForm: FC = () => {
 
     onSubmit: async (values) => {
       try {
-        const archiveRoot =
-          values.sourceType === "ubuntu-snapshots"
-            ? `https://${UBUNTU_SNAPSHOTS_HOST}/ubuntu/${values.snapshotDate}`
-            : values.sourceUrl;
-
         const { data: newMirror } = await createMirror({
-          archiveRoot,
+          archiveRoot: getArchiveRoot(values),
           components: values.components.map((component) => component.trim()),
           displayName: values.name,
           architectures: values.architectures.map((architecture) =>
@@ -139,7 +151,7 @@ const AddMirrorForm: FC = () => {
 
   const proServiceOptions: SelectOption[] = ubuntuEsmInfo.map((proService) => ({
     label: proService.label,
-    value: proService.mirror_type,
+    value: proService.mirror_url,
     disabled: !isArchiveInfoValid(proService),
   }));
 

--- a/src/features/mirrors/components/AddMirrorForm/helpers.ts
+++ b/src/features/mirrors/components/AddMirrorForm/helpers.ts
@@ -132,7 +132,7 @@ export const getInitialUbuntuProValues = (
     sourceType: "ubuntu-pro",
     token: "",
     sourceUrl: `https://${UBUNTU_PRO_HOST}/`,
-    proService: firstValidProService ? firstValidProService.mirror_type : "",
+    proService: firstValidProService ? firstValidProService.mirror_url : "",
   };
 };
 

--- a/src/features/mirrors/components/SelectableMirrorContentsBlock/SelectableMirrorContentsBlock.test.tsx
+++ b/src/features/mirrors/components/SelectableMirrorContentsBlock/SelectableMirrorContentsBlock.test.tsx
@@ -10,6 +10,7 @@ import type { FormProps } from "../AddMirrorForm/types";
 import type { ComponentProps } from "react";
 import { hasOneItem } from "@/utils/_helpers";
 import type { Distribution } from "../../types";
+import { screen } from "@testing-library/react";
 
 const TestComponent = ({
   initialValues,
@@ -75,10 +76,12 @@ describe("SelectableMirrorContentsBlock", () => {
           name: "",
           sourceType: "ubuntu-pro",
           sourceUrl: "",
-          proService: proService.mirror_type,
+          proService: proService.mirror_url,
           token: "",
         }}
       />,
     );
+
+    expect(screen.queryAllByRole("combobox")).toHaveLength(0);
   });
 });

--- a/src/features/mirrors/components/SelectableMirrorContentsBlock/SelectableMirrorContentsBlock.tsx
+++ b/src/features/mirrors/components/SelectableMirrorContentsBlock/SelectableMirrorContentsBlock.tsx
@@ -32,7 +32,7 @@ const SelectableMirrorContentsBlock: FC<SelectableMirrorContentsBlockProps> = ({
 
       case "ubuntu-pro": {
         const proService = ubuntuEsmInfo.find(
-          ({ mirror_type }) => mirror_type === formik.values.proService,
+          ({ mirror_url }) => mirror_url === formik.values.proService,
         );
 
         return proService ? proService.distributions : [];


### PR DESCRIPTION
## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
