### PR TITLE
fix: specify which token Ubuntu Pro repo mirrors require [LNDENG-4636]

### DIFF
--- a/.changeset/cuddly-llamas-search.md
+++ b/.changeset/cuddly-llamas-search.md
@@ -2,4 +2,4 @@
 "landscape-ui": patch
 ---
 
-Clarify that the token for Ubuntu Pro repository mirrors is the bearer token from an Ubuntu Pro-attached machine, not the contract token
+Rename the Ubuntu Pro mirror token field to "Bearer token" and clarify that it is not the Ubuntu Pro subscription token

--- a/.changeset/cuddly-llamas-search.md
+++ b/.changeset/cuddly-llamas-search.md
@@ -2,4 +2,4 @@
 "landscape-ui": patch
 ---
 
-Rename the Ubuntu Pro mirror token field to "Bearer token" and clarify that it is not the Ubuntu Pro subscription token
+Rename the Ubuntu Pro mirror token field to "Bearer token", clarify that it is not the Ubuntu Pro subscription token, and mask the entered token

--- a/.changeset/cuddly-llamas-search.md
+++ b/.changeset/cuddly-llamas-search.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Clarify that the token for Ubuntu Pro repository mirrors is the bearer token from an Ubuntu Pro-attached machine, not the contract token

--- a/.changeset/tame-keys-hide.md
+++ b/.changeset/tame-keys-hide.md
@@ -1,5 +1,0 @@
----
-"landscape-ui": patch
----
-
-Mask the Ubuntu Pro bearer token field and disable browser autofill

--- a/.changeset/tame-keys-hide.md
+++ b/.changeset/tame-keys-hide.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Mask the Ubuntu Pro bearer token field and disable browser autofill

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.module.scss
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.module.scss
@@ -11,3 +11,14 @@
 .heading {
   margin-top: 1.5rem;
 }
+
+.maskedInput {
+  /* Mask the entered bearer token without type="password", which browsers
+   * autofill (and offer to generate passwords for) even with autocomplete="off". */
+  /* stylelint-disable-next-line property-no-unknown */
+  -webkit-text-security: disc;
+}
+
+.tooltip {
+  z-index: var(--z-tooltip);
+}

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.test.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.test.tsx
@@ -6,6 +6,7 @@ import {
   screen,
   waitFor,
   waitForElementToBeRemoved,
+  within,
 } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UBUNTU_ARCHIVE_HOST, UBUNTU_SNAPSHOTS_HOST } from "../../constants";
@@ -156,12 +157,24 @@ describe("AddMirrorForm", () => {
       "Ubuntu Pro",
     );
 
-    expect(screen.getByLabelText("Bearer token")).toBeInTheDocument();
+    const tokenInput = screen.getByLabelText("Bearer token");
+    expect(tokenInput).toBeInTheDocument();
+
+    // The explanatory copy now lives in a tooltip on the field label.
+    const helpIcon = document
+      .querySelector(`label[for="${tokenInput.id}"]`)
+      ?.querySelector(".p-icon--help");
+    assert(helpIcon);
+    await user.hover(helpIcon);
+
+    const tooltip = await screen.findByRole("tooltip");
     expect(
-      screen.getByText(/this is not your ubuntu pro subscription token/i),
+      within(tooltip).getByText(
+        /this is not your ubuntu pro subscription token/i,
+      ),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("/etc/apt/auth.conf.d/90ubuntu-advantage"),
+      within(tooltip).getByText("/etc/apt/auth.conf.d/90ubuntu-advantage"),
     ).toBeInTheDocument();
   });
 

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.test.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.test.tsx
@@ -142,7 +142,7 @@ describe("AddMirrorForm", () => {
       "Ubuntu Pro",
     );
 
-    await user.type(screen.getByLabelText("Token"), token);
+    await user.type(screen.getByLabelText("Bearer token"), token);
     await user.click(screen.getByRole("button", { name: "Add mirror" }));
 
     expect(mockCreateMirror).toHaveBeenCalledExactlyOnceWith(
@@ -156,8 +156,9 @@ describe("AddMirrorForm", () => {
       "Ubuntu Pro",
     );
 
+    expect(screen.getByLabelText("Bearer token")).toBeInTheDocument();
     expect(
-      screen.getByText(/use the bearer token for the pro service/i),
+      screen.getByText(/this is not your ubuntu pro subscription token/i),
     ).toBeInTheDocument();
     expect(
       screen.getByText("/etc/apt/auth.conf.d/90ubuntu-advantage"),

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.test.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.test.tsx
@@ -150,6 +150,20 @@ describe("AddMirrorForm", () => {
     );
   });
 
+  it("explains which token an ubuntu pro mirror requires", async () => {
+    await user.selectOptions(
+      screen.getByLabelText("Source type"),
+      "Ubuntu Pro",
+    );
+
+    expect(
+      screen.getByText(/use the bearer token for the pro service/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("/etc/apt/auth.conf.d/90ubuntu-advantage"),
+    ).toBeInTheDocument();
+  });
+
   it("submits a mirror with preserve signatures enabled", async () => {
     await user.click(screen.getByLabelText(/Preserve upstream signing key/));
     await user.click(screen.getByRole("button", { name: "Add mirror" }));

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
@@ -252,6 +252,15 @@ const AddMirrorForm: FC = () => {
                   type="text"
                   label="Token"
                   required
+                  help={
+                    <>
+                      Use the bearer token for the Pro service you want to
+                      mirror, found in{" "}
+                      <code>/etc/apt/auth.conf.d/90ubuntu-advantage</code> on an
+                      Ubuntu Pro-attached machine. This is not your Ubuntu Pro
+                      contract token.
+                    </>
+                  }
                   {...formik.getFieldProps("token")}
                   error={getFormikError(formik, "token")}
                 />

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
@@ -250,7 +250,7 @@ const AddMirrorForm: FC = () => {
               {formik.values.sourceType === "ubuntu-pro" && (
                 <Input
                   type="password"
-                  autoComplete="new-password"
+                  autoComplete="off"
                   label="Bearer token"
                   required
                   help={

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
@@ -250,15 +250,14 @@ const AddMirrorForm: FC = () => {
               {formik.values.sourceType === "ubuntu-pro" && (
                 <Input
                   type="text"
-                  label="Token"
+                  label="Bearer token"
                   required
                   help={
                     <>
                       Use the bearer token for the Pro service you want to
-                      mirror, found in{" "}
-                      <code>/etc/apt/auth.conf.d/90ubuntu-advantage</code> on an
-                      Ubuntu Pro-attached machine. This is not your Ubuntu Pro
-                      contract token.
+                      mirror. This is not your Ubuntu Pro subscription token.
+                      For ESM repositories, your token is found in{" "}
+                      <code>/etc/apt/auth.conf.d/90ubuntu-advantage</code>.
                     </>
                   }
                   {...formik.getFieldProps("token")}

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
@@ -5,9 +5,11 @@ import { getFormikError } from "@/utils/formikErrors";
 import {
   CheckboxInput,
   Form,
+  Icon,
   Input,
   Select,
   Textarea,
+  Tooltip,
 } from "@canonical/react-components";
 import { useFormik } from "formik";
 import { type ComponentProps, type FC, useEffect, useRef } from "react";
@@ -249,18 +251,30 @@ const AddMirrorForm: FC = () => {
               />
               {formik.values.sourceType === "ubuntu-pro" && (
                 <Input
-                  type="password"
+                  type="text"
+                  className={classes.maskedInput}
                   autoComplete="off"
-                  label="Bearer token"
-                  required
-                  help={
+                  label={
                     <>
-                      Use the bearer token for the Pro service you want to
-                      mirror. This is not your Ubuntu Pro subscription token.
-                      For ESM repositories, your token is found in{" "}
-                      <code>/etc/apt/auth.conf.d/90ubuntu-advantage</code>.
+                      <span>Bearer token </span>
+                      <Tooltip
+                        message={
+                          <>
+                            Use the bearer token for the Pro service you want to
+                            mirror. This is not your Ubuntu Pro subscription
+                            token. For ESM repositories, your token is found in{" "}
+                            <code>/etc/apt/auth.conf.d/90ubuntu-advantage</code>
+                            .
+                          </>
+                        }
+                        position="top-center"
+                        tooltipClassName={classes.tooltip}
+                      >
+                        <Icon name="help" />
+                      </Tooltip>
                     </>
                   }
+                  required
                   {...formik.getFieldProps("token")}
                   error={getFormikError(formik, "token")}
                 />

--- a/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
+++ b/src/features/mirrors/components/AddMirrorForm/AddMirrorForm.tsx
@@ -249,7 +249,8 @@ const AddMirrorForm: FC = () => {
               />
               {formik.values.sourceType === "ubuntu-pro" && (
                 <Input
-                  type="text"
+                  type="password"
+                  autoComplete="new-password"
                   label="Bearer token"
                   required
                   help={


### PR DESCRIPTION
## Done

Renamed the **Token** field to **Bearer token** for the **Ubuntu Pro** mirror source type and added help text:

> Use the bearer token for the Pro service you want to mirror. This is not your Ubuntu Pro subscription token. For ESM repositories, your token is found in `/etc/apt/auth.conf.d/90ubuntu-advantage`.

Per the Launchpad report, the field gave no indication of which token to enter (Pro subscription token vs bearer token). [Andrew Stok's comment](https://bugs.launchpad.net/landscape/+bug/2156303) confirms the bearer token is the one required.

Other token fields were checked and intentionally left unchanged:
- `EditMirrorForm` has no token field (the token isn't editable after creation).
- `TokenFormBase` (ubuntupro feature) takes the Pro subscription token for attaching instances — a different token, where the current copy is correct.

Note: the official Landscape docs don't currently cover the Ubuntu Pro mirror source type or its Token field, so there is no docs page to link from the UI — possibly worth flagging to the docs team.

## QA

1. Go to **Repositories > Mirrors > Add mirror**.
2. Select **Ubuntu Pro** as the source type.
3. The Bearer token field now explains which token to use and where to find it.

Ticket: [LNDENG-4636](https://warthogs.atlassian.net/browse/LNDENG-4636)
Launchpad: [#2156303](https://bugs.launchpad.net/landscape/+bug/2156303)

[LNDENG-4636]: https://warthogs.atlassian.net/browse/LNDENG-4636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ