### PR TITLE
Feat: Add LRO information to publications

### DIFF
--- a/.changeset/better-boats-eat.md
+++ b/.changeset/better-boats-eat.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": minor
+---
+
+Add publishing status for publications

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,7 +2,7 @@ name: Validate
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**", "point/**"]
   merge_group:
     types: [checks_requested]
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,3 +45,4 @@ export const MAX_PASSWORD_LENGTH = 50;
 export const DEFAULT_MODAL_PAGE_SIZE = 10;
 export const GENERIC_DOMAIN = "landscape.canonical.com";
 export const MASKED_VALUE = "****************";
+export const DEFAULT_POLLING_INTERVAL = 2000;

--- a/src/features/mirrors/components/MirrorDetails/MirrorDetails.test.tsx
+++ b/src/features/mirrors/components/MirrorDetails/MirrorDetails.test.tsx
@@ -9,8 +9,7 @@ import { expectLoadingState } from "@/tests/helpers";
 import { screen, waitFor, within } from "@testing-library/react";
 import type { Mirror } from "@canonical/landscape-openapi";
 
-const mirrorWithFilter = (mirrors as Mirror[]).find((mirror) => mirror.filter);
-assert(mirrorWithFilter, "Test data should include a mirror with a filter");
+const typedMirrors = mirrors as Mirror[];
 
 describe("MirrorDetails", () => {
   it("renders", async () => {
@@ -64,6 +63,53 @@ describe("MirrorDetails", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders without operation", async () => {
+    const mirrorNoLro = typedMirrors.find(
+      ({ lastOperation }) => !lastOperation,
+    );
+    assert(mirrorNoLro, "Missing mock mirror without lastOperation");
+
+    renderWithProviders(
+      <Suspense fallback={<LoadingState />}>
+        <MirrorDetails />
+      </Suspense>,
+      undefined,
+      `?name=${mirrorNoLro.name}`,
+    );
+
+    await expectLoadingState();
+
+    expect(await screen.findByText("Not yet updated")).toBeInTheDocument();
+  });
+
+  it("renders failed update notification", async () => {
+    const failedMirror = typedMirrors.find(({ lastOperation }) =>
+      lastOperation?.includes("ffff-llll-dddd"),
+    );
+    assert(failedMirror, "Missing mock mirror with a failed operation");
+
+    renderWithProviders(
+      <Suspense fallback={<LoadingState />}>
+        <MirrorDetails />
+      </Suspense>,
+      undefined,
+      `?name=${failedMirror.name}`,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Update failed" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Your last mirror update was not completed successfully.",
+      ),
+    ).toBeInTheDocument();
+
+    expect(screen.getAllByRole("button", { name: "View logs" })).toHaveLength(
+      2,
+    );
+  });
+
   it("renders GPG key fingerprint", async () => {
     renderWithProviders(
       <Suspense fallback={<LoadingState />}>
@@ -107,6 +153,9 @@ describe("MirrorDetails", () => {
   });
 
   it("shows include dependencies in filter field only if mirror has filter", async () => {
+    const mirrorWithFilter = typedMirrors.find(({ filter }) => filter);
+    assert(mirrorWithFilter, "Test data should include a mirror with a filter");
+
     const { container } = renderWithProviders(
       <Suspense fallback={<LoadingState />}>
         <MirrorDetails />
@@ -117,9 +166,9 @@ describe("MirrorDetails", () => {
 
     await expectLoadingState();
 
-    await waitFor(() =>
-      expect(container).toHaveInfoItem("Include dependencies in filter", "Yes"),
-    );
+    await waitFor(() => {
+      expect(container).toHaveInfoItem("Include dependencies in filter", "Yes");
+    });
   });
 
   it("renders packages tab when clicked", async () => {

--- a/src/features/mirrors/components/MirrorDetails/MirrorDetails.tsx
+++ b/src/features/mirrors/components/MirrorDetails/MirrorDetails.tsx
@@ -8,7 +8,10 @@ import usePageParams from "@/hooks/usePageParams";
 import { getSourceType } from "./helpers";
 import MirrorPackagesCount from "../MirrorPackagesCount";
 import moment from "moment";
-import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
+import {
+  DEFAULT_POLLING_INTERVAL,
+  DISPLAY_DATE_TIME_FORMAT,
+} from "@/constants";
 import { boolToLabel } from "@/utils/output";
 import {
   AssociatedPublicationsList,
@@ -30,8 +33,6 @@ import {
 } from "@/features/operations";
 import MirrorDetailsActionBlock from "./components/MirrorDetailsActionBlock";
 
-const POLLING_INTERVAL = 2000;
-
 const MirrorDetails: FC = () => {
   const { name } = usePageParams();
   const [tabId, setTabId] = useState<"details" | "packages">("details");
@@ -42,7 +43,7 @@ const MirrorDetails: FC = () => {
     {
       enabled: !!mirror.lastOperation,
       refetchInterval: ({ state }) =>
-        state.data?.data?.done ? false : POLLING_INTERVAL,
+        state.data?.data?.done ? false : DEFAULT_POLLING_INTERVAL,
     },
   );
   const { publications, isGettingPublications } =
@@ -77,7 +78,7 @@ const MirrorDetails: FC = () => {
     <>
       <SidePanel.Header>{mirror.displayName}</SidePanel.Header>
       <SidePanel.Content>
-        {!!operation && !!operation.error && (
+        {!!operation?.error && (
           <Notification
             severity="negative"
             title="Update failed"
@@ -120,7 +121,10 @@ const MirrorDetails: FC = () => {
                       {!!iconName && (
                         <Icon name={iconName} className={classes.icon} />
                       )}
-                      <OperationStatusCell operation={operation} />
+                      <OperationStatusCell
+                        operation={operation}
+                        type="mirror"
+                      />
                     </>
                   }
                 />

--- a/src/features/mirrors/components/MirrorDetails/components/MirrorDetailsActionBlock/MirrorDetailsActionBlock.test.tsx
+++ b/src/features/mirrors/components/MirrorDetails/components/MirrorDetailsActionBlock/MirrorDetailsActionBlock.test.tsx
@@ -8,6 +8,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useLocation } from "react-router";
 import { inProgressOperation } from "@/tests/mocks/operations";
+import { resetLroProgress } from "@/tests/server/handlers/operations";
 
 const [mirror] = mirrors;
 
@@ -32,6 +33,7 @@ const ComponentWrapper = ({
 describe("MirrorDetailsActionBlock", () => {
   beforeEach(() => {
     setEndpointStatus("default");
+    resetLroProgress();
   });
 
   it("opens UpdateMirrorModal if updateModal param is true", async () => {
@@ -80,7 +82,7 @@ describe("MirrorDetailsActionBlock", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows disabled Updating button with tooltip when operation is in progress", async () => {
+  it("shows disabled Updating button when operation is in progress", async () => {
     renderWithProviders(
       <ComponentWrapper inProgress />,
       undefined,
@@ -90,6 +92,10 @@ describe("MirrorDetailsActionBlock", () => {
     expect(
       await screen.findByRole("button", { name: /Updating/i }),
     ).toHaveAttribute("aria-disabled", "true");
+
+    expect(
+      screen.queryByRole("button", { name: "Update" }),
+    ).not.toBeInTheDocument();
   });
 
   it("opens RemoveMirrorModal when Remove button is clicked", async () => {

--- a/src/features/mirrors/components/MirrorsList/MirrorsList.tsx
+++ b/src/features/mirrors/components/MirrorsList/MirrorsList.tsx
@@ -1,5 +1,8 @@
 import ResponsiveTable from "@/components/layout/ResponsiveTable";
-import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
+import {
+  DEFAULT_POLLING_INTERVAL,
+  DISPLAY_DATE_TIME_FORMAT,
+} from "@/constants";
 import type { Mirror } from "@canonical/landscape-openapi";
 import { Button } from "@canonical/react-components";
 import moment from "moment";
@@ -18,8 +21,6 @@ import {
   getOperationStatusIcon,
 } from "@/features/operations";
 
-const POLL_INTERVAL = 2000;
-
 interface MirrorsListProps {
   readonly mirrors: Mirror[];
   readonly emptyMsg?: string;
@@ -37,7 +38,7 @@ const MirrorsList: FC<MirrorsListProps> = ({ mirrors, emptyMsg }) => {
     {
       refetchInterval: ({ state }) =>
         Object.values(state.data ?? {}).some((operation) => !operation.done)
-          ? POLL_INTERVAL
+          ? DEFAULT_POLLING_INTERVAL
           : false,
     },
   );
@@ -70,6 +71,7 @@ const MirrorsList: FC<MirrorsListProps> = ({ mirrors, emptyMsg }) => {
             <OperationStatusCell
               isGettingOperation={isGettingOperations}
               operation={operation}
+              type="mirror"
             />
           );
         },

--- a/src/features/mirrors/components/MirrorsList/MirrorsList.tsx
+++ b/src/features/mirrors/components/MirrorsList/MirrorsList.tsx
@@ -33,7 +33,7 @@ const MirrorsList: FC<MirrorsListProps> = ({ mirrors, emptyMsg }) => {
     .filter((mirror) => mirror.lastOperation)
     .map((mirror) => mirror.lastOperation ?? "");
 
-  const { operations: operations, isGettingOperations } = useBatchGetOperations(
+  const { operations, isGettingOperations } = useBatchGetOperations(
     operationNames,
     {
       refetchInterval: ({ state }) =>

--- a/src/features/operations/api/index.ts
+++ b/src/features/operations/api/index.ts
@@ -1,2 +1,3 @@
 export * from "./useGetOperation";
 export * from "./useBatchGetOperations";
+export * from "./useGetOperationResource";

--- a/src/features/operations/api/useGetOperationResource.ts
+++ b/src/features/operations/api/useGetOperationResource.ts
@@ -5,20 +5,16 @@ import type { AxiosResponse } from "axios";
 interface OperationResource {
   readonly name: string;
   readonly displayName: string;
-  readonly lastOperation: string;
+  readonly lastOperation?: string;
 }
 
 export const useGetOperationResource = (name: string) => {
   const authFetchDebArchive = useFetchDebArchive();
 
-  const { data, error } = useSuspenseQuery<AxiosResponse<OperationResource>>({
-    queryKey: ["operation", name],
+  const { data } = useSuspenseQuery<AxiosResponse<OperationResource>>({
+    queryKey: ["resource", name],
     queryFn: async () => authFetchDebArchive.get(name),
   });
-
-  if (error) {
-    throw new Error(error.message);
-  }
 
   return data.data;
 };

--- a/src/features/operations/api/useGetOperationResource.ts
+++ b/src/features/operations/api/useGetOperationResource.ts
@@ -1,0 +1,24 @@
+import useFetchDebArchive from "@/hooks/useFetchDebArchive";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import type { AxiosResponse } from "axios";
+
+interface OperationResource {
+  readonly name: string;
+  readonly displayName: string;
+  readonly lastOperation: string;
+}
+
+export const useGetOperationResource = (name: string) => {
+  const authFetchDebArchive = useFetchDebArchive();
+
+  const { data, error } = useSuspenseQuery<AxiosResponse<OperationResource>>({
+    queryKey: ["operation", name],
+    queryFn: async () => authFetchDebArchive.get(name),
+  });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data.data;
+};

--- a/src/features/operations/components/OperationStatusCell/OperationStatusCell.test.tsx
+++ b/src/features/operations/components/OperationStatusCell/OperationStatusCell.test.tsx
@@ -8,30 +8,44 @@ import {
   succeededOperation,
   inProgressOperation,
 } from "@/tests/mocks/operations";
+import { resetLroProgress } from "@/tests/server/handlers/operations";
 
 describe("OperationStatusCell", () => {
   it("renders loading while fetching", () => {
     renderWithProviders(
-      <OperationStatusCell operation={undefined} isGettingOperation={true} />,
+      <OperationStatusCell
+        operation={undefined}
+        isGettingOperation={true}
+        type={"mirror"}
+      />,
     );
 
     expect(screen.getByRole("status")).toBeInTheDocument();
   });
 
   it("renders operation status when operation is undefined", () => {
-    renderWithProviders(<OperationStatusCell operation={undefined} />);
+    renderWithProviders(
+      <OperationStatusCell operation={undefined} type={"mirror"} />,
+    );
 
     expect(screen.getByText("Not yet updated")).toBeInTheDocument();
   });
 
-  it("renders successful operation status", () => {
-    renderWithProviders(<OperationStatusCell operation={succeededOperation} />);
+  it("renders successful publication operation status", () => {
+    renderWithProviders(
+      <OperationStatusCell
+        operation={succeededOperation}
+        type={"publication"}
+      />,
+    );
 
-    expect(screen.getByText("Updated")).toBeInTheDocument();
+    expect(screen.getByText("Published")).toBeInTheDocument();
   });
 
-  it("renders failed operation status", () => {
-    renderWithProviders(<OperationStatusCell operation={failedOperation} />);
+  it("renders failed mirror operation status", () => {
+    renderWithProviders(
+      <OperationStatusCell operation={failedOperation} type={"mirror"} />,
+    );
 
     expect(screen.getByText("Update failed")).toBeInTheDocument();
     expect(
@@ -39,19 +53,23 @@ describe("OperationStatusCell", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders in progress operation status", () => {
+  it("renders in progress mirror operation status", () => {
+    resetLroProgress();
+
     renderWithProviders(
-      <OperationStatusCell operation={inProgressOperation} />,
+      <OperationStatusCell operation={inProgressOperation} type={"mirror"} />,
     );
 
     expect(screen.getByText("Updating")).toBeInTheDocument();
-    expect(screen.getByText("38%")).toBeInTheDocument();
+    expect(screen.getByText("78%")).toBeInTheDocument();
   });
 
-  it("renders in progress operation status for idle operation", () => {
-    renderWithProviders(<OperationStatusCell operation={idleOperation} />);
+  it("renders idle local operation status", () => {
+    renderWithProviders(
+      <OperationStatusCell operation={idleOperation} type={"local"} />,
+    );
 
-    expect(screen.getByText("Updating")).toBeInTheDocument();
+    expect(screen.getByText("Importing packages")).toBeInTheDocument();
     expect(screen.getByText("0%")).toBeInTheDocument();
   });
 });

--- a/src/features/operations/components/OperationStatusCell/OperationStatusCell.test.tsx
+++ b/src/features/operations/components/OperationStatusCell/OperationStatusCell.test.tsx
@@ -3,7 +3,7 @@ import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import OperationStatusCell from "./OperationStatusCell";
 import {
-  failedOperation,
+  failedMirrorOperation,
   idleOperation,
   succeededOperation,
   inProgressOperation,
@@ -44,7 +44,7 @@ describe("OperationStatusCell", () => {
 
   it("renders failed mirror operation status", () => {
     renderWithProviders(
-      <OperationStatusCell operation={failedOperation} type={"mirror"} />,
+      <OperationStatusCell operation={failedMirrorOperation} type={"mirror"} />,
     );
 
     expect(screen.getByText("Update failed")).toBeInTheDocument();

--- a/src/features/operations/components/OperationStatusCell/OperationStatusCell.tsx
+++ b/src/features/operations/components/OperationStatusCell/OperationStatusCell.tsx
@@ -3,42 +3,49 @@ import type { FC } from "react";
 import classes from "./OperationStatusCell.module.scss";
 import ViewLogsButton from "../ViewLogsButton";
 import LoadingState from "@/components/layout/LoadingState";
+import { getOperationTypeTexts } from "./helpers";
 
 interface OperationStatusCellProps {
   readonly operation: Operation | undefined;
   readonly isGettingOperation?: boolean;
+  readonly type: "publication" | "mirror" | "local";
 }
 
 const OperationStatusCell: FC<OperationStatusCellProps> = ({
   operation,
   isGettingOperation = false,
+  type,
 }) => {
   if (isGettingOperation) {
     return <LoadingState inline />;
   }
 
+  const { inexistent, successful, failed, ongoing } =
+    getOperationTypeTexts(type);
   const { status, resource, progressPercent = 0 } = operation?.metadata ?? {};
+  const resourceIdentifier =
+    type === "mirror" ? resource : resource?.split("/").pop();
 
   if (!status) {
-    return "Not yet updated";
+    return inexistent;
   }
 
   if (status === "succeeded") {
-    return "Updated";
+    return successful;
   }
 
   if (status === "failed") {
     return (
       <>
-        <span className={classes.failedText}>Update failed</span>
-        <ViewLogsButton resource={resource} />
+        <span className={classes.failedText}>{failed}</span>
+        <ViewLogsButton resource={resourceIdentifier} />
       </>
     );
   }
 
   return (
     <>
-      Updating
+      {ongoing}
       <div className={classes.progressBar}>
         <div style={{ width: `${progressPercent}%` }} />
       </div>

--- a/src/features/operations/components/OperationStatusCell/helpers.ts
+++ b/src/features/operations/components/OperationStatusCell/helpers.ts
@@ -1,0 +1,34 @@
+interface OperationTypeTexts {
+  inexistent: string;
+  successful: string;
+  failed: string;
+  ongoing: string;
+}
+
+export const getOperationTypeTexts = (
+  type: "publication" | "mirror" | "local",
+): OperationTypeTexts => {
+  switch (type) {
+    case "publication":
+      return {
+        inexistent: "Not yet published",
+        successful: "Published",
+        failed: "Publishing failed",
+        ongoing: "Publishing",
+      };
+    case "local":
+      return {
+        inexistent: "No packages have been imported",
+        successful: "Packages imported",
+        failed: "Import failed",
+        ongoing: "Importing packages",
+      };
+    case "mirror":
+      return {
+        inexistent: "Not yet updated",
+        successful: "Updated",
+        failed: "Update failed",
+        ongoing: "Updating",
+      };
+  }
+};

--- a/src/features/operations/components/ViewLogsSidePanel/ViewLogsSidePanel.test.tsx
+++ b/src/features/operations/components/ViewLogsSidePanel/ViewLogsSidePanel.test.tsx
@@ -8,25 +8,15 @@ import Suspense from "@/components/layout/SidePanel/Suspense";
 import LoadingState from "@/components/layout/SidePanel/LoadingState";
 import { mirrors } from "@/tests/mocks/mirrors";
 import type { Mirror } from "@canonical/landscape-openapi";
+import { publications } from "@/tests/mocks/publications";
 
 const COPIED_FEEDBACK_TIMEOUT = 2010;
 const typedMirrors = mirrors as Mirror[];
 
 const failedMirror = typedMirrors.find(
-  (mirror) => mirror.lastOperation === "operations/ffff-llll-dddd",
+  (mirror) => mirror.lastOperation === "operations/mirror-ffff-llll-dddd",
 );
 assert(failedMirror, "Missing mock mirror with a failed operation");
-
-const ComponentWrapper = ({
-  isTestingCopy = false,
-}: {
-  readonly isTestingCopy?: boolean;
-}) => (
-  <Suspense fallback={<LoadingState />}>
-    <ViewLogsSidePanel />
-    {isTestingCopy && <input type="textbox" />}
-  </Suspense>
-);
 
 describe("ViewLogsSidePanel", () => {
   beforeEach(() => {
@@ -35,7 +25,9 @@ describe("ViewLogsSidePanel", () => {
 
   it("renders loading state when fetching", () => {
     renderWithProviders(
-      <ComponentWrapper />,
+      <Suspense fallback={<LoadingState />}>
+        <ViewLogsSidePanel resourceType="mirrors" />
+      </Suspense>,
       undefined,
       `?sidePath=logs&name=${failedMirror.name}`,
     );
@@ -45,7 +37,9 @@ describe("ViewLogsSidePanel", () => {
 
   it("renders operation logs when available", async () => {
     renderWithProviders(
-      <ComponentWrapper />,
+      <Suspense fallback={<LoadingState />}>
+        <ViewLogsSidePanel resourceType="mirrors" />
+      </Suspense>,
       undefined,
       `?sidePath=logs&name=${failedMirror.name}`,
     );
@@ -64,7 +58,9 @@ describe("ViewLogsSidePanel", () => {
 
   it("displays actions when logs are available", async () => {
     renderWithProviders(
-      <ComponentWrapper />,
+      <Suspense fallback={<LoadingState />}>
+        <ViewLogsSidePanel resourceType="mirrors" />
+      </Suspense>,
       undefined,
       `?sidePath=logs&name=${failedMirror.name}`,
     );
@@ -79,7 +75,7 @@ describe("ViewLogsSidePanel", () => {
     expect(downloadLink).toBeInTheDocument();
     expect(downloadLink).toHaveAttribute(
       "download",
-      `${failedMirror.name}.log`,
+      `${failedMirror.displayName.replaceAll(" ", "-")}_mirror-ffff-llll-dddd.log`,
     );
   });
 
@@ -87,7 +83,9 @@ describe("ViewLogsSidePanel", () => {
     const user = userEvent.setup();
 
     renderWithProviders(
-      <ComponentWrapper isTestingCopy />,
+      <Suspense fallback={<LoadingState />}>
+        <ViewLogsSidePanel resourceType="mirrors" />
+      </Suspense>,
       undefined,
       `?sidePath=logs&name=${failedMirror.name}`,
     );
@@ -115,7 +113,9 @@ describe("ViewLogsSidePanel", () => {
     );
 
     renderWithProviders(
-      <ComponentWrapper />,
+      <Suspense fallback={<LoadingState />}>
+        <ViewLogsSidePanel resourceType="mirrors" />
+      </Suspense>,
       undefined,
       `?sidePath=logs&name=${failedMirror.name}`,
     );
@@ -130,25 +130,32 @@ describe("ViewLogsSidePanel", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows error notification when operation has no error details", async () => {
-    const noLogsMirror = typedMirrors.find(
-      (mirror) => mirror.lastOperation === "operations/ssss-cccc-dddd",
+  it("shows empty state when operation has no error details", async () => {
+    const noLogsPublication = publications.find(
+      (pub) => pub.lastOperation === "operations/ssss-cccc-dddd",
     );
-    assert(noLogsMirror, "Missing mock mirror with a successful operation");
+    assert(
+      noLogsPublication,
+      "Missing mock publication with a successful operation",
+    );
 
     renderWithProviders(
-      <ComponentWrapper />,
+      <Suspense fallback={<LoadingState />}>
+        <ViewLogsSidePanel resourceType="publications" />
+      </Suspense>,
       undefined,
-      `?sidePath=logs&name=${noLogsMirror.name}`,
+      `?sidePath=logs&name=${noLogsPublication.publicationId}`,
     );
 
     await expectLoadingState();
 
     expect(
       await screen.findByRole("heading", {
-        name: "The last update attempt for the selected mirror had no logs.",
+        name: `Publication logs for ${noLogsPublication.displayName}`,
       }),
     ).toBeInTheDocument();
+
+    expect(await screen.findByText("Logs not found")).toBeInTheDocument();
 
     expect(
       screen.queryByRole("button", { name: /copy/i }),
@@ -163,22 +170,13 @@ describe("ViewLogsSidePanel", () => {
     assert(unsyncedMirror, "Missing mock mirror with no lastOperation");
 
     renderWithProviders(
-      <ComponentWrapper />,
+      <Suspense fallback={<LoadingState />}>
+        <ViewLogsSidePanel resourceType="mirrors" />
+      </Suspense>,
       undefined,
       `?sidePath=logs&name=${unsyncedMirror.name}`,
     );
 
-    await expectLoadingState();
-
-    expect(
-      await screen.findByRole("heading", {
-        name: `Update logs for ${unsyncedMirror.displayName}`,
-      }),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByRole("heading", {
-        name: "The selected mirror hasn't had any update attempts yet.",
-      }),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("Logs not found")).toBeInTheDocument();
   });
 });

--- a/src/features/operations/components/ViewLogsSidePanel/ViewLogsSidePanel.test.tsx
+++ b/src/features/operations/components/ViewLogsSidePanel/ViewLogsSidePanel.test.tsx
@@ -71,15 +71,44 @@ describe("ViewLogsSidePanel", () => {
       await screen.findByRole("button", { name: /copy/i }),
     ).toBeInTheDocument();
 
-    const downloadLink = screen.getByRole("link", { name: /download/i });
-    expect(downloadLink).toBeInTheDocument();
-    expect(downloadLink).toHaveAttribute(
-      "download",
-      `${failedMirror.displayName.replaceAll(" ", "-")}_mirror-ffff-llll-dddd.log`,
-    );
+    expect(
+      screen.getByRole("button", { name: /download/i }),
+    ).toBeInTheDocument();
   });
 
-  it("Updates button content when copy button is clicked", async () => {
+  it("downloads the logs file when download button is clicked", async () => {
+    const user = userEvent.setup();
+
+    const anchorClick = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+
+    renderWithProviders(
+      <Suspense fallback={<LoadingState />}>
+        <ViewLogsSidePanel resourceType="mirrors" />
+      </Suspense>,
+      undefined,
+      `?sidePath=logs&name=${failedMirror.name}`,
+    );
+
+    await expectLoadingState();
+
+    const createElementSpy = vi.spyOn(document, "createElement");
+
+    await user.click(await screen.findByRole("button", { name: /download/i }));
+
+    const anchor = createElementSpy.mock.results.find(
+      (result) => result.value instanceof HTMLAnchorElement,
+    )?.value as HTMLAnchorElement;
+
+    expect(anchor).toBeDefined();
+    expect(anchor.download).toBe(
+      "Third-party-mirror_mirror-ffff-llll-dddd.log",
+    );
+    expect(anchorClick).toHaveBeenCalledOnce();
+  });
+
+  it("updates button content when copy button is clicked", async () => {
     const user = userEvent.setup();
 
     renderWithProviders(
@@ -161,7 +190,7 @@ describe("ViewLogsSidePanel", () => {
       screen.queryByRole("button", { name: /copy/i }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("link", { name: /download/i }),
+      screen.queryByRole("button", { name: /download/i }),
     ).not.toBeInTheDocument();
   });
 

--- a/src/features/operations/components/ViewLogsSidePanel/ViewLogsSidePanel.test.tsx
+++ b/src/features/operations/components/ViewLogsSidePanel/ViewLogsSidePanel.test.tsx
@@ -20,7 +20,7 @@ assert(failedMirror, "Missing mock mirror with a failed operation");
 
 describe("ViewLogsSidePanel", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   it("renders loading state when fetching", () => {

--- a/src/features/operations/components/ViewLogsSidePanel/ViewLogsSidePanel.tsx
+++ b/src/features/operations/components/ViewLogsSidePanel/ViewLogsSidePanel.tsx
@@ -1,26 +1,43 @@
 import SidePanel from "@/components/layout/SidePanel";
 import usePageParams from "@/hooks/usePageParams";
-import {
-  Button,
-  CodeSnippet,
-  Icon,
-  Notification,
-} from "@canonical/react-components";
+import { Button, CodeSnippet, Icon } from "@canonical/react-components";
 import { useEffect, useMemo, useRef, useState, type FC } from "react";
-import { useGetOperation } from "../../api";
+import { useGetOperation, useGetOperationResource } from "../../api";
 import classes from "./ViewLogsSidePanel.module.scss";
-import { useGetMirror } from "@/features/mirrors";
+import EmptyState from "@/components/layout/EmptyState";
 
 const COPIED_FEEDBACK_TIMEOUT = 2000;
 
-const ViewLogsSidePanel: FC = () => {
+interface ViewLogsSidePanelProps {
+  readonly resourceType: "mirrors" | "publications" | "locals";
+}
+
+const ViewLogsSidePanel: FC<ViewLogsSidePanelProps> = ({ resourceType }) => {
   const { name } = usePageParams();
-  const mirror = useGetMirror(name).data.data;
+  const resourceIdentifier =
+    resourceType === "mirrors" ? name : `${resourceType}/${name}`;
+  const resource = useGetOperationResource(resourceIdentifier);
   const { operation, isGettingOperation } = useGetOperation(
-    mirror.lastOperation ?? "",
-    { enabled: !!mirror.lastOperation },
+    resource.lastOperation ?? "",
+    { enabled: !!resource.lastOperation },
   );
-  const logs = operation?.error?.details?.join("\n") ?? "";
+
+  const { error: { details } = {}, metadata: { operationId } = {} } =
+    operation ?? {};
+
+  const logs = details?.join("\n") ?? "";
+
+  const getOperationType = () => {
+    switch (resourceType) {
+      case "publications":
+        return "Publication";
+      case "mirrors":
+        return "Update";
+      case "locals":
+        return "Import";
+    }
+  };
+  const operationType = getOperationType();
 
   const [copied, setCopied] = useState(false);
   const copiedTimeoutRef = useRef<number | undefined>(undefined);
@@ -55,33 +72,25 @@ const ViewLogsSidePanel: FC = () => {
     }
   };
 
-  const title = (
-    <SidePanel.Header>Update logs for {mirror.displayName}</SidePanel.Header>
-  );
-
-  if (!mirror.lastOperation) {
-    return (
-      <>
-        {title}
-        <SidePanel.Content>
-          <Notification
-            severity="negative"
-            title="The selected mirror hasn't had any update attempts yet."
-          />
-        </SidePanel.Content>
-      </>
-    );
-  }
-
-  if (isGettingOperation) {
+  if (resource.lastOperation && isGettingOperation) {
     return <SidePanel.LoadingState />;
   }
 
+  const file = `${resource.displayName.replaceAll(" ", "-")}_${operationId}`;
+
   return (
     <>
-      {title}
+      <SidePanel.Header>
+        {operationType} logs for {resource.displayName}
+      </SidePanel.Header>
       <SidePanel.Content>
-        {logs ? (
+        {!logs ? (
+          <EmptyState
+            icon="file"
+            title="Logs not found"
+            body="It seems that the logs you're looking for don't exist."
+          />
+        ) : (
           <>
             <div className={classes.actionRow}>
               <Button
@@ -97,7 +106,7 @@ const ViewLogsSidePanel: FC = () => {
               <a
                 className="p-button--base has-icon u-no-margin--bottom"
                 href={url}
-                download={`${name}.log`}
+                download={`${file}.log`}
               >
                 <Icon name="begin-downloading" />
                 <span>Download</span>
@@ -114,11 +123,6 @@ const ViewLogsSidePanel: FC = () => {
               className={classes.code}
             />
           </>
-        ) : (
-          <Notification
-            severity="negative"
-            title="The last update attempt for the selected mirror had no logs."
-          />
         )}
       </SidePanel.Content>
     </>

--- a/src/features/operations/components/ViewLogsSidePanel/ViewLogsSidePanel.tsx
+++ b/src/features/operations/components/ViewLogsSidePanel/ViewLogsSidePanel.tsx
@@ -1,7 +1,7 @@
 import SidePanel from "@/components/layout/SidePanel";
 import usePageParams from "@/hooks/usePageParams";
 import { Button, CodeSnippet, Icon } from "@canonical/react-components";
-import { useEffect, useMemo, useRef, useState, type FC } from "react";
+import { useEffect, useRef, useState, type FC } from "react";
 import { useGetOperation, useGetOperationResource } from "../../api";
 import classes from "./ViewLogsSidePanel.module.scss";
 import EmptyState from "@/components/layout/EmptyState";
@@ -42,22 +42,25 @@ const ViewLogsSidePanel: FC<ViewLogsSidePanelProps> = ({ resourceType }) => {
   const [copied, setCopied] = useState(false);
   const copiedTimeoutRef = useRef<number | undefined>(undefined);
 
-  const url = useMemo(() => {
-    const blob = new Blob([logs], { type: "text/plain" });
-    return URL.createObjectURL(blob);
-  }, [logs]);
-
   useEffect(() => {
     return () => {
       window.clearTimeout(copiedTimeoutRef.current);
     };
   }, []);
 
-  useEffect(() => {
-    return () => {
-      URL.revokeObjectURL(url);
-    };
-  }, [url]);
+  const fileName = resource.displayName.replaceAll(" ", "-");
+
+  const handleDownload = () => {
+    const blob = new Blob([logs], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${fileName}_${operationId}.log`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
 
   const handleCopy = async () => {
     try {
@@ -75,8 +78,6 @@ const ViewLogsSidePanel: FC<ViewLogsSidePanelProps> = ({ resourceType }) => {
   if (resource.lastOperation && isGettingOperation) {
     return <SidePanel.LoadingState />;
   }
-
-  const file = `${resource.displayName.replaceAll(" ", "-")}_${operationId}`;
 
   return (
     <>
@@ -103,14 +104,16 @@ const ViewLogsSidePanel: FC<ViewLogsSidePanelProps> = ({ resourceType }) => {
                 <Icon name={copied ? "success" : "copy"} />
                 <span>{copied ? "Copied" : "Copy"}</span>
               </Button>
-              <a
-                className="p-button--base has-icon u-no-margin--bottom"
-                href={url}
-                download={`${file}.log`}
+              <Button
+                appearance="base"
+                className="u-no-margin--bottom"
+                hasIcon
+                onClick={handleDownload}
+                type="button"
               >
                 <Icon name="begin-downloading" />
                 <span>Download</span>
-              </a>
+              </Button>
             </div>
             <CodeSnippet
               blocks={[

--- a/src/features/publications/components/PublicationDetails/PublicationDetails.module.scss
+++ b/src/features/publications/components/PublicationDetails/PublicationDetails.module.scss
@@ -1,0 +1,5 @@
+@import "vanilla-framework/scss/settings_spacing";
+
+.icon {
+  margin-right: $sph--small;
+}

--- a/src/features/publications/components/PublicationDetails/PublicationDetails.test.tsx
+++ b/src/features/publications/components/PublicationDetails/PublicationDetails.test.tsx
@@ -10,6 +10,8 @@ import { getSourceType } from "../..";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import moment from "moment";
 import { AUTOMATIC_LABELS } from "../../constants";
+import { expectLoadingState } from "@/tests/helpers";
+import { NO_DATA_TEXT } from "@/components/layout/NoData";
 
 describe("PublicationDetails", () => {
   const user = userEvent.setup();
@@ -22,7 +24,7 @@ describe("PublicationDetails", () => {
     publicationTargets.find((t) => t.name === publication.publicationTarget)
       ?.displayName ?? publication.publicationTarget;
 
-  it("renders all info sections and values", () => {
+  it("renders all info sections and values", async () => {
     const { container } = renderWithProviders(
       <PublicationDetails
         publication={publication}
@@ -31,13 +33,16 @@ describe("PublicationDetails", () => {
       />,
     );
 
+    await expectLoadingState();
+
     const infoItems = [
       { label: "Name", value: publication.displayName },
       { label: "Source type", value: getSourceType(publication.source) },
       { label: "Source", value: sourceDisplayName },
       { label: "Publication target", value: publicationTargetDisplayName },
+      { label: "Status", value: "Published" },
       {
-        label: "Date published",
+        label: "Last published",
         value: moment(publication.publishTime).format(DISPLAY_DATE_TIME_FORMAT),
       },
       { label: "Distribution", value: publication.distribution },
@@ -59,6 +64,79 @@ describe("PublicationDetails", () => {
     }
   });
 
+  it("renders unpublished values", async () => {
+    const { container } = renderWithProviders(
+      <PublicationDetails
+        publication={{
+          ...publication,
+          lastOperation: undefined,
+          publishTime: undefined,
+        }}
+        sourceDisplayName={sourceDisplayName}
+        publicationTargetDisplayName={publicationTargetDisplayName}
+      />,
+    );
+
+    const infoItems = [
+      { label: "Status", value: "Not yet published" },
+      {
+        label: "Last published",
+        value: NO_DATA_TEXT,
+      },
+    ];
+
+    for (const { label, value } of infoItems) {
+      expect(container).toHaveInfoItem(label, value);
+    }
+
+    expect(
+      screen.queryByRole("heading", { name: "Publishing failed" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders failed publication notification", async () => {
+    renderWithProviders(
+      <PublicationDetails
+        publication={manualPublication}
+        sourceDisplayName={sourceDisplayName}
+        publicationTargetDisplayName={publicationTargetDisplayName}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Publishing failed" }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText("Your last publication was not completed successfully."),
+    ).toBeInTheDocument();
+
+    expect(screen.getAllByRole("button", { name: "View logs" })).toHaveLength(
+      2,
+    );
+  });
+
+  it("renders disabled button while publishing", async () => {
+    renderWithProviders(
+      <PublicationDetails
+        publication={publicationWithKey}
+        sourceDisplayName={sourceDisplayName}
+        publicationTargetDisplayName={publicationTargetDisplayName}
+      />,
+    );
+
+    await expectLoadingState();
+
+    expect(
+      screen.queryByRole("button", { name: "Republish" }),
+    ).not.toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: "Publishing" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
   it("renders GPG key fingerprint when it exists", async () => {
     const { container } = renderWithProviders(
       <PublicationDetails
@@ -67,6 +145,8 @@ describe("PublicationDetails", () => {
         publicationTargetDisplayName={publicationTargetDisplayName}
       />,
     );
+
+    await expectLoadingState();
 
     expect(container).toHaveInfoItem(
       "Signing GPG Key",
@@ -83,6 +163,8 @@ describe("PublicationDetails", () => {
       />,
     );
 
+    await expectLoadingState();
+
     expect(container).toHaveInfoItem(
       "Installs and upgrades",
       AUTOMATIC_LABELS.autoUpgrades,
@@ -97,6 +179,8 @@ describe("PublicationDetails", () => {
         publicationTargetDisplayName={publicationTargetDisplayName}
       />,
     );
+
+    await expectLoadingState();
 
     expect(container).toHaveInfoItem(
       "Installs and upgrades",
@@ -114,11 +198,9 @@ describe("PublicationDetails", () => {
     );
     const publicationDisplayName = publication.displayName;
 
-    await user.click(
-      screen.getByRole("button", {
-        name: `Republish ${publicationDisplayName}`,
-      }),
-    );
+    await expectLoadingState();
+
+    await user.click(screen.getByRole("button", { name: "Republish" }));
 
     expect(
       screen.getByRole("heading", {
@@ -137,9 +219,9 @@ describe("PublicationDetails", () => {
     );
     const publicationDisplayName = publication.displayName;
 
-    await user.click(
-      screen.getByRole("button", { name: `Remove ${publicationDisplayName}` }),
-    );
+    await expectLoadingState();
+
+    await user.click(screen.getByRole("button", { name: "Remove" }));
 
     expect(
       screen.getByRole("heading", { name: `Remove ${publicationDisplayName}` }),

--- a/src/features/publications/components/PublicationDetails/PublicationDetails.test.tsx
+++ b/src/features/publications/components/PublicationDetails/PublicationDetails.test.tsx
@@ -12,6 +12,7 @@ import moment from "moment";
 import { AUTOMATIC_LABELS } from "../../constants";
 import { expectLoadingState } from "@/tests/helpers";
 import { NO_DATA_TEXT } from "@/components/layout/NoData";
+import { resetLroProgress } from "@/tests/server/handlers/operations";
 
 describe("PublicationDetails", () => {
   const user = userEvent.setup();
@@ -117,6 +118,8 @@ describe("PublicationDetails", () => {
   });
 
   it("renders disabled button while publishing", async () => {
+    resetLroProgress();
+
     renderWithProviders(
       <PublicationDetails
         publication={publicationWithKey}

--- a/src/features/publications/components/PublicationDetails/PublicationDetails.tsx
+++ b/src/features/publications/components/PublicationDetails/PublicationDetails.tsx
@@ -30,8 +30,8 @@ import classes from "./PublicationDetails.module.scss";
 
 interface PublicationDetailsProps {
   readonly publication: Publication;
-  readonly sourceDisplayName?: string;
-  readonly publicationTargetDisplayName?: string;
+  readonly sourceDisplayName: string;
+  readonly publicationTargetDisplayName: string;
 }
 
 const PublicationDetails = ({

--- a/src/features/publications/components/PublicationDetails/PublicationDetails.tsx
+++ b/src/features/publications/components/PublicationDetails/PublicationDetails.tsx
@@ -2,14 +2,31 @@ import Blocks from "@/components/layout/Blocks";
 import InfoGrid from "@/components/layout/InfoGrid";
 import { boolToLabel } from "@/utils/output";
 import type { Publication } from "@canonical/landscape-openapi";
-import { Button, Icon, ICONS } from "@canonical/react-components";
+import {
+  Button,
+  Icon,
+  ICONS,
+  Notification,
+  Tooltip,
+} from "@canonical/react-components";
 import { useBoolean } from "usehooks-ts";
 import RemovePublicationModal from "../RemovePublicationModal";
 import RepublishPublicationModal from "../RepublishPublicationModal";
 import { getInstallsAndUpgradesText, getSourceType } from "../../helpers";
-import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
+import {
+  DISPLAY_DATE_TIME_FORMAT,
+  DEFAULT_POLLING_INTERVAL,
+} from "@/constants";
 import moment from "moment";
 import { NO_DATA_TEXT } from "@/components/layout/NoData/constants";
+import {
+  getOperationStatusIcon,
+  OperationStatusCell,
+  useGetOperation,
+  ViewLogsButton,
+} from "@/features/operations";
+import LoadingState from "@/components/layout/LoadingState";
+import classes from "./PublicationDetails.module.scss";
 
 interface PublicationDetailsProps {
   readonly publication: Publication;
@@ -34,32 +51,70 @@ const PublicationDetails = ({
     setFalse: closeRepublishModal,
   } = useBoolean();
 
+  const { operation, isGettingOperation } = useGetOperation(
+    publication.lastOperation ?? "",
+    {
+      enabled: !!publication.lastOperation,
+      refetchInterval: ({ state }) =>
+        state.data?.data?.done ? false : DEFAULT_POLLING_INTERVAL,
+    },
+  );
+
+  if (publication.lastOperation && isGettingOperation) {
+    return <LoadingState />;
+  }
+
+  const iconName = getOperationStatusIcon(operation);
+
   return (
     <>
-      <div
-        className="p-segmented-control"
-        style={{
-          marginBottom: "1.5rem",
-        }}
-      >
-        <div className="p-segmented-control__list">
-          <Button
-            type="button"
-            className="p-segmented-control__button"
-            onClick={openRepublishModal}
-            hasIcon
-            aria-label={`Republish ${publication.displayName}`}
+      <div className="p-segmented-control u-sv2">
+        {!!operation?.error && (
+          <Notification
+            severity="negative"
+            title="Publishing failed"
+            actions={[
+              <ViewLogsButton
+                resource={publication.publicationId}
+                key="view-logs"
+              />,
+            ]}
           >
-            <Icon name="upload" />
-            <span>Republish</span>
-          </Button>
-
+            Your last publication was not completed successfully.
+          </Notification>
+        )}
+        <div className="p-segmented-control__list">
+          {operation && !operation.done ? (
+            <Tooltip
+              message="You must wait for this action to be completed to republish it."
+              position="btm-center"
+            >
+              <Button
+                type="button"
+                hasIcon
+                className="p-segmented-control__button"
+                disabled
+              >
+                <Icon name="spinner" className="u-animation--spin" />
+                <span>Publishing</span>
+              </Button>
+            </Tooltip>
+          ) : (
+            <Button
+              type="button"
+              className="p-segmented-control__button"
+              onClick={openRepublishModal}
+              hasIcon
+            >
+              <Icon name="upload" />
+              <span>Republish</span>
+            </Button>
+          )}
           <Button
             type="button"
             className="p-segmented-control__button"
             onClick={openRemoveModal}
             hasIcon
-            aria-label={`Remove ${publication.displayName}`}
           >
             <Icon name={`${ICONS.delete}--negative`} />
             <span className="u-text--negative">Remove</span>
@@ -70,22 +125,34 @@ const PublicationDetails = ({
       <Blocks>
         <Blocks.Item title="Details">
           <InfoGrid dense>
-            <InfoGrid.Item label="Name" large value={publication.displayName} />
-
-            <InfoGrid.Item
-              label="Source type"
-              value={getSourceType(publication.source)}
-            />
-
-            <InfoGrid.Item label="Source" value={sourceDisplayName} />
-
+            <InfoGrid.Item label="Name" value={publication.displayName} />
             <InfoGrid.Item
               label="Publication target"
               value={publicationTargetDisplayName}
             />
 
             <InfoGrid.Item
-              label="Date published"
+              label="Source type"
+              value={getSourceType(publication.source)}
+            />
+            <InfoGrid.Item label="Source" value={sourceDisplayName} />
+
+            <InfoGrid.Item
+              label="Status"
+              value={
+                <>
+                  {!!iconName && (
+                    <Icon name={iconName} className={classes.icon} />
+                  )}
+                  <OperationStatusCell
+                    operation={operation}
+                    type="publication"
+                  />
+                </>
+              }
+            />
+            <InfoGrid.Item
+              label="Last published"
               value={
                 publication.publishTime
                   ? moment(publication.publishTime).format(

--- a/src/features/publications/components/PublicationsList/PublicationsList.module.scss
+++ b/src/features/publications/components/PublicationsList/PublicationsList.module.scss
@@ -1,0 +1,3 @@
+.status {
+  width: 15rem;
+}

--- a/src/features/publications/components/PublicationsList/PublicationsList.test.tsx
+++ b/src/features/publications/components/PublicationsList/PublicationsList.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import PublicationsList from "./PublicationsList";
 import { mirrors } from "@/tests/mocks/mirrors";
 import { NO_DATA_TEXT } from "@/components/layout/NoData";
+import { resetLroProgress } from "@/tests/server/handlers/operations";
 
 const buildDisplayNameMaps = (pubs: typeof publications) => {
   const sourceDisplayNames: Record<string, string> = {};
@@ -31,6 +32,8 @@ describe("PublicationsList", () => {
     buildDisplayNameMaps(publications);
 
   it("renders list columns and row data", async () => {
+    resetLroProgress();
+
     renderWithProviders(
       <PublicationsList
         publications={publications}

--- a/src/features/publications/components/PublicationsList/PublicationsList.test.tsx
+++ b/src/features/publications/components/PublicationsList/PublicationsList.test.tsx
@@ -5,6 +5,7 @@ import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import PublicationsList from "./PublicationsList";
 import { mirrors } from "@/tests/mocks/mirrors";
+import { NO_DATA_TEXT } from "@/components/layout/NoData";
 
 const buildDisplayNameMaps = (pubs: typeof publications) => {
   const sourceDisplayNames: Record<string, string> = {};
@@ -29,7 +30,7 @@ describe("PublicationsList", () => {
   const { sourceDisplayNames, publicationTargetDisplayNames } =
     buildDisplayNameMaps(publications);
 
-  it("renders list columns and row data", () => {
+  it("renders list columns and row data", async () => {
     renderWithProviders(
       <PublicationsList
         publications={publications}
@@ -39,6 +40,10 @@ describe("PublicationsList", () => {
     );
 
     expect(screen.getByRole("columnheader", { name: "name" })).toBeVisible();
+    expect(screen.getByRole("columnheader", { name: "status" })).toBeVisible();
+    expect(
+      screen.getByRole("columnheader", { name: "last published" }),
+    ).toBeVisible();
     expect(
       screen.getByRole("columnheader", { name: "source type" }),
     ).toBeVisible();
@@ -52,6 +57,12 @@ describe("PublicationsList", () => {
         name: publication.displayName,
       }),
     ).toBeInTheDocument();
+
+    expect(await screen.findByText("Publishing")).toBeInTheDocument();
+    expect(screen.getByText("Published")).toBeInTheDocument();
+    expect(screen.getByText("Publishing failed")).toBeInTheDocument();
+
+    expect(screen.getByText("Mar 12, 2026, 00:00")).toBeInTheDocument();
 
     const mirrorsCount = publications.filter((pub) =>
       pub.source.startsWith("mirrors/"),
@@ -72,6 +83,25 @@ describe("PublicationsList", () => {
         name: publicationTargetDisplayNames[publication.publicationTarget],
       }),
     ).toBeInTheDocument();
+  });
+
+  it("renders status cell for no operation as fallback", async () => {
+    renderWithProviders(
+      <PublicationsList
+        publications={[
+          {
+            ...publication,
+            lastOperation: undefined,
+            publishTime: undefined,
+          },
+        ]}
+        sourceDisplayNames={sourceDisplayNames}
+        publicationTargetDisplayNames={publicationTargetDisplayNames}
+      />,
+    );
+
+    expect(screen.getByText("Not yet published")).toBeInTheDocument();
+    expect(screen.getByText(NO_DATA_TEXT)).toBeInTheDocument();
   });
 
   it("shows empty message with search query", () => {

--- a/src/features/publications/components/PublicationsList/PublicationsList.tsx
+++ b/src/features/publications/components/PublicationsList/PublicationsList.tsx
@@ -44,7 +44,7 @@ const PublicationsList: FC<PublicationsListProps> = ({
     .filter((publication) => publication.lastOperation)
     .map((publication) => publication.lastOperation ?? "");
 
-  const { operations: operations, isGettingOperations } = useBatchGetOperations(
+  const { operations, isGettingOperations } = useBatchGetOperations(
     operationNames,
     {
       refetchInterval: ({ state }) =>

--- a/src/features/publications/components/PublicationsList/PublicationsList.tsx
+++ b/src/features/publications/components/PublicationsList/PublicationsList.tsx
@@ -13,10 +13,19 @@ import {
   getSourceType,
 } from "../../helpers";
 import type { Publication } from "@canonical/landscape-openapi";
-import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
+import {
+  DEFAULT_POLLING_INTERVAL,
+  DISPLAY_DATE_TIME_FORMAT,
+} from "@/constants";
 import moment from "moment";
 import { ROUTES } from "@/libs/routes";
 import { NO_DATA_TEXT } from "@/components/layout/NoData";
+import {
+  getOperationStatusIcon,
+  OperationStatusCell,
+  useBatchGetOperations,
+} from "@/features/operations";
+import classes from "./PublicationsList.module.scss";
 
 interface PublicationsListProps {
   readonly publications: Publication[];
@@ -30,6 +39,21 @@ const PublicationsList: FC<PublicationsListProps> = ({
   publicationTargetDisplayNames = {},
 }) => {
   const { query, createPageParamsSetter } = usePageParams();
+
+  const operationNames = publications
+    .filter((publication) => publication.lastOperation)
+    .map((publication) => publication.lastOperation ?? "");
+
+  const { operations: operations, isGettingOperations } = useBatchGetOperations(
+    operationNames,
+    {
+      refetchInterval: ({ state }) =>
+        Object.values(state.data ?? {}).some((operation) => !operation.done)
+          ? DEFAULT_POLLING_INTERVAL
+          : false,
+    },
+  );
+
   const columns = useMemo<Column<Publication>[]>(
     () => [
       {
@@ -48,6 +72,35 @@ const PublicationsList: FC<PublicationsListProps> = ({
             {row.original.displayName}
           </Button>
         ),
+      },
+      {
+        Header: "status",
+        className: classes.status,
+        Cell: ({ row: { original: publication } }: CellProps<Publication>) => {
+          const operation = operations[publication.lastOperation ?? ""];
+          return (
+            <OperationStatusCell
+              isGettingOperation={isGettingOperations}
+              operation={operation}
+              type="publication"
+            />
+          );
+        },
+        getCellIcon: ({
+          row: { original: publication },
+        }: CellProps<Publication>) => {
+          const operation = operations[publication.lastOperation ?? ""];
+          return getOperationStatusIcon(operation);
+        },
+      },
+      {
+        accessor: "publishTime",
+        Header: "last published",
+        className: "medium-cell",
+        Cell: ({ row: { original } }: CellProps<Publication>) =>
+          original.publishTime
+            ? moment(original.publishTime).format(DISPLAY_DATE_TIME_FORMAT)
+            : NO_DATA_TEXT,
       },
       {
         id: "sourceType",
@@ -98,21 +151,19 @@ const PublicationsList: FC<PublicationsListProps> = ({
         ),
       },
       {
-        accessor: "publishTime",
-        Header: "Date published",
-        Cell: ({ row: { original } }: CellProps<Publication>) =>
-          original.publishTime
-            ? moment(original.publishTime).format(DISPLAY_DATE_TIME_FORMAT)
-            : NO_DATA_TEXT,
-      },
-      {
         ...LIST_ACTIONS_COLUMN_PROPS,
         Cell: ({ row: { original } }: CellProps<Publication>) => (
           <PublicationsListActions publication={original} />
         ),
       },
     ],
-    [createPageParamsSetter, sourceDisplayNames, publicationTargetDisplayNames],
+    [
+      createPageParamsSetter,
+      operations,
+      isGettingOperations,
+      sourceDisplayNames,
+      publicationTargetDisplayNames,
+    ],
   );
 
   return (
@@ -120,6 +171,7 @@ const PublicationsList: FC<PublicationsListProps> = ({
       columns={columns}
       data={publications}
       emptyMsg={`No publications found with the search: "${query}"`}
+      minWidth={1250}
     />
   );
 };

--- a/src/pages/dashboard/repositories/mirrors/MirrorsPage.test.tsx
+++ b/src/pages/dashboard/repositories/mirrors/MirrorsPage.test.tsx
@@ -148,4 +148,29 @@ describe("MirrorsPage", () => {
       }),
     ).toBeInTheDocument();
   });
+
+  it("renders the logs side panel when sidePath=logs is in the URL", async () => {
+    setScreenSize("xxl");
+
+    renderWithProviders(
+      <Suspense fallback={<LoadingState />}>
+        <MirrorsPage />
+      </Suspense>,
+      undefined,
+      "/?sidePath=logs&name=mirrors/third-party-mirror",
+    );
+
+    await expectLoadingState();
+
+    expect(
+      await screen.findByRole("heading", {
+        name: /Update logs for Third party mirror/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      await within(screen.getByLabelText("Side panel")).findByRole("button", {
+        name: /copy/i,
+      }),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/pages/dashboard/repositories/mirrors/MirrorsPage.tsx
+++ b/src/pages/dashboard/repositories/mirrors/MirrorsPage.tsx
@@ -128,7 +128,7 @@ const MirrorsPage: FC = () => {
         )}
         {lastSidePathSegment === "logs" && (
           <SidePanel.Suspense key="logs">
-            <ViewLogsSidePanel />
+            <ViewLogsSidePanel resourceType="mirrors" />
           </SidePanel.Suspense>
         )}
       </SidePanel>

--- a/src/pages/dashboard/repositories/publications/PublicationsPage.test.tsx
+++ b/src/pages/dashboard/repositories/publications/PublicationsPage.test.tsx
@@ -44,10 +44,10 @@ describe("PublicationsPage", () => {
       "/?sidePath=view&name=7b1d5c2f-0c4e-4d8e-8f2f-99d4f2d9a123",
     );
 
-    await expectLoadingState();
+    const sidePanel = await screen.findByLabelText("Side panel");
 
     expect(
-      await within(screen.getByLabelText("Side panel")).findByRole(
+      await within(sidePanel).findByRole(
         "button",
         { name: /republish/i },
         { timeout: 2000 },

--- a/src/pages/dashboard/repositories/publications/PublicationsPage.test.tsx
+++ b/src/pages/dashboard/repositories/publications/PublicationsPage.test.tsx
@@ -44,10 +44,37 @@ describe("PublicationsPage", () => {
       "/?sidePath=view&name=7b1d5c2f-0c4e-4d8e-8f2f-99d4f2d9a123",
     );
 
+    await expectLoadingState();
+
     expect(
-      await within(screen.getByLabelText("Side panel")).findByRole("button", {
-        name: /republish/i,
+      await within(screen.getByLabelText("Side panel")).findByRole(
+        "button",
+        { name: /republish/i },
+        { timeout: 2000 },
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the logs side panel when sidePath=logs is in the URL", async () => {
+    setScreenSize("xxl");
+
+    renderWithProviders(
+      <PublicationsPage />,
+      undefined,
+      "/?sidePath=logs&name=g8h8888e-c8f8-8e88-ab8c-ef8a8c8af8c8",
+    );
+
+    await expectLoadingState();
+
+    const sidePanel = screen.getByLabelText("Side panel");
+
+    expect(
+      await within(sidePanel).findByRole("heading", {
+        name: /Publication logs for local publication/i,
       }),
+    ).toBeInTheDocument();
+    expect(
+      within(sidePanel).getByRole("button", { name: /copy/i }),
     ).toBeInTheDocument();
   });
 });

--- a/src/pages/dashboard/repositories/publications/PublicationsPage.test.tsx
+++ b/src/pages/dashboard/repositories/publications/PublicationsPage.test.tsx
@@ -64,9 +64,7 @@ describe("PublicationsPage", () => {
       "/?sidePath=logs&name=g8h8888e-c8f8-8e88-ab8c-ef8a8c8af8c8",
     );
 
-    await expectLoadingState();
-
-    const sidePanel = screen.getByLabelText("Side panel");
+    const sidePanel = await screen.findByLabelText("Side panel");
 
     expect(
       await within(sidePanel).findByRole("heading", {

--- a/src/pages/dashboard/repositories/publications/PublicationsPage.tsx
+++ b/src/pages/dashboard/repositories/publications/PublicationsPage.tsx
@@ -14,16 +14,25 @@ const PublicationDetailsSidePanel = lazy(
     import("@/features/publications/components/PublicationDetailsSidePanel"),
 );
 
+const ViewLogsSidePanel = lazy(
+  async () => import("@/features/operations/components/ViewLogsSidePanel"),
+);
+
 const PublicationsPage: FC = () => {
   const { sidePath, lastSidePathSegment, popSidePathUntilClear } =
     usePageParams();
 
-  useSetDynamicFilterValidation("sidePath", ["add", "add-target", "view"]);
+  useSetDynamicFilterValidation("sidePath", ["add", "view", "logs"]);
+
   return (
     <PageMain>
       <PublicationsContainer />
 
-      <SidePanel isOpen={!!sidePath.length} onClose={popSidePathUntilClear}>
+      <SidePanel
+        isOpen={!!sidePath.length}
+        onClose={popSidePathUntilClear}
+        size={lastSidePathSegment === "logs" ? "medium" : "small"}
+      >
         {lastSidePathSegment === "add" && (
           <SidePanel.Suspense key="add">
             <SidePanel.Header>Add publication</SidePanel.Header>
@@ -35,6 +44,11 @@ const PublicationsPage: FC = () => {
         {lastSidePathSegment === "view" && (
           <SidePanel.Suspense key="view">
             <PublicationDetailsSidePanel />
+          </SidePanel.Suspense>
+        )}
+        {lastSidePathSegment === "logs" && (
+          <SidePanel.Suspense key="logs">
+            <ViewLogsSidePanel resourceType="publications" />
           </SidePanel.Suspense>
         )}
       </SidePanel>

--- a/src/tests/mocks/mirrors.ts
+++ b/src/tests/mocks/mirrors.ts
@@ -50,7 +50,7 @@ export const mirrors = [
     filter: "!package1 | !package2",
     filterWithDeps: true,
     lastDownloadDate: new Date("2024-05-01T12:00:00Z"),
-    lastOperation: "operations/ffff-llll-dddd",
+    lastOperation: "operations/mirror-ffff-llll-dddd",
   },
   {
     name: "mirrors/unsynced-mirror",

--- a/src/tests/mocks/operations.ts
+++ b/src/tests/mocks/operations.ts
@@ -55,7 +55,7 @@ export const failedOperation: FailedOperation = {
     operationId: "ffff-llll-dddd",
     status: "failed",
     progressPercent: 62,
-    resource: "mirrors/third-party-mirror",
+    resource: "locals/cccc-dddd-eeee",
   },
   done: true,
   error: {
@@ -99,7 +99,7 @@ export const timeoutOperation: FailedOperation = {
       "Validate import into local repo Noble Security Patches (e755a4bd-8044-4529-8b5d-53f1c3887e9e)",
     operationId: "tttt-mmmm-oooo",
     status: "failed",
-    progressPercent: 79,
+    progressPercent: 39,
     resource: "locals/e755a4bd-8044-4529-8b5d-53f1c3887e9e",
   },
   done: true,
@@ -120,7 +120,7 @@ export const inProgressOperation: UnfinishedOperation = {
       "Validate import into local repo Noble Security Patches (e755a4bd-8044-4529-8b5d-53f1c3887e9e)",
     operationId: "pppp-gggg-ssss",
     status: "in progress",
-    progressPercent: 38,
+    progressPercent: 78,
     resource: "locals/e755a4bd-8044-4529-8b5d-53f1c3887e9e",
   },
   done: false,
@@ -272,6 +272,96 @@ export const overCountOperation: SuccessfulOperation = {
   },
 };
 
+export const failedMirrorOperation: FailedOperation = {
+  name: "operations/mirror-ffff-llll-dddd",
+  metadata: {
+    "@type":
+      "type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskMetadata",
+    description:
+      "Validate import into local repo Noble Security Patches (e755a4bd-8044-4529-8b5d-53f1c3887e9e)",
+    operationId: "mirror-ffff-llll-dddd",
+    status: "failed",
+    progressPercent: 62,
+    resource: "mirrors/third-party-mirror",
+  },
+  done: true,
+  error: {
+    code: 13,
+    message: "The operation failed unexpectedly.",
+    details: [
+      "0% [Working]",
+      "0% [Connecting to 10.0.1.13]",
+      "0% [Waiting for headers]",
+      "Get:1 http://us.archive.ubuntu.com/ubuntu/ trusty-updates/main libssl-dev amd64 1.0.1f-1ubuntu2.2 [1066 kB]",
+      "0% [1 libssl-dev 2465 B/1066 kB 0%]",
+      "1% [1 libssl-dev 21.9 kB/1066 kB 2%]",
+      "15% [1 libssl-dev 749 kB/1066 kB 70%]",
+      "21% [Working]",
+      "21% [Waiting for headers]",
+      "Get:2 http://us.archive.ubuntu.com/ubuntu/ trusty-updates/main libssl1.0.0 i386 1.0.1f-1ubuntu2.2 [779 kB]",
+      "21% [2 libssl1.0.0:i386 1080 B/779 kB 0%]",
+      "36% [Working]",
+      "36% [Waiting for headers]",
+      "Get:3 http://us.archive.ubuntu.com/ubuntu/ trusty-updates/main libssl1.0.0 amd64 1.0.1f-1ubuntu2.2 [826 kB]",
+      "36% [3 libssl1.0.0 1080 B/826 kB 0%]",
+      "39% [3 libssl1.0.0 129 kB/826 kB 15%]",
+      "52% [Working]",
+      "52% [Waiting for headers]",
+      "Get:4 http://us.archive.ubuntu.com/ubuntu/ trusty-updates/main openssl amd64 1.0.1f-1ubuntu2.2 [488 kB]",
+      "52% [4 openssl 2468 B/488 kB 0%]",
+      "62% [Working]",
+      "62% [Waiting for headers]",
+      "Get:5 http://us.archive.ubuntu.com/ubuntu/ trusty-updates/main unity amd64 7.2.1+14.04.20140513-0ubuntu2 [1452 kB]",
+      "62% [5 unity 1078 B/1452 kB 0%]",
+    ],
+  },
+};
+
+export const failedPublicationOperation: FailedOperation = {
+  name: "operations/publication-ffff-llll-dddd",
+  metadata: {
+    "@type":
+      "type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskMetadata",
+    description:
+      "Validate import into local repo Noble Security Patches (e755a4bd-8044-4529-8b5d-53f1c3887e9e)",
+    operationId: "publication-ffff-llll-dddd",
+    status: "failed",
+    progressPercent: 62,
+    resource: "publications/g8h8888e-c8f8-8e88-ab8c-ef8a8c8af8c8",
+  },
+  done: true,
+  error: {
+    code: 13,
+    message: "The operation failed unexpectedly.",
+    details: [
+      "0% [Working]",
+      "0% [Connecting to 10.0.1.13]",
+      "0% [Waiting for headers]",
+      "Get:1 http://us.archive.ubuntu.com/ubuntu/ trusty-updates/main libssl-dev amd64 1.0.1f-1ubuntu2.2 [1066 kB]",
+      "0% [1 libssl-dev 2465 B/1066 kB 0%]",
+      "1% [1 libssl-dev 21.9 kB/1066 kB 2%]",
+      "15% [1 libssl-dev 749 kB/1066 kB 70%]",
+      "21% [Working]",
+      "21% [Waiting for headers]",
+      "Get:2 http://us.archive.ubuntu.com/ubuntu/ trusty-updates/main libssl1.0.0 i386 1.0.1f-1ubuntu2.2 [779 kB]",
+      "21% [2 libssl1.0.0:i386 1080 B/779 kB 0%]",
+      "36% [Working]",
+      "36% [Waiting for headers]",
+      "Get:3 http://us.archive.ubuntu.com/ubuntu/ trusty-updates/main libssl1.0.0 amd64 1.0.1f-1ubuntu2.2 [826 kB]",
+      "36% [3 libssl1.0.0 1080 B/826 kB 0%]",
+      "39% [3 libssl1.0.0 129 kB/826 kB 15%]",
+      "52% [Working]",
+      "52% [Waiting for headers]",
+      "Get:4 http://us.archive.ubuntu.com/ubuntu/ trusty-updates/main openssl amd64 1.0.1f-1ubuntu2.2 [488 kB]",
+      "52% [4 openssl 2468 B/488 kB 0%]",
+      "62% [Working]",
+      "62% [Waiting for headers]",
+      "Get:5 http://us.archive.ubuntu.com/ubuntu/ trusty-updates/main unity amd64 7.2.1+14.04.20140513-0ubuntu2 [1452 kB]",
+      "62% [5 unity 1078 B/1452 kB 0%]",
+    ],
+  },
+};
+
 export const operations: Operation[] = [
   idleOperation,
   succeededOperation,
@@ -280,4 +370,6 @@ export const operations: Operation[] = [
   inProgressOperation,
   emptyOperation,
   overCountOperation,
+  failedMirrorOperation,
+  failedPublicationOperation,
 ];

--- a/src/tests/mocks/publications.ts
+++ b/src/tests/mocks/publications.ts
@@ -21,6 +21,7 @@ export const publications = [
     skipBz2: false,
     skipContents: false,
     publishTime: new Date("March 12, 2026"),
+    lastOperation: "operations/ssss-cccc-dddd",
   },
   {
     name: "publications/c9f6355e-c8f3-4e73-ab4c-ef6a4c8af4c0",
@@ -43,7 +44,8 @@ export const publications = [
       armor: "-----BEGIN PGP PRIVATE KEY BLOCK-----...",
       fingerprint: "38683D0347E42FDA",
     },
-    publishTime: new Date("March 12, 2026"),
+    publishTime: new Date("December 1, 2025"),
+    lastOperation: "operations/pppp-gggg-ssss",
   },
   {
     name: "publications/g8h8888e-c8f8-8e88-ab8c-ef8a8c8af8c8",
@@ -63,5 +65,6 @@ export const publications = [
     skipBz2: true,
     skipContents: true,
     publishTime: new Date("April 20, 2026"),
+    lastOperation: "operations/publication-ffff-llll-dddd",
   },
 ] as const satisfies Publication[];

--- a/src/tests/server/handlers/operations.ts
+++ b/src/tests/server/handlers/operations.ts
@@ -1,17 +1,16 @@
 import { API_URL_DEB_ARCHIVE } from "@/constants";
 import {
-  failedOperation,
   inProgressOperation,
-  emptyOperation,
   succeededOperation,
-  overCountOperation,
-  timeoutOperation,
-  idleOperation,
   operations,
 } from "@/tests/mocks/operations";
-import { http, delay, HttpResponse } from "msw";
+import { http, HttpResponse } from "msw";
 
 let progress = inProgressOperation.metadata.progressPercent;
+
+export const resetLroProgress = () => {
+  progress = inProgressOperation.metadata.progressPercent;
+};
 
 export default [
   http.post<never, { names: string[] }>(
@@ -49,47 +48,33 @@ export default [
     },
   ),
 
-  http.get(`${API_URL_DEB_ARCHIVE}operations/:operationId`, ({ params }) => {
-    const { operationId } = params;
-    delay(1000);
+  http.get(
+    `${API_URL_DEB_ARCHIVE}operations/:operationId`,
+    async ({ params }) => {
+      const { operationId } = params;
 
-    if (operationId === "ffff-llll-dddd") {
-      return HttpResponse.json(failedOperation);
-    }
+      if (operationId === "pppp-gggg-ssss") {
+        progress += 10;
 
-    if (operationId === "iiii-dddd-llll") {
-      return HttpResponse.json(idleOperation);
-    }
+        if (progress >= 100) {
+          progress = inProgressOperation.metadata.progressPercent;
+          return HttpResponse.json(succeededOperation);
+        }
 
-    if (operationId === "tttt-mmmm-oooo") {
-      return HttpResponse.json(timeoutOperation);
-    }
-
-    if (operationId === "pppp-gggg-ssss") {
-      progress += 10;
-
-      if (progress >= 100) {
-        progress = inProgressOperation.metadata.progressPercent;
-        return HttpResponse.json(succeededOperation);
+        return HttpResponse.json({
+          ...inProgressOperation,
+          metadata: {
+            ...inProgressOperation.metadata,
+            progressPercent: progress,
+          },
+        });
       }
 
-      return HttpResponse.json({
-        ...inProgressOperation,
-        metadata: {
-          ...inProgressOperation.metadata,
-          progressPercent: progress,
-        },
-      });
-    }
-
-    if (operationId === "mmmm-pppp-tttt") {
-      return HttpResponse.json(emptyOperation);
-    }
-
-    if (operationId === "ssss-cccc-dddd") {
-      return HttpResponse.json(succeededOperation);
-    }
-
-    return HttpResponse.json(overCountOperation);
-  }),
+      return HttpResponse.json(
+        operations.find(
+          (operation) => operation.metadata.operationId === operationId,
+        ),
+      );
+    },
+  ),
 ];

--- a/src/tests/server/handlers/operations.ts
+++ b/src/tests/server/handlers/operations.ts
@@ -1,4 +1,5 @@
 import { API_URL_DEB_ARCHIVE } from "@/constants";
+import type { Operation } from "@/features/operations";
 import {
   inProgressOperation,
   succeededOperation,
@@ -12,6 +13,35 @@ export const resetLroProgress = () => {
   progress = inProgressOperation.metadata.progressPercent;
 };
 
+const getOperationResponse = (operation: Operation) => {
+  if (operation.metadata.operationId === "pppp-gggg-ssss") {
+    progress += 10;
+
+    if (progress >= 100) {
+      progress = inProgressOperation.metadata.progressPercent;
+
+      return {
+        ...succeededOperation,
+        name: operation.name,
+        metadata: {
+          ...operation.metadata,
+          progressPercent: 100,
+          status: succeededOperation.metadata.status,
+        },
+      };
+    }
+
+    return {
+      ...operation,
+      metadata: {
+        ...operation.metadata,
+        progressPercent: progress,
+      },
+    };
+  }
+  return operation;
+};
+
 export default [
   http.post<never, { names: string[] }>(
     `${API_URL_DEB_ARCHIVE}operations\\:batchGet`,
@@ -22,27 +52,7 @@ export default [
         operations: operations
           .filter(({ name }) => names.includes(name ?? ""))
           .map((operation) => {
-            if (operation.metadata.operationId === "pppp-gggg-ssss") {
-              progress += 10;
-
-              if (progress >= 100) {
-                progress = inProgressOperation.metadata.progressPercent;
-
-                return {
-                  ...succeededOperation,
-                  name: operation.name,
-                };
-              }
-
-              return {
-                ...operation,
-                metadata: {
-                  ...operation.metadata,
-                  progressPercent: progress,
-                },
-              };
-            }
-            return operation;
+            return getOperationResponse(operation);
           }),
       });
     },
@@ -53,27 +63,17 @@ export default [
     async ({ params }) => {
       const { operationId } = params;
 
-      if (operationId === "pppp-gggg-ssss") {
-        progress += 10;
+      const operation = operations.find(
+        (op) => op.metadata.operationId === operationId,
+      );
 
-        if (progress >= 100) {
-          progress = inProgressOperation.metadata.progressPercent;
-          return HttpResponse.json(succeededOperation);
-        }
-
-        return HttpResponse.json({
-          ...inProgressOperation,
-          metadata: {
-            ...inProgressOperation.metadata,
-            progressPercent: progress,
-          },
-        });
+      if (operation) {
+        return HttpResponse.json(getOperationResponse(operation));
       }
 
       return HttpResponse.json(
-        operations.find(
-          (operation) => operation.metadata.operationId === operationId,
-        ),
+        { error: "Operation not found" },
+        { status: 404 },
       );
     },
   ),


### PR DESCRIPTION
## Summary

Summarize the changes made in this pull request. Include any relevant context or background information that would help reviewers understand the purpose and scope of the changes.

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [ ] `main` — next beta → publishes to `ppa-build`
- [x] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [ ] Patch (fix)
- [x] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
