### PR TITLE
refactor: replace moment.js with custom class

### DIFF
--- a/.changeset/replace-momentjs.md
+++ b/.changeset/replace-momentjs.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Replace moment.js with a custom `LandscapeDate` class to remove the moment.js dependency and reduce bundle size. Behavior is preserved across parsing, formatting, UTC/local modes, calendar, diff math (including DST adjustment), and strict ISO 8601 validation.

--- a/.changeset/replace-momentjs.md
+++ b/.changeset/replace-momentjs.md
@@ -2,4 +2,4 @@
 "landscape-ui": patch
 ---
 
-Replace moment.js with a custom `LandscapeDate` class to remove the moment.js dependency and reduce bundle size. Behavior is preserved across parsing, formatting, UTC/local modes, calendar, diff math (including DST adjustment), and strict ISO 8601 validation.
+Replace moment.js with a custom `ChronoDate` class to remove the moment.js dependency and reduce bundle size. Behavior is preserved across parsing, formatting, UTC/local modes, calendar, diff math (including DST adjustment), and strict ISO 8601 validation.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "classnames": "2.5.1",
     "downshift": "9.3.4",
     "formik": "2.4.9",
-    "moment": "2.30.1",
     "monaco-editor": "0.55.1",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       formik:
         specifier: 2.4.9
         version: 2.4.9(@types/react@19.2.16)(react@19.2.7)
-      moment:
-        specifier: 2.30.1
-        version: 2.30.1
       monaco-editor:
         specifier: 0.55.1
         version: 0.55.1
@@ -2659,9 +2656,6 @@ packages:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
-
-  moment@2.30.1:
-    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
   monaco-editor@0.55.1:
     resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
@@ -6616,8 +6610,6 @@ snapshots:
   minipass@7.1.3: {}
 
   mkdirp@3.0.1: {}
-
-  moment@2.30.1: {}
 
   monaco-editor@0.55.1:
     dependencies:

--- a/src/components/form/DeliveryScheduling/components/DeliveryBlock/DeliveryBlock.tsx
+++ b/src/components/form/DeliveryScheduling/components/DeliveryBlock/DeliveryBlock.tsx
@@ -1,5 +1,5 @@
 import type { FormikContextType } from "formik";
-import moment from "moment";
+import date from "@/libs/date";
 import { Input } from "@canonical/react-components";
 import { getFormikError } from "@/utils/formikErrors";
 import RadioGroup from "@/components/form/RadioGroup";
@@ -34,7 +34,7 @@ const DeliveryBlock = <T extends DeliveryProps>({
           onSelect: async () => {
             await formik.setFieldValue(
               "deliver_after",
-              moment().add(5, "minutes").toISOString().slice(0, 16),
+              date().add(5, "minutes").toISOString().slice(0, 16),
             );
           },
           expansion: (

--- a/src/components/form/DeliveryScheduling/helpers.ts
+++ b/src/components/form/DeliveryScheduling/helpers.ts
@@ -10,8 +10,7 @@ export const deliveryValidationSchema = {
       schema.required("This field is required.").test({
         name: "is-in-future",
         message: "You have to enter a valid date and time in the future.",
-        test: (value) =>
-          date(value).isValid() && date(value).isAfter(date()),
+        test: (value) => date(value).isValid() && date(value).isAfter(date()),
       }),
   }),
 };

--- a/src/components/form/DeliveryScheduling/helpers.ts
+++ b/src/components/form/DeliveryScheduling/helpers.ts
@@ -1,5 +1,5 @@
 import * as Yup from "yup";
-import moment from "moment";
+import date from "@/libs/date";
 import { MAX_DELIVERY_DELAY_WINDOW } from "@/constants";
 
 export const deliveryValidationSchema = {
@@ -11,7 +11,7 @@ export const deliveryValidationSchema = {
         name: "is-in-future",
         message: "You have to enter a valid date and time in the future.",
         test: (value) =>
-          moment(value).isValid() && moment(value).isAfter(moment()),
+          date(value).isValid() && date(value).isAfter(date()),
       }),
   }),
 };

--- a/src/components/form/ScheduleBlock/components/ScheduleBlockBase/ScheduleBlockBase.tsx
+++ b/src/components/form/ScheduleBlock/components/ScheduleBlockBase/ScheduleBlockBase.tsx
@@ -2,7 +2,7 @@ import { INPUT_DATE_TIME_FORMAT } from "@/constants";
 import { getFormikError } from "@/utils/formikErrors";
 import { Col, Input, Row, Select } from "@canonical/react-components";
 import type { FormikContextType } from "formik";
-import moment from "moment";
+import date from "@/libs/date";
 import type { ScheduleBlockFormProps } from "../../types";
 import OnSelect from "../OnSelect";
 
@@ -13,7 +13,7 @@ interface ScheduleBlockProps<T extends ScheduleBlockFormProps> {
 const ScheduleBlockBase = <T extends ScheduleBlockFormProps>({
   formik,
 }: ScheduleBlockProps<T>) => {
-  const currentDate = moment().format(INPUT_DATE_TIME_FORMAT);
+  const currentDate = date().format(INPUT_DATE_TIME_FORMAT);
 
   switch (formik.values.start_type) {
     case "on-a-date":

--- a/src/features/activities/components/Activities/Activities.tsx
+++ b/src/features/activities/components/Activities/Activities.tsx
@@ -5,7 +5,7 @@ import { TablePagination } from "@/components/layout/TablePagination";
 import { BREAKPOINT_PX, DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import { ROUTES } from "@/libs/routes";
 import { Button, CheckboxInput } from "@canonical/react-components";
-import moment from "moment/moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { useCallback, useMemo } from "react";
 import { Link } from "react-router";
@@ -184,7 +184,7 @@ const Activities: FC<ActivitiesProps> = ({
           className: "large-cell",
           Cell: ({ row }: CellProps<ActivityCommon>) => (
             <span className="font-monospace">
-              {moment(row.original.creation_time).format(
+              {date(row.original.creation_time).format(
                 DISPLAY_DATE_TIME_FORMAT,
               )}
             </span>

--- a/src/features/activities/components/ActivitiesExportForm/ActivitiesExportForm.tsx
+++ b/src/features/activities/components/ActivitiesExportForm/ActivitiesExportForm.tsx
@@ -9,7 +9,7 @@ import {
   type ExportField,
   type ExportFormValues,
 } from "@/features/exports";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { useNavigate } from "react-router";
 import { useExportActivitiesTsv } from "../../api/useExportActivitiesTsv";
@@ -49,7 +49,7 @@ const ActivitiesExportForm: FC<ActivitiesExportFormProps> = ({
         name: values.name.trim(),
         query,
         selected_field_ids: fieldsToExport.map((field) => field.id),
-        retain_until: moment(values.retainUntil).toISOString(),
+        retain_until: date(values.retainUntil).toISOString(),
       });
       const job = response.data;
       const exportScope = getExportScope({

--- a/src/features/activities/components/ActivitiesExportForm/constants.ts
+++ b/src/features/activities/components/ActivitiesExportForm/constants.ts
@@ -1,6 +1,6 @@
 import type { ExportFieldGroup, ExportFormValues } from "@/features/exports";
 import { INPUT_DATE_FORMAT } from "@/constants";
-import moment from "moment";
+import date from "@/libs/date";
 
 const VISIBLE_COLUMN_FIELD_IDS: string[] = [
   "summary",
@@ -13,7 +13,7 @@ const VISIBLE_COLUMN_FIELD_IDS: string[] = [
 export const INITIAL_VALUES: ExportFormValues = {
   name: "",
   selectedFieldIds: VISIBLE_COLUMN_FIELD_IDS,
-  retainUntil: moment().add(3, "years").format(INPUT_DATE_FORMAT),
+  retainUntil: date().add(3, "years").format(INPUT_DATE_FORMAT),
 };
 
 export const EXPORT_FIELD_GROUPS: readonly ExportFieldGroup[] = [

--- a/src/features/activities/components/ActivityDetails/ActivityDetails.tsx
+++ b/src/features/activities/components/ActivityDetails/ActivityDetails.tsx
@@ -4,7 +4,7 @@ import StaticLink from "@/components/layout/StaticLink";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import { useGetInstance } from "@/features/instances";
 import { CodeSnippet, Icon } from "@canonical/react-components";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { ACTIVITY_STATUSES } from "../../constants";
 import { useGetSingleActivity } from "../../api";
@@ -79,7 +79,7 @@ const ActivityDetails: FC<ActivityDetailsProps> = ({ activityId }) => {
         />
         <InfoGrid.Item
           label="Created at"
-          value={moment(activity.creation_time).format(
+          value={date(activity.creation_time).format(
             DISPLAY_DATE_TIME_FORMAT,
           )}
         />
@@ -87,7 +87,7 @@ const ActivityDetails: FC<ActivityDetailsProps> = ({ activityId }) => {
         {typeof activity.delivery_time === "string" && (
           <InfoGrid.Item
             label="Delivered at"
-            value={moment(activity.delivery_time).format(
+            value={date(activity.delivery_time).format(
               DISPLAY_DATE_TIME_FORMAT,
             )}
           />
@@ -95,7 +95,7 @@ const ActivityDetails: FC<ActivityDetailsProps> = ({ activityId }) => {
         {activity.completion_time !== null && (
           <InfoGrid.Item
             label="Completed at"
-            value={moment(activity.completion_time).format(
+            value={date(activity.completion_time).format(
               DISPLAY_DATE_TIME_FORMAT,
             )}
           />

--- a/src/features/activities/components/ActivityDetails/ActivityDetails.tsx
+++ b/src/features/activities/components/ActivityDetails/ActivityDetails.tsx
@@ -79,9 +79,7 @@ const ActivityDetails: FC<ActivityDetailsProps> = ({ activityId }) => {
         />
         <InfoGrid.Item
           label="Created at"
-          value={date(activity.creation_time).format(
-            DISPLAY_DATE_TIME_FORMAT,
-          )}
+          value={date(activity.creation_time).format(DISPLAY_DATE_TIME_FORMAT)}
         />
 
         {typeof activity.delivery_time === "string" && (

--- a/src/features/autoinstall-files/components/AutoinstallFileInfo/AutoinstallFileInfo.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFileInfo/AutoinstallFileInfo.tsx
@@ -1,6 +1,6 @@
 import InfoGrid from "@/components/layout/InfoGrid";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import type { AutoinstallFile } from "../../types";
 
@@ -16,12 +16,12 @@ const AutoinstallFileInfo: FC<AutoinstallFileInfoProps> = ({ file }) => (
 
     <InfoGrid.Item
       label="Last modified"
-      value={moment(file.last_modified_at).format(DISPLAY_DATE_TIME_FORMAT)}
+      value={date(file.last_modified_at).format(DISPLAY_DATE_TIME_FORMAT)}
     />
 
     <InfoGrid.Item
       label="Date created"
-      value={moment(file.created_at).format(DISPLAY_DATE_TIME_FORMAT)}
+      value={date(file.created_at).format(DISPLAY_DATE_TIME_FORMAT)}
     />
   </InfoGrid>
 );

--- a/src/features/autoinstall-files/components/AutoinstallFileVersion/AutoinstallFileVersion.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFileVersion/AutoinstallFileVersion.tsx
@@ -4,7 +4,7 @@ import InfoItem from "@/components/layout/InfoItem";
 import LoadingState from "@/components/layout/LoadingState";
 import { DISPLAY_DATE_FORMAT } from "@/constants";
 import { Input } from "@canonical/react-components";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { useGetAutoinstallFile } from "../../api";
 import {
@@ -50,7 +50,7 @@ const AutoinstallFileVersion: FC<AutoinstallFileVersionProps> = ({
 
       <InfoItem
         label="Date created"
-        value={moment(versionInfo.created_at).format(DISPLAY_DATE_FORMAT)}
+        value={date(versionInfo.created_at).format(DISPLAY_DATE_FORMAT)}
       />
 
       {isAutoinstallFileLoading ? (

--- a/src/features/autoinstall-files/components/AutoinstallFileVersionHistory/AutoinstallFileVersionHistory.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFileVersionHistory/AutoinstallFileVersionHistory.tsx
@@ -3,7 +3,7 @@ import { SidePanelTablePagination } from "@/components/layout/TablePagination";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import useSidePanel from "@/hooks/useSidePanel";
 import { Button, ModularTable } from "@canonical/react-components";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC, ReactNode } from "react";
 import { lazy, Suspense, useMemo, useState } from "react";
 import type { CellProps, Column } from "react-table";
@@ -88,7 +88,7 @@ const AutoinstallFileVersionHistory: FC<AutoinstallFileVersionHistoryProps> = ({
           },
         }: CellProps<AutoinstallFileVersionInfo>): ReactNode => (
           <div className="font-monospace">
-            {moment(created_at).format(DISPLAY_DATE_TIME_FORMAT)}
+            {date(created_at).format(DISPLAY_DATE_TIME_FORMAT)}
           </div>
         ),
       },

--- a/src/features/autoinstall-files/components/AutoinstallFilesList/AutoinstallFilesList.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFilesList/AutoinstallFilesList.tsx
@@ -3,7 +3,7 @@ import { LIST_ACTIONS_COLUMN_PROPS } from "@/components/layout/ListActions";
 import ResponsiveTable from "@/components/layout/ResponsiveTable";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import { Button } from "@canonical/react-components";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC, ReactNode } from "react";
 import { useMemo } from "react";
 import type { CellProps, Column } from "react-table";
@@ -66,7 +66,7 @@ const AutoinstallFilesList: FC<AutoinstallFilesListProps> = ({
           },
         }: CellProps<AutoinstallFile>): ReactNode => (
           <div className="font-monospace">
-            {moment(last_modified_at).format(DISPLAY_DATE_TIME_FORMAT)}
+            {date(last_modified_at).format(DISPLAY_DATE_TIME_FORMAT)}
           </div>
         ),
       },

--- a/src/features/events-log/components/EventsLogList/EventsLogList.tsx
+++ b/src/features/events-log/components/EventsLogList/EventsLogList.tsx
@@ -2,7 +2,7 @@ import ResponsiveTable from "@/components/layout/ResponsiveTable";
 import TruncatedCell from "@/components/layout/TruncatedCell";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import { useExpandableRow } from "@/hooks/useExpandableRow";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { useMemo } from "react";
 import type { CellProps, Column } from "react-table";
@@ -26,7 +26,7 @@ const EventsLogList: FC<EventsLogListProps> = ({ eventsLog }) => {
         className: "large-cell",
         Cell: ({ row }: CellProps<EventLog>) => (
           <span className="font-monospace">
-            {moment(row.original.creation_time).format(
+            {date(row.original.creation_time).format(
               DISPLAY_DATE_TIME_FORMAT,
             )}
           </span>

--- a/src/features/events-log/components/EventsLogList/EventsLogList.tsx
+++ b/src/features/events-log/components/EventsLogList/EventsLogList.tsx
@@ -26,9 +26,7 @@ const EventsLogList: FC<EventsLogListProps> = ({ eventsLog }) => {
         className: "large-cell",
         Cell: ({ row }: CellProps<EventLog>) => (
           <span className="font-monospace">
-            {date(row.original.creation_time).format(
-              DISPLAY_DATE_TIME_FORMAT,
-            )}
+            {date(row.original.creation_time).format(DISPLAY_DATE_TIME_FORMAT)}
           </span>
         ),
       },

--- a/src/features/exports/components/ExportDetailsSidePanel/ExportDetails.tsx
+++ b/src/features/exports/components/ExportDetailsSidePanel/ExportDetails.tsx
@@ -10,7 +10,7 @@ import {
   Icon,
   ICONS,
 } from "@canonical/react-components";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { useCancelExportJob } from "../../api/useCancelExportJob";
 import { useDiscardExportJob } from "../../api/useDiscardExportJob";
@@ -205,7 +205,7 @@ const ExportDetails: FC<ExportDetailsProps> = ({ job }) => {
               label="Created"
               value={
                 <span className="font-monospace">
-                  {moment(job.created_at).format(DISPLAY_DATE_TIME_FORMAT)}
+                  {date(job.created_at).format(DISPLAY_DATE_TIME_FORMAT)}
                 </span>
               }
             />
@@ -213,7 +213,7 @@ const ExportDetails: FC<ExportDetailsProps> = ({ job }) => {
               label="Expires"
               value={
                 <span className="font-monospace">
-                  {moment(job.retain_until).format(DISPLAY_DATE_TIME_FORMAT)}
+                  {date(job.retain_until).format(DISPLAY_DATE_TIME_FORMAT)}
                 </span>
               }
             />

--- a/src/features/exports/components/ExportForm/ExportForm.test.tsx
+++ b/src/features/exports/components/ExportForm/ExportForm.test.tsx
@@ -2,7 +2,7 @@ import { INPUT_DATE_FORMAT } from "@/constants";
 import { renderWithProviders } from "@/tests/render";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import moment from "moment";
+import date from "@/libs/date";
 import { useLocation } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 import ExportForm from "./ExportForm";
@@ -33,7 +33,7 @@ const FIELD_GROUPS: readonly ExportFieldGroup[] = [
 const INITIAL_VALUES: ExportFormValues = {
   name: "",
   selectedFieldIds: [],
-  retainUntil: moment().add(3, "years").format(INPUT_DATE_FORMAT),
+  retainUntil: date().add(3, "years").format(INPUT_DATE_FORMAT),
 };
 
 const renderForm = (

--- a/src/features/exports/components/ExportForm/ExportForm.tsx
+++ b/src/features/exports/components/ExportForm/ExportForm.tsx
@@ -11,7 +11,7 @@ import {
 } from "@canonical/react-components";
 import classNames from "classnames";
 import { useFormik } from "formik";
-import moment from "moment";
+import date from "@/libs/date";
 import { useCallback, useMemo, useState, type FC } from "react";
 import SortableFieldList from "../SortableFieldList";
 import { getFilteredFieldGroups, getGroupSearchRank } from "./helpers";
@@ -217,8 +217,8 @@ const ExportForm: FC<ExportFormProps> = ({
             type="date"
             label="Keep until"
             required
-            min={moment().add(1, "day").format(INPUT_DATE_FORMAT)}
-            max={moment().add(100, "years").format(INPUT_DATE_FORMAT)}
+            min={date().add(1, "day").format(INPUT_DATE_FORMAT)}
+            max={date().add(100, "years").format(INPUT_DATE_FORMAT)}
             error={getFormikError(formik, "retainUntil")}
             {...formik.getFieldProps("retainUntil")}
           />

--- a/src/features/exports/components/ExportForm/constants.ts
+++ b/src/features/exports/components/ExportForm/constants.ts
@@ -1,4 +1,4 @@
-import moment from "moment";
+import date from "@/libs/date";
 import * as Yup from "yup";
 
 export const VALIDATION_SCHEMA = Yup.object().shape({
@@ -11,12 +11,12 @@ export const VALIDATION_SCHEMA = Yup.object().shape({
     .test(
       "retain-until-future",
       "Must be a date in the future",
-      (value) => !!value && moment(value).isAfter(moment().startOf("day")),
+      (value) => !!value && date(value).isAfter(date().format("YYYY-MM-DD")),
     )
     .test(
       "retain-until-max",
       "Must be within 100 years from today",
       (value) =>
-        !!value && moment(value).isSameOrBefore(moment().add(100, "years")),
+        !!value && date(value).isSameOrBefore(date().add(100, "years")),
     ),
 });

--- a/src/features/exports/components/ExportsList/ExportsList.tsx
+++ b/src/features/exports/components/ExportsList/ExportsList.tsx
@@ -3,7 +3,7 @@ import ResponsiveTable from "@/components/layout/ResponsiveTable";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import usePageParams from "@/hooks/usePageParams";
 import { Button } from "@canonical/react-components";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { useMemo } from "react";
 import type { CellProps, Column } from "react-table";
@@ -81,9 +81,7 @@ const ExportsList: FC<ExportsListProps> = ({ exportJobs }) => {
         accessor: "job.created_at",
         Cell: ({ row }: CellProps<ExportRowData>) => (
           <span className="font-monospace">
-            {moment(row.original.job.created_at).format(
-              DISPLAY_DATE_TIME_FORMAT,
-            )}
+            {date(row.original.job.created_at).format(DISPLAY_DATE_TIME_FORMAT)}
           </span>
         ),
       },
@@ -92,7 +90,7 @@ const ExportsList: FC<ExportsListProps> = ({ exportJobs }) => {
         accessor: "job.retain_until",
         Cell: ({ row }: CellProps<ExportRowData>) => (
           <span className="font-monospace">
-            {moment(row.original.job.retain_until).format(
+            {date(row.original.job.retain_until).format(
               DISPLAY_DATE_TIME_FORMAT,
             )}
           </span>

--- a/src/features/instances/components/InstanceList/InstanceList.tsx
+++ b/src/features/instances/components/InstanceList/InstanceList.tsx
@@ -15,7 +15,7 @@ import {
   Tooltip,
 } from "@canonical/react-components";
 import classNames from "classnames";
-import moment from "moment";
+import date from "@/libs/date";
 import { memo, useCallback, useEffect, useId, useMemo } from "react";
 import type { CellProps, Column } from "react-table";
 import InstanceStatus, {
@@ -338,11 +338,11 @@ const InstanceList = memo(function InstanceList({
         Cell: ({ row }: CellProps<Instance>) => {
           if (
             row.original.ubuntu_pro_info?.attached &&
-            moment(row.original.ubuntu_pro_info.expires).isValid()
+            date(row.original.ubuntu_pro_info.expires).isValid()
           ) {
             return (
               <span className="font-monospace">
-                {moment(row.original.ubuntu_pro_info.expires).format(
+                {date(row.original.ubuntu_pro_info.expires).format(
                   DISPLAY_DATE_TIME_FORMAT,
                 )}
               </span>
@@ -360,9 +360,9 @@ const InstanceList = memo(function InstanceList({
         className: "large-cell",
         Cell: ({ row }: CellProps<Instance>) => (
           <>
-            {moment(row.original.last_ping_time).isValid() ? (
+            {date(row.original.last_ping_time).isValid() ? (
               <span className="font-monospace">
-                {moment(row.original.last_ping_time).format(
+                {date(row.original.last_ping_time).format(
                   DISPLAY_DATE_TIME_FORMAT,
                 )}
               </span>

--- a/src/features/instances/components/InstancesExportForm/InstancesExportForm.tsx
+++ b/src/features/instances/components/InstancesExportForm/InstancesExportForm.tsx
@@ -9,7 +9,7 @@ import {
   type ExportField,
   type ExportFormValues,
 } from "@/features/exports";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { useNavigate } from "react-router";
 import { useExportInstancesTsv } from "../../api/useExportInstancesTsv";
@@ -53,7 +53,7 @@ const InstancesExportForm: FC<InstancesExportFormProps> = ({
         wsl_children: exportParams.wsl_children,
         wsl_parents: exportParams.wsl_parents,
         selected_field_ids: fieldsToExport.map((field) => field.id),
-        retain_until: moment(values.retainUntil).toISOString(),
+        retain_until: date(values.retainUntil).toISOString(),
       });
       const job = response.data;
       const exportScope = getExportScope({

--- a/src/features/instances/components/InstancesExportForm/constants.ts
+++ b/src/features/instances/components/InstancesExportForm/constants.ts
@@ -1,11 +1,11 @@
 import type { ExportFieldGroup, ExportFormValues } from "@/features/exports";
 import { INPUT_DATE_FORMAT } from "@/constants";
-import moment from "moment";
+import date from "@/libs/date";
 
 export const INITIAL_VALUES: ExportFormValues = {
   name: "",
   selectedFieldIds: [],
-  retainUntil: moment().add(3, "years").format(INPUT_DATE_FORMAT),
+  retainUntil: date().add(3, "years").format(INPUT_DATE_FORMAT),
 };
 
 export const EXPORT_FIELD_GROUPS: readonly ExportFieldGroup[] = [

--- a/src/features/instances/constants.ts
+++ b/src/features/instances/constants.ts
@@ -2,7 +2,7 @@ import type { ListFilter } from "@/types/Filters";
 import type { SelectOption } from "@/types/SelectOption";
 import type { Status } from "./types";
 import * as Yup from "yup";
-import moment from "moment";
+import date from "@/libs/date";
 
 export const STATUS_FILTERS = {
   Online: {
@@ -274,11 +274,11 @@ export const REBOOT_OR_SHUT_DOWN_VALIDATION_SCHEMA = Yup.object().shape({
         .required("This field is required")
         .test({
           message: "Invalid date",
-          test: (value) => moment(value).isValid(),
+          test: (value) => date(value).isValid(),
         })
         .test({
           message: "Date must be in the future",
-          test: (value) => moment(value).isAfter(),
+          test: (value) => date(value).isAfter(),
         }),
   }),
   deliverImmediately: Yup.boolean(),

--- a/src/features/kernel/components/KernelOverview/helpers.test.ts
+++ b/src/features/kernel/components/KernelOverview/helpers.test.ts
@@ -1,5 +1,5 @@
 import { DISPLAY_DATE_FORMAT } from "@/constants";
-import moment from "moment";
+import date from "@/libs/date";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getLivepatchCoverageDisplayValue,
@@ -28,7 +28,7 @@ describe("KernelOverview helpers", () => {
     expect(
       getStatusTooltipMessage("Kernel upgrade available", expiry),
     ).toContain(
-      `covered by Livepatch until ${moment(expiry).format(DISPLAY_DATE_FORMAT)}`,
+      `covered by Livepatch until ${date(expiry).format(DISPLAY_DATE_FORMAT)}`,
     );
   });
 
@@ -70,9 +70,9 @@ describe("KernelOverview helpers", () => {
   });
 
   it("computes livepatch coverage icons by enablement and expiry window", () => {
-    const soonExpiry = moment(NOW).add(TWO_DAYS, "days").toISOString();
-    const laterExpiry = moment(NOW).add(TEN_DAYS, "days").toISOString();
-    const expired = moment(NOW).subtract(1, "day").toISOString();
+    const soonExpiry = date(NOW).add(TWO_DAYS, "days").toISOString();
+    const laterExpiry = date(NOW).add(TEN_DAYS, "days").toISOString();
+    const expired = date(NOW).subtract(1, "day").toISOString();
 
     expect(getLivepatchCoverageIcon(true, soonExpiry)).toBe(
       "status-waiting-small",
@@ -90,15 +90,15 @@ describe("KernelOverview helpers", () => {
   });
 
   it("computes display value for disabled, expired, and active coverage", () => {
-    const laterExpiry = moment(NOW).add(TEN_DAYS, "days").toISOString();
-    const expired = moment(NOW).subtract(1, "day").toISOString();
+    const laterExpiry = date(NOW).add(TEN_DAYS, "days").toISOString();
+    const expired = date(NOW).subtract(1, "day").toISOString();
 
     expect(getLivepatchCoverageDisplayValue(false, laterExpiry)).toBe(
       "Livepatch is disabled",
     );
     expect(getLivepatchCoverageDisplayValue(true, expired)).toBe("Expired");
     expect(getLivepatchCoverageDisplayValue(true, laterExpiry)).toBe(
-      `Expires on ${moment(laterExpiry).format(DISPLAY_DATE_FORMAT)}`,
+      `Expires on ${date(laterExpiry).format(DISPLAY_DATE_FORMAT)}`,
     );
   });
 });

--- a/src/features/kernel/components/KernelOverview/helpers.ts
+++ b/src/features/kernel/components/KernelOverview/helpers.ts
@@ -1,14 +1,14 @@
 import { DISPLAY_DATE_FORMAT } from "@/constants";
-import moment from "moment";
+import date from "@/libs/date";
 
 export const getStatusTooltipMessage = (type: string, expiryDate: string) => {
   switch (type) {
     case "Fully patched":
       return "All available kernel security patches have been applied. You have no pending patches.";
     case "Kernel upgrade available": {
-      const date = moment(expiryDate);
+      const coverageDate = date(expiryDate);
 
-      return `A new kernel version is available.${date.isValid() ? ` The current version is covered by Livepatch until ${date.format(DISPLAY_DATE_FORMAT)}` : ""}`;
+      return `A new kernel version is available.${coverageDate.isValid() ? ` The current version is covered by Livepatch until ${coverageDate.format(DISPLAY_DATE_FORMAT)}` : ""}`;
     }
     case "Restart required":
       return "Low and/or medium patches have been installed. You must restart to complete patching.";
@@ -40,11 +40,11 @@ export const getLivepatchCoverageIcon = (
   livepatchEnabled: boolean,
   expiryDate: string,
 ): string => {
-  const expiry = moment(expiryDate);
-  const today = moment();
+  const expiry = date(expiryDate);
+  const today = date();
   const diffDays = expiry.diff(today, "days");
 
-  if (diffDays < 0 || !livepatchEnabled || !moment(expiryDate).isValid()) {
+  if (diffDays < 0 || !livepatchEnabled || !date(expiryDate).isValid()) {
     return "status-failed-small";
   } else if (diffDays < 7) {
     return "status-waiting-small";
@@ -61,13 +61,13 @@ export const getLivepatchCoverageDisplayValue = (
     return "Livepatch is disabled";
   }
 
-  const expiry = moment(expiryDate);
-  const today = moment();
+  const expiry = date(expiryDate);
+  const today = date();
   const diffDays = expiry.diff(today, "days");
 
   if (diffDays < 0) {
     return "Expired";
   } else {
-    return `Expires on ${moment(expiryDate).format(DISPLAY_DATE_FORMAT)}`;
+    return `Expires on ${date(expiryDate).format(DISPLAY_DATE_FORMAT)}`;
   }
 };

--- a/src/features/kernel/components/KernelOverview/helpers.ts
+++ b/src/features/kernel/components/KernelOverview/helpers.ts
@@ -44,7 +44,7 @@ export const getLivepatchCoverageIcon = (
   const today = date();
   const diffDays = expiry.diff(today, "days");
 
-  if (diffDays < 0 || !livepatchEnabled || !date(expiryDate).isValid()) {
+  if (diffDays < 0 || !livepatchEnabled || !expiry.isValid()) {
     return "status-failed-small";
   } else if (diffDays < 7) {
     return "status-waiting-small";
@@ -68,6 +68,6 @@ export const getLivepatchCoverageDisplayValue = (
   if (diffDays < 0) {
     return "Expired";
   } else {
-    return `Expires on ${date(expiryDate).format(DISPLAY_DATE_FORMAT)}`;
+    return `Expires on ${expiry.format(DISPLAY_DATE_FORMAT)}`;
   }
 };

--- a/src/features/local-repositories/components/LocalRepositoriesList/LocalRepositoriesList.tsx
+++ b/src/features/local-repositories/components/LocalRepositoriesList/LocalRepositoriesList.tsx
@@ -12,7 +12,7 @@ import { AssociatedPublicationsCount } from "@/features/publications";
 import { OperationStatusCell, OperationProvider } from "@/features/operations";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import classes from "./LocalRepositoriesList.module.scss";
-import moment from "moment";
+import date from "@/libs/date";
 import { NO_DATA_TEXT } from "@/components/layout/NoData";
 
 interface LocalRepositoriesListProps {
@@ -73,7 +73,7 @@ const LocalRepositoriesList: FC<LocalRepositoriesListProps> = ({
         className: classes.datetime,
         Cell: ({ row: { original } }: CellProps<Local>) =>
           original.lastImportTime
-            ? moment(original.lastImportTime).format(DISPLAY_DATE_TIME_FORMAT)
+            ? date(original.lastImportTime).format(DISPLAY_DATE_TIME_FORMAT)
             : NO_DATA_TEXT,
       },
       {

--- a/src/features/local-repositories/components/ViewLocalRepositorySidePanel/components/ViewLocalRepositoryDetailsTab/ViewLocalRepositoryDetailsTab.test.tsx
+++ b/src/features/local-repositories/components/ViewLocalRepositorySidePanel/components/ViewLocalRepositoryDetailsTab/ViewLocalRepositoryDetailsTab.test.tsx
@@ -7,7 +7,7 @@ import { NO_DATA_TEXT } from "@/components/layout/NoData/constants";
 import { succeededOperation } from "@/tests/mocks/operations";
 import type { Local } from "@canonical/landscape-openapi";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
-import moment from "moment";
+import date from "@/libs/date";
 
 const [repository] = repositories;
 
@@ -26,7 +26,7 @@ describe("ViewLocalRepositoryDetailsTab", () => {
     expect(container).toHaveInfoItem("Status", "Packages imported");
     expect(container).toHaveInfoItem(
       "Last import",
-      moment(repository.lastImportTime).format(DISPLAY_DATE_TIME_FORMAT),
+      date(repository.lastImportTime).format(DISPLAY_DATE_TIME_FORMAT),
     );
     expect(container).toHaveInfoItem("Description", NO_DATA_TEXT);
     expect(container).toHaveInfoItem(

--- a/src/features/local-repositories/components/ViewLocalRepositorySidePanel/components/ViewLocalRepositoryDetailsTab/ViewLocalRepositoryDetailsTab.tsx
+++ b/src/features/local-repositories/components/ViewLocalRepositorySidePanel/components/ViewLocalRepositoryDetailsTab/ViewLocalRepositoryDetailsTab.tsx
@@ -11,7 +11,7 @@ import {
   OperationStatusContent,
   type OperationMetadata,
 } from "@/features/operations";
-import moment from "moment";
+import date from "@/libs/date";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 
 interface ViewLocalRepositoryDetailsTabProps {
@@ -48,7 +48,7 @@ const ViewLocalRepositoryDetailsTab: FC<ViewLocalRepositoryDetailsTabProps> = ({
             label="Last import"
             value={
               repository.lastImportTime
-                ? moment(repository.lastImportTime).format(
+                ? date(repository.lastImportTime).format(
                     DISPLAY_DATE_TIME_FORMAT,
                   )
                 : null

--- a/src/features/mirrors/components/AddMirrorForm/helpers.ts
+++ b/src/features/mirrors/components/AddMirrorForm/helpers.ts
@@ -1,5 +1,5 @@
 import { INPUT_DATE_FORMAT } from "@/constants";
-import moment from "moment";
+import date from "@/libs/date";
 import type {
   BaseFormProps,
   FormProps,
@@ -113,7 +113,7 @@ export function getInitialUbuntuSnapshotsValues(
     ...getInitialBaseValues(ubuntuArchiveInfo?.distributions ?? []),
     sourceType: "ubuntu-snapshots",
     sourceUrl: `https://${UBUNTU_SNAPSHOTS_HOST}/ubuntu/`,
-    snapshotDate: moment().format(INPUT_DATE_FORMAT),
+    snapshotDate: date().format(INPUT_DATE_FORMAT),
   };
 }
 

--- a/src/features/mirrors/components/MirrorDetails/MirrorDetails.tsx
+++ b/src/features/mirrors/components/MirrorDetails/MirrorDetails.tsx
@@ -13,7 +13,7 @@ import { useGetMirror } from "../../api";
 import usePageParams from "@/hooks/usePageParams";
 import { getSourceType, shouldShowAuthentication } from "./helpers";
 import MirrorPackagesCount from "../MirrorPackagesCount";
-import moment from "moment";
+import date from "@/libs/date";
 import {
   DEFAULT_POLLING_INTERVAL,
   DISPLAY_DATE_TIME_FORMAT,
@@ -220,7 +220,7 @@ const MirrorDetails: FC = () => {
                   label="Last update"
                   value={
                     mirror.lastDownloadDate &&
-                    moment(mirror.lastDownloadDate).format(
+                    date(mirror.lastDownloadDate).format(
                       DISPLAY_DATE_TIME_FORMAT,
                     )
                   }

--- a/src/features/mirrors/components/MirrorsList/MirrorsList.test.tsx
+++ b/src/features/mirrors/components/MirrorsList/MirrorsList.test.tsx
@@ -2,7 +2,7 @@ import { renderWithProviders } from "@/tests/render";
 import { describe } from "vitest";
 import MirrorsList from "./MirrorsList";
 import { mirrors } from "@/tests/mocks/mirrors";
-import moment from "moment";
+import date from "@/libs/date";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import { screen } from "@testing-library/react";
 import { NO_DATA_TEXT } from "@/components/layout/NoData";
@@ -19,7 +19,7 @@ describe("MirrorsList", () => {
 
     expect(
       screen.getByText(
-        moment(mirror.lastDownloadDate).format(DISPLAY_DATE_TIME_FORMAT),
+        date(mirror.lastDownloadDate).format(DISPLAY_DATE_TIME_FORMAT),
       ),
     ).toBeInTheDocument();
   });

--- a/src/features/mirrors/components/MirrorsList/MirrorsList.tsx
+++ b/src/features/mirrors/components/MirrorsList/MirrorsList.tsx
@@ -2,7 +2,7 @@ import ResponsiveTable from "@/components/layout/ResponsiveTable";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import type { Mirror } from "@canonical/landscape-openapi";
 import { Button } from "@canonical/react-components";
-import moment from "moment";
+import date from "@/libs/date";
 import { Suspense, useMemo, type FC } from "react";
 import type { CellProps, Column } from "react-table";
 import { LIST_ACTIONS_COLUMN_PROPS } from "@/components/layout/ListActions";
@@ -70,7 +70,7 @@ const MirrorsList: FC<MirrorsListProps> = ({ mirrors, emptyMsg }) => {
         className: classes.datetime,
         Cell: ({ row: { original: mirror } }: CellProps<Mirror>) =>
           mirror.lastDownloadDate ? (
-            moment(mirror.lastDownloadDate).format(DISPLAY_DATE_TIME_FORMAT)
+            date(mirror.lastDownloadDate).format(DISPLAY_DATE_TIME_FORMAT)
           ) : (
             <NoData />
           ),

--- a/src/features/overview/components/InfoTablesContainer/InfoTablesContainer.tsx
+++ b/src/features/overview/components/InfoTablesContainer/InfoTablesContainer.tsx
@@ -25,7 +25,7 @@ import {
 } from "@canonical/react-components";
 import type { AxiosResponse } from "axios";
 import classNames from "classnames";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC, ReactNode } from "react";
 import { useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router";
@@ -317,10 +317,10 @@ const InfoTablesContainer: FC = () => {
         Header: "Created at",
         accessor: "creation_time",
         Cell: ({ row }: CellProps<ActivityCommon>): ReactNode => {
-          const date = moment(row.original.creation_time);
+          const createdAt = date(row.original.creation_time);
           return (
             <span className="font-monospace">
-              {date.local().format(DISPLAY_DATE_TIME_FORMAT)}
+              {createdAt.local().format(DISPLAY_DATE_TIME_FORMAT)}
             </span>
           );
         },

--- a/src/features/processes/components/ProcessesList/ProcessesList.test.tsx
+++ b/src/features/processes/components/ProcessesList/ProcessesList.test.tsx
@@ -3,7 +3,7 @@ import { processes } from "@/tests/mocks/process";
 import { renderWithProviders } from "@/tests/render";
 import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import moment from "moment/moment";
+import date from "@/libs/date";
 import { describe, expect, vi } from "vitest";
 import ProcessesList from "./ProcessesList";
 
@@ -38,7 +38,7 @@ describe("ProcessesList", () => {
     renderWithProviders(<ProcessesList {...props} />);
     const [chosenProcess] = processes;
     const row = screen.getByRole("row", {
-      name: `Select process ${chosenProcess.name}${chosenProcess.name} ${chosenProcess.state} ${chosenProcess.vm_size} ${(100 * chosenProcess.cpu_utilisation).toFixed(1)}% ${chosenProcess.pid} ${moment(chosenProcess.start_time).format(DISPLAY_DATE_TIME_FORMAT)} ${chosenProcess.gid}`,
+      name: `Select process ${chosenProcess.name}${chosenProcess.name} ${chosenProcess.state} ${chosenProcess.vm_size} ${(100 * chosenProcess.cpu_utilisation).toFixed(1)}% ${chosenProcess.pid} ${date(chosenProcess.start_time).format(DISPLAY_DATE_TIME_FORMAT)} ${chosenProcess.gid}`,
     });
     const processCheckbox = await within(row).findByRole("checkbox", {
       name: `Select process ${chosenProcess.name}`,

--- a/src/features/processes/components/ProcessesList/ProcessesList.tsx
+++ b/src/features/processes/components/ProcessesList/ProcessesList.tsx
@@ -1,7 +1,7 @@
 import ResponsiveTable from "@/components/layout/ResponsiveTable";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import { CheckboxInput } from "@canonical/react-components";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { useMemo } from "react";
 import type { CellProps, Column } from "react-table";
@@ -95,7 +95,7 @@ const ProcessesList: FC<ProcessesListProps> = ({
         className: "large-cell",
         Cell: ({ row }: CellProps<Process>) => (
           <span className="font-monospace">
-            {moment(row.original.start_time).format(DISPLAY_DATE_TIME_FORMAT)}
+            {date(row.original.start_time).format(DISPLAY_DATE_TIME_FORMAT)}
           </span>
         ),
       },

--- a/src/features/profiles/components/ProfilesList/helpers.tsx
+++ b/src/features/profiles/components/ProfilesList/helpers.tsx
@@ -18,7 +18,7 @@ import { getTitleByName } from "@/utils/_helpers";
 import { Button, Link } from "@canonical/react-components";
 import type { CellProps, Column } from "react-table";
 import ProfilesListActions from "./components/ProfilesListActions";
-import moment from "moment";
+import date from "@/libs/date";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import { ROUTES } from "@/libs/routes";
 import type { AxiosResponse } from "axios";
@@ -276,7 +276,7 @@ export const getScriptColumns = (): Column<Profile>[] => [
               query: `parent-id:${last_activity.id}`,
             })}
           >
-            {moment(last_activity.creation_time)
+            {date(last_activity.creation_time)
               .utc()
               .format(DISPLAY_DATE_TIME_FORMAT)}
           </Link>
@@ -315,7 +315,7 @@ export const getRebootColumn = (): Column<Profile> => ({
   },
   Cell: ({ row: { original: profile } }: CellProps<Profile>) => {
     if (isRebootProfile(profile)) {
-      return moment(profile.next_run).utc().format(DISPLAY_DATE_TIME_FORMAT);
+      return date(profile.next_run).utc().format(DISPLAY_DATE_TIME_FORMAT);
     }
 
     return null;

--- a/src/features/profiles/components/ViewProfileSidePanel/components/ViewProfileActionsBlock/ViewProfileActionsBlock.tsx
+++ b/src/features/profiles/components/ViewProfileSidePanel/components/ViewProfileActionsBlock/ViewProfileActionsBlock.tsx
@@ -7,7 +7,7 @@ import type { Action } from "@/types/Action";
 import classes from "./ViewProfileActionsBlock.module.scss";
 import { useGetProfileActions } from "../../../../hooks/useGetProfileActions";
 import { isScriptProfile, type ProfileTypes } from "../../../../helpers";
-import moment from "moment";
+import date from "@/libs/date";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 
 const RemoveProfileModal = lazy(
@@ -41,7 +41,7 @@ const ViewProfileActionsBlock: FC<ViewProfileActionsBlockProps> = ({
     return (
       <Notification inline title="Profile archived:" severity="caution">
         The profile was archived on{" "}
-        {moment(profile.last_edited_at).format(DISPLAY_DATE_TIME_FORMAT)}.
+        {date(profile.last_edited_at).format(DISPLAY_DATE_TIME_FORMAT)}.
       </Notification>
     );
   }

--- a/src/features/profiles/components/ViewProfileSidePanel/components/ViewProfileScheduleBlock/ViewProfileScheduleBlock.tsx
+++ b/src/features/profiles/components/ViewProfileSidePanel/components/ViewProfileScheduleBlock/ViewProfileScheduleBlock.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../../../helpers";
 import Blocks from "@/components/layout/Blocks";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
-import moment from "moment";
+import date from "@/libs/date";
 import { getLastRunData, getNextRunData, getScheduleMessage } from "./helpers";
 import { pluralize } from "@/utils/_helpers";
 
@@ -44,7 +44,7 @@ const ViewProfileScheduleBlock: FC<ViewProfileScheduleBlockProps> = ({
             label="Last run"
             value={
               lastRun
-                ? `${moment(lastRun).utc().format(DISPLAY_DATE_TIME_FORMAT)} UTC`
+                ? `${date(lastRun).utc().format(DISPLAY_DATE_TIME_FORMAT)} UTC`
                 : null
             }
           />
@@ -62,7 +62,7 @@ const ViewProfileScheduleBlock: FC<ViewProfileScheduleBlockProps> = ({
             label={nextLabel}
             value={
               nextRun
-                ? `${moment(nextRun).utc().format(DISPLAY_DATE_TIME_FORMAT)} UTC`
+                ? `${date(nextRun).utc().format(DISPLAY_DATE_TIME_FORMAT)} UTC`
                 : null
             }
           />

--- a/src/features/publications/components/AssociatedPublicationsList/AssociatedPublicationsList.tsx
+++ b/src/features/publications/components/AssociatedPublicationsList/AssociatedPublicationsList.tsx
@@ -2,7 +2,7 @@ import ModalTablePagination from "@/components/layout/TablePagination/components
 import NoData from "@/components/layout/NoData";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import { ModularTable } from "@canonical/react-components";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC, ReactNode } from "react";
 import { useMemo, useState } from "react";
 import type { CellProps, Column } from "react-table";
@@ -107,7 +107,7 @@ const AssociatedPublicationsList: FC<AssociatedPublicationsListProps> = ({
         }: CellProps<Publication>): ReactNode =>
           publishTime ? (
             <span>
-              {moment(publishTime).format(DISPLAY_DATE_TIME_FORMAT) + " UTC"}
+              {date(publishTime).format(DISPLAY_DATE_TIME_FORMAT) + " UTC"}
             </span>
           ) : (
             <NoData />

--- a/src/features/publications/components/PublicationDetails/PublicationDetails.test.tsx
+++ b/src/features/publications/components/PublicationDetails/PublicationDetails.test.tsx
@@ -8,7 +8,7 @@ import PublicationDetails from "./PublicationDetails";
 import { mirrors } from "@/tests/mocks/mirrors";
 import { getSourceType } from "../..";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
-import moment from "moment";
+import date from "@/libs/date";
 import { AUTOMATIC_LABELS } from "../../constants";
 import { expectLoadingState } from "@/tests/helpers";
 import { NO_DATA_TEXT } from "@/components/layout/NoData";
@@ -44,7 +44,7 @@ describe("PublicationDetails", () => {
       { label: "Status", value: "Published" },
       {
         label: "Last published",
-        value: moment(publication.publishTime).format(DISPLAY_DATE_TIME_FORMAT),
+        value: date(publication.publishTime).format(DISPLAY_DATE_TIME_FORMAT),
       },
       { label: "Distribution", value: publication.distribution },
       {

--- a/src/features/publications/components/PublicationDetails/PublicationDetails.tsx
+++ b/src/features/publications/components/PublicationDetails/PublicationDetails.tsx
@@ -11,7 +11,7 @@ import {
   DISPLAY_DATE_TIME_FORMAT,
   DEFAULT_POLLING_INTERVAL,
 } from "@/constants";
-import moment from "moment";
+import date from "@/libs/date";
 import { NO_DATA_TEXT } from "@/components/layout/NoData/constants";
 import {
   OperationStatusContent,
@@ -134,7 +134,7 @@ const PublicationDetails = ({
               label="Last published"
               value={
                 publication.publishTime
-                  ? moment(publication.publishTime).format(
+                  ? date(publication.publishTime).format(
                       DISPLAY_DATE_TIME_FORMAT,
                     )
                   : NO_DATA_TEXT

--- a/src/features/publications/components/PublicationsList/PublicationsList.tsx
+++ b/src/features/publications/components/PublicationsList/PublicationsList.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../helpers";
 import type { Publication } from "@canonical/landscape-openapi";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
-import moment from "moment";
+import date from "@/libs/date";
 import { ROUTES } from "@/libs/routes";
 import { NO_DATA_TEXT } from "@/components/layout/NoData";
 import { OperationStatusCell, OperationProvider } from "@/features/operations";
@@ -76,7 +76,7 @@ const PublicationsList: FC<PublicationsListProps> = ({
         className: classes.datetime,
         Cell: ({ row: { original } }: CellProps<Publication>) =>
           original.publishTime
-            ? moment(original.publishTime).format(DISPLAY_DATE_TIME_FORMAT)
+            ? date(original.publishTime).format(DISPLAY_DATE_TIME_FORMAT)
             : NO_DATA_TEXT,
       },
       {

--- a/src/features/script-profiles/components/ScriptProfileActivitiesList/ScriptProfileActivitiesList.test.tsx
+++ b/src/features/script-profiles/components/ScriptProfileActivitiesList/ScriptProfileActivitiesList.test.tsx
@@ -2,7 +2,7 @@ import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import { ACTIVITY_STATUSES } from "@/features/activities";
 import { activities } from "@/tests/mocks/activity";
 import { renderWithProviders } from "@/tests/render";
-import moment from "moment";
+import date from "@/libs/date";
 import { describe, it } from "vitest";
 import ScriptProfileActivitiesList from "./ScriptProfileActivitiesList";
 
@@ -19,7 +19,7 @@ describe("ScriptProfileActivitiesList", () => {
 
     for (const activity of activities) {
       expect(table).toHaveTextContent(
-        moment(activity.creation_time).utc().format(DISPLAY_DATE_TIME_FORMAT),
+        date(activity.creation_time).utc().format(DISPLAY_DATE_TIME_FORMAT),
       );
       expect(table).toHaveTextContent(
         ACTIVITY_STATUSES[activity.activity_status].label,

--- a/src/features/script-profiles/components/ScriptProfileActivitiesList/ScriptProfileActivitiesList.tsx
+++ b/src/features/script-profiles/components/ScriptProfileActivitiesList/ScriptProfileActivitiesList.tsx
@@ -1,7 +1,7 @@
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import { ACTIVITY_STATUSES, type ActivityCommon } from "@/features/activities";
 import { ModularTable } from "@canonical/react-components";
-import moment from "moment";
+import date from "@/libs/date";
 import { type FC, useMemo } from "react";
 import { Link } from "react-router";
 import type { CellProps, Column } from "react-table";
@@ -24,7 +24,7 @@ const ScriptProfileActivitiesList: FC<ScriptProfileActivitiesListProps> = ({
             className="font-monospace"
             to={ROUTES.activities.root({ query: `parent-id:${activity.id}` })}
           >
-            {moment(activity.creation_time)
+            {date(activity.creation_time)
               .utc()
               .format(DISPLAY_DATE_TIME_FORMAT)}
           </Link>

--- a/src/features/script-profiles/components/ScriptProfileAddSidePanel/constants.ts
+++ b/src/features/script-profiles/components/ScriptProfileAddSidePanel/constants.ts
@@ -1,15 +1,15 @@
 import { INPUT_DATE_TIME_FORMAT } from "@/constants";
-import moment from "moment";
+import date from "@/libs/date";
 import type { ScriptProfileFormValues } from "../ScriptProfileForm/types";
 
 export const SCRIPT_PROFILE_ADD_SIDE_PANEL_INITIAL_VALUES: ScriptProfileFormValues =
   {
     all_computers: false,
     interval: "",
-    start_after: moment().utc().format(INPUT_DATE_TIME_FORMAT),
+    start_after: date().utc().format(INPUT_DATE_TIME_FORMAT),
     tags: [],
     time_limit: 300,
-    timestamp: moment().utc().format(INPUT_DATE_TIME_FORMAT),
+    timestamp: date().utc().format(INPUT_DATE_TIME_FORMAT),
     title: "",
     trigger_type: "",
     username: "root",

--- a/src/features/script-profiles/components/ScriptProfileEditSidePanel/helpers.ts
+++ b/src/features/script-profiles/components/ScriptProfileEditSidePanel/helpers.ts
@@ -1,5 +1,5 @@
 import { INPUT_DATE_TIME_FORMAT } from "@/constants";
-import moment from "moment";
+import date from "@/libs/date";
 import type { ScriptProfile } from "../../types";
 
 export const getScriptProfileEditFormInitialValues = (
@@ -10,13 +10,13 @@ export const getScriptProfileEditFormInitialValues = (
   ...scriptProfile.trigger,
   start_after:
     scriptProfile.trigger.trigger_type == "recurring"
-      ? moment(scriptProfile.trigger.start_after)
+      ? date(scriptProfile.trigger.start_after)
           .utc()
           .format(INPUT_DATE_TIME_FORMAT)
       : "",
   timestamp:
     scriptProfile.trigger.trigger_type == "one_time"
-      ? moment(scriptProfile.trigger.timestamp)
+      ? date(scriptProfile.trigger.timestamp)
           .utc()
           .format(INPUT_DATE_TIME_FORMAT)
       : "",

--- a/src/features/script-profiles/components/ScriptProfileForm/ScriptProfileForm.test.tsx
+++ b/src/features/script-profiles/components/ScriptProfileForm/ScriptProfileForm.test.tsx
@@ -4,8 +4,8 @@ import { renderWithProviders } from "@/tests/render";
 import server from "@/tests/server";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import date from "@/libs/date";
 import { http, HttpResponse } from "msw";
-import moment from "moment";
 import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import ScriptProfileForm from "./ScriptProfileForm";
@@ -15,10 +15,10 @@ describe("ScriptProfileForm", () => {
     initialValues: {
       all_computers: false,
       interval: "0 0 * * *",
-      start_after: moment().format(INPUT_DATE_TIME_FORMAT),
+      start_after: date().format(INPUT_DATE_TIME_FORMAT),
       tags: [],
       time_limit: 300,
-      timestamp: moment().format(INPUT_DATE_TIME_FORMAT),
+      timestamp: date().format(INPUT_DATE_TIME_FORMAT),
       title: "New profile",
       trigger_type: "event",
       username: "root",
@@ -82,10 +82,10 @@ describe("ScriptProfileForm instances request params", () => {
     initialValues: {
       all_computers: false,
       interval: "0 0 * * *",
-      start_after: moment().format(INPUT_DATE_TIME_FORMAT),
+      start_after: date().format(INPUT_DATE_TIME_FORMAT),
       tags: [],
       time_limit: 300,
-      timestamp: moment().format(INPUT_DATE_TIME_FORMAT),
+      timestamp: date().format(INPUT_DATE_TIME_FORMAT),
       title: "New profile",
       trigger_type: "event",
       username: "root",

--- a/src/features/script-profiles/components/ScriptProfileForm/ScriptProfileForm.tsx
+++ b/src/features/script-profiles/components/ScriptProfileForm/ScriptProfileForm.tsx
@@ -20,7 +20,7 @@ import {
 } from "@canonical/react-components";
 import classNames from "classnames";
 import { useFormik } from "formik";
-import moment from "moment";
+import date from "@/libs/date";
 import { useLayoutEffect, useRef, type ComponentProps, type FC } from "react";
 import * as Yup from "yup";
 import { useGetScriptProfileLimits } from "../../api";
@@ -337,7 +337,7 @@ const ScriptProfileForm: FC<ScriptProfileFormProps> = ({
             type="datetime-local"
             label="Date"
             required
-            min={moment().utc(true).format(INPUT_DATE_TIME_FORMAT)}
+            min={date().utc(true).format(INPUT_DATE_TIME_FORMAT)}
             {...formik.getFieldProps("timestamp")}
             error={getFormikError(formik, "timestamp")}
           />
@@ -349,7 +349,7 @@ const ScriptProfileForm: FC<ScriptProfileFormProps> = ({
               type="datetime-local"
               label="Start date"
               required
-              min={moment().utc(true).format(INPUT_DATE_TIME_FORMAT)}
+              min={date().utc(true).format(INPUT_DATE_TIME_FORMAT)}
               {...formik.getFieldProps("start_after")}
               error={getFormikError(formik, "start_after")}
             />

--- a/src/features/scripts/api/useRunScript.ts
+++ b/src/features/scripts/api/useRunScript.ts
@@ -3,7 +3,7 @@ import useFetchOld from "@/hooks/useFetchOld";
 import type { ApiError } from "@/types/api/ApiError";
 import { useMutation } from "@tanstack/react-query";
 import type { AxiosError, AxiosResponse } from "axios";
-import moment from "moment";
+import date from "@/libs/date";
 
 export interface RunScriptParams {
   query: string;
@@ -27,7 +27,7 @@ export const useRunScript = () => {
       const formattedParams = {
         ...params,
         deliver_after: params.deliver_after
-          ? moment(params.deliver_after).utc().format("YYYY-MM-DDTHH:mm:ss[Z]")
+          ? date(params.deliver_after).utc().format("YYYY-MM-DDTHH:mm:ss[Z]")
           : undefined,
       };
 

--- a/src/features/scripts/components/RunScriptForm/RunScriptForm.tsx
+++ b/src/features/scripts/components/RunScriptForm/RunScriptForm.tsx
@@ -18,7 +18,7 @@ import {
   Row,
 } from "@canonical/react-components";
 import { useFormik } from "formik";
-import moment from "moment/moment";
+import date from "@/libs/date";
 import { type FC, useState } from "react";
 import { useBoolean } from "usehooks-ts";
 import { useEditScript, useRunScript } from "../../api";
@@ -85,13 +85,13 @@ const RunScriptForm: FC<RunScriptFormProps> = ({
       time_limit: Number(values.time_limit),
       deliver_after: values.deliver_immediately
         ? undefined
-        : moment(values.deliver_after)
+        : date(values.deliver_after)
             .toISOString()
             .replace(/\.\d+(?=Z$)/, ""),
     };
 
     if (!values.deliver_immediately) {
-      valuesToSubmit.deliver_after = moment(values.deliver_after)
+      valuesToSubmit.deliver_after = date(values.deliver_after)
         .toISOString()
         .replace(/\.\d+(?=Z$)/, "");
     }

--- a/src/features/scripts/components/ScriptDetails/ScriptDetails.tsx
+++ b/src/features/scripts/components/ScriptDetails/ScriptDetails.tsx
@@ -4,7 +4,7 @@ import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import { useGetSingleScript } from "@/features/scripts";
 import useSidePanel from "@/hooks/useSidePanel";
 import { Button, Icon, ICONS, Notification } from "@canonical/react-components";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { lazy, Suspense } from "react";
 import { useArchiveScriptModal, useDeleteScriptModal } from "../../hooks";
@@ -120,7 +120,7 @@ const ScriptDetails: FC<ScriptDetailsProps> = ({
       <Notification severity="caution" className="u-no-margin">
         <b>Script deleted:</b> The script was deleted by{" "}
         {script.last_edited_by.name} on{" "}
-        {moment(script.last_edited_at).format(DISPLAY_DATE_TIME_FORMAT)}
+        {date(script.last_edited_at).format(DISPLAY_DATE_TIME_FORMAT)}
       </Notification>
     );
   }
@@ -131,7 +131,7 @@ const ScriptDetails: FC<ScriptDetailsProps> = ({
         <Notification severity="caution">
           <b>Script archived:</b> The script was archived by{" "}
           {script.last_edited_by.name} on{" "}
-          {moment(script.last_edited_at).format(DISPLAY_DATE_TIME_FORMAT)}
+          {date(script.last_edited_at).format(DISPLAY_DATE_TIME_FORMAT)}
         </Notification>
       ) : null}
 

--- a/src/features/scripts/components/ScriptList/ScriptList.tsx
+++ b/src/features/scripts/components/ScriptList/ScriptList.tsx
@@ -12,7 +12,7 @@ import useSidePanel from "@/hooks/useSidePanel";
 import { ROUTES } from "@/libs/routes";
 import type { SelectOption } from "@/types/SelectOption";
 import { Button } from "@canonical/react-components";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC, ReactElement } from "react";
 import { lazy, Suspense, useCallback, useMemo } from "react";
 import type { CellProps, Column } from "react-table";
@@ -144,7 +144,7 @@ const ScriptList: FC<ScriptListProps> = ({ scripts }) => {
         }: CellProps<Script>): ReactElement<Element> => (
           <div>
             <div className="font-monospace">
-              {moment(original.created_at).format(DISPLAY_DATE_TIME_FORMAT)}
+              {date(original.created_at).format(DISPLAY_DATE_TIME_FORMAT)}
             </div>
             <div className="u-text--muted p-text--small u-no-margin--bottom">
               {original.created_by.name}
@@ -161,7 +161,7 @@ const ScriptList: FC<ScriptListProps> = ({ scripts }) => {
         }: CellProps<Script>): ReactElement<Element> => (
           <div>
             <div className="font-monospace">
-              {moment(original.last_edited_at).format(DISPLAY_DATE_TIME_FORMAT)}
+              {date(original.last_edited_at).format(DISPLAY_DATE_TIME_FORMAT)}
             </div>
             <div className="u-text--muted p-text--small u-no-margin--bottom">
               {original.last_edited_by.name}

--- a/src/features/scripts/helpers.test.ts
+++ b/src/features/scripts/helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import moment from "moment";
+import date from "@/libs/date";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import {
   formatTitleCase,
@@ -92,13 +92,13 @@ describe("scripts helpers", () => {
   it("formats shebang code and author metadata", () => {
     const interpreter = "/usr/bin/python3";
     const code = "print('ok')";
-    const date = "2024-01-01T12:34:56Z";
+    const dateString = "2024-01-01T12:34:56Z";
 
     expect(getCode({ interpreter, code })).toBe(
       "#!/usr/bin/python3\nprint('ok')",
     );
-    expect(getAuthorInfo({ author: "alice", date })).toBe(
-      `${moment(date).format(DISPLAY_DATE_TIME_FORMAT)}, by alice`,
+    expect(getAuthorInfo({ author: "alice", date: dateString })).toBe(
+      `${date(dateString).format(DISPLAY_DATE_TIME_FORMAT)}, by alice`,
     );
   });
 });

--- a/src/features/scripts/helpers.ts
+++ b/src/features/scripts/helpers.ts
@@ -1,7 +1,7 @@
 import type { ScriptFormValues } from "./types";
 import type { CreateScriptAttachmentParams } from "./api";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
-import moment from "moment";
+import date from "@/libs/date";
 
 const uint8ToBase64 = (bytes: Uint8Array): string => {
   let binary = "";
@@ -99,10 +99,10 @@ export const getCode = ({
 
 export const getAuthorInfo = ({
   author,
-  date,
+  date: dateString,
 }: {
   author: string;
   date: string;
 }) => {
-  return `${moment(date).format(DISPLAY_DATE_TIME_FORMAT)}, by ${author}`;
+  return `${date(dateString).format(DISPLAY_DATE_TIME_FORMAT)}, by ${author}`;
 };

--- a/src/features/snaps/components/HoldSnapForm/HoldSnapForm.tsx
+++ b/src/features/snaps/components/HoldSnapForm/HoldSnapForm.tsx
@@ -12,7 +12,7 @@ import { hasOneItem, pluralize } from "@/utils/_helpers";
 import { getFormikError } from "@/utils/formikErrors";
 import { Form, Input } from "@canonical/react-components";
 import { useFormik } from "formik";
-import moment from "moment";
+import date from "@/libs/date";
 import type { ChangeEvent, FC } from "react";
 import { useParams } from "react-router";
 import { useSnapAction } from "../../api";
@@ -46,12 +46,12 @@ const HoldSnapForm: FC<HoldSnapFormProps> = ({ installedSnaps }) => {
         if (values.hold === "forever") {
           holdTime = "forever";
         } else if (values.hold_until) {
-          holdTime = moment(values.hold_until).format();
+          holdTime = date(values.hold_until).format();
         }
 
         const deliverAfter =
           !values.deliver_immediately && values.deliver_after
-            ? moment(values.deliver_after).format()
+            ? date(values.deliver_after).format()
             : undefined;
 
         await snapAction({
@@ -81,7 +81,7 @@ const HoldSnapForm: FC<HoldSnapFormProps> = ({ installedSnaps }) => {
     if (event.currentTarget.value === "date") {
       void formik.setFieldValue(
         "hold_until",
-        moment().toISOString().slice(0, 16),
+        date().toISOString().slice(0, 16),
       );
     }
   };

--- a/src/features/snaps/components/HoldSnapForm/constants.ts
+++ b/src/features/snaps/components/HoldSnapForm/constants.ts
@@ -3,7 +3,7 @@ import {
   deliveryValidationSchema,
   randomizationValidationSchema,
 } from "@/components/form/DeliveryScheduling";
-import moment from "moment";
+import date from "@/libs/date";
 import * as Yup from "yup";
 
 export const INITIAL_VALUES: HoldFormValues = {
@@ -24,7 +24,7 @@ export const VALIDATION_SCHEMA = Yup.object().shape({
       if (!value) {
         return true;
       }
-      return moment(value).isValid();
+      return date(value).isValid();
     },
     message: "You have to enter a valid date and time",
   }),

--- a/src/features/snaps/components/RefreshSnapForm/RefreshSnapForm.tsx
+++ b/src/features/snaps/components/RefreshSnapForm/RefreshSnapForm.tsx
@@ -10,7 +10,7 @@ import type { UrlParams } from "@/types/UrlParams";
 import { getSelectionLabel, pluralize } from "@/utils/_helpers";
 import { Form } from "@canonical/react-components";
 import { useFormik } from "formik";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { useParams } from "react-router";
 import { useSnapAction } from "../../api";
@@ -38,7 +38,7 @@ const RefreshSnapForm: FC<RefreshSnapFormProps> = ({ installedSnaps }) => {
       try {
         const deliverAfter =
           !values.deliver_immediately && values.deliver_after
-            ? moment(values.deliver_after).format()
+            ? date(values.deliver_after).format()
             : undefined;
         await snapAction({
           computer_ids: [instanceId],

--- a/src/features/snaps/components/SnapDetails/SnapDetails.test.tsx
+++ b/src/features/snaps/components/SnapDetails/SnapDetails.test.tsx
@@ -3,7 +3,7 @@ import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import "@/tests/matcher";
 import { installedSnaps } from "@/tests/mocks/snap";
 import { renderWithProviders } from "@/tests/render";
-import moment from "moment";
+import date from "@/libs/date";
 import { describe } from "vitest";
 import type { InstalledSnap } from "../../types";
 import SnapDetails from "./SnapDetails";
@@ -28,8 +28,8 @@ describe("Snap details", () => {
           { label: "Confinement", value: installedSnap.confinement },
           {
             label: "Held until",
-            value: moment(installedSnap.held_until).isValid() ? (
-              moment(installedSnap.held_until).format(DISPLAY_DATE_TIME_FORMAT)
+            value: date(installedSnap.held_until).isValid() ? (
+              date(installedSnap.held_until).format(DISPLAY_DATE_TIME_FORMAT)
             ) : (
               <NoData />
             ),

--- a/src/features/snaps/components/SnapDetails/SnapDetails.tsx
+++ b/src/features/snaps/components/SnapDetails/SnapDetails.tsx
@@ -1,6 +1,6 @@
 import InfoGrid from "@/components/layout/InfoGrid";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import type { InstalledSnap } from "../../types";
 import SnapsActions from "../SnapsActions";
@@ -23,8 +23,8 @@ const SnapDetails: FC<SnapDetailsProps> = ({ installedSnap }) => {
         <InfoGrid.Item
           label="Held until"
           value={
-            moment(installedSnap.held_until).isValid()
-              ? moment(installedSnap.held_until).format(
+            date(installedSnap.held_until).isValid()
+              ? date(installedSnap.held_until).format(
                   DISPLAY_DATE_TIME_FORMAT,
                 )
               : null

--- a/src/features/snaps/components/SnapDetails/SnapDetails.tsx
+++ b/src/features/snaps/components/SnapDetails/SnapDetails.tsx
@@ -24,9 +24,7 @@ const SnapDetails: FC<SnapDetailsProps> = ({ installedSnap }) => {
           label="Held until"
           value={
             date(installedSnap.held_until).isValid()
-              ? date(installedSnap.held_until).format(
-                  DISPLAY_DATE_TIME_FORMAT,
-                )
+              ? date(installedSnap.held_until).format(DISPLAY_DATE_TIME_FORMAT)
               : null
           }
         />

--- a/src/features/snaps/components/SnapsList/SnapsList.test.tsx
+++ b/src/features/snaps/components/SnapsList/SnapsList.test.tsx
@@ -4,7 +4,7 @@ import { installedSnaps } from "@/tests/mocks/snap";
 import { renderWithProviders } from "@/tests/render";
 import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import moment from "moment";
+import date from "@/libs/date";
 import { describe, expect, vi } from "vitest";
 import SnapsList from "./SnapsList";
 import { setScreenSize } from "@/tests/helpers";
@@ -150,8 +150,8 @@ describe("SnapsList", () => {
         { label: "Confinement", value: selectedSnap.confinement },
         {
           label: "Held until",
-          value: moment(selectedSnap.held_until).isValid() ? (
-            moment(selectedSnap.held_until).format(DISPLAY_DATE_TIME_FORMAT)
+          value: date(selectedSnap.held_until).isValid() ? (
+            date(selectedSnap.held_until).format(DISPLAY_DATE_TIME_FORMAT)
           ) : (
             <NoData />
           ),

--- a/src/features/snaps/components/SnapsList/SnapsList.tsx
+++ b/src/features/snaps/components/SnapsList/SnapsList.tsx
@@ -119,9 +119,7 @@ const SnapsList: FC<SnapsListProps> = ({
             {date(row.original.held_until).isValid() ? (
               <span className="font-monospace">
                 {" "}
-                {date(row.original.held_until).format(
-                  DISPLAY_DATE_TIME_FORMAT,
-                )}
+                {date(row.original.held_until).format(DISPLAY_DATE_TIME_FORMAT)}
               </span>
             ) : (
               <NoData />

--- a/src/features/snaps/components/SnapsList/SnapsList.tsx
+++ b/src/features/snaps/components/SnapsList/SnapsList.tsx
@@ -4,7 +4,7 @@ import ResponsiveTable from "@/components/layout/ResponsiveTable";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import useSidePanel from "@/hooks/useSidePanel";
 import { Button, CheckboxInput, Tooltip } from "@canonical/react-components";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { Suspense, useCallback, useMemo } from "react";
 import type { CellProps, Column, Row } from "react-table";
@@ -116,10 +116,10 @@ const SnapsList: FC<SnapsListProps> = ({
         className: "large-cell",
         Cell: ({ row }: CellProps<InstalledSnap>) => (
           <>
-            {moment(row.original.held_until).isValid() ? (
+            {date(row.original.held_until).isValid() ? (
               <span className="font-monospace">
                 {" "}
-                {moment(row.original.held_until).format(
+                {date(row.original.held_until).format(
                   DISPLAY_DATE_TIME_FORMAT,
                 )}
               </span>

--- a/src/features/snaps/components/SwitchSnapForm/SwitchSnapForm.tsx
+++ b/src/features/snaps/components/SwitchSnapForm/SwitchSnapForm.tsx
@@ -11,7 +11,7 @@ import { pluralize } from "@/utils/_helpers";
 import { getFormikError } from "@/utils/formikErrors";
 import { Form, Select } from "@canonical/react-components";
 import { useFormik } from "formik";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { useMemo } from "react";
 import { useParams } from "react-router";
@@ -55,7 +55,7 @@ const SwitchSnapForm: FC<SwitchSnapFormProps> = ({
       try {
         const deliverAfter =
           !values.deliver_immediately && values.deliver_after
-            ? moment(values.deliver_after).format()
+            ? date(values.deliver_after).format()
             : undefined;
         await snapAction({
           computer_ids: [instanceId],

--- a/src/features/snaps/components/UnholdSnapForm/UnholdSnapForm.tsx
+++ b/src/features/snaps/components/UnholdSnapForm/UnholdSnapForm.tsx
@@ -11,7 +11,7 @@ import type { UrlParams } from "@/types/UrlParams";
 import { hasOneItem, pluralize } from "@/utils/_helpers";
 import { Form } from "@canonical/react-components";
 import { useFormik } from "formik";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { useParams } from "react-router";
 import { useSnapAction } from "../../api";
@@ -42,7 +42,7 @@ const UnholdSnapForm: FC<UnholdSnapFormProps> = ({ installedSnaps }) => {
       try {
         const deliverAfter =
           !values.deliver_immediately && values.deliver_after
-            ? moment(values.deliver_after).format()
+            ? date(values.deliver_after).format()
             : undefined;
         await snapAction({
           computer_ids: [instanceId],

--- a/src/features/snaps/components/UninstallSnapForm/UninstallSnapForm.tsx
+++ b/src/features/snaps/components/UninstallSnapForm/UninstallSnapForm.tsx
@@ -10,7 +10,7 @@ import type { UrlParams } from "@/types/UrlParams";
 import { getSelectionLabel, pluralize } from "@/utils/_helpers";
 import { Form } from "@canonical/react-components";
 import { useFormik } from "formik";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { useParams } from "react-router";
 import { useSnapAction } from "../../api";
@@ -38,7 +38,7 @@ const UninstallSnapForm: FC<UninstallSnapFormProps> = ({ installedSnaps }) => {
       try {
         const deliverAfter =
           !values.deliver_immediately && values.deliver_after
-            ? moment(values.deliver_after).format()
+            ? date(values.deliver_after).format()
             : undefined;
         await snapAction({
           computer_ids: [instanceId],

--- a/src/features/ubuntupro/components/UbuntuProInfoRow/UbuntuProInfoRow.test.tsx
+++ b/src/features/ubuntupro/components/UbuntuProInfoRow/UbuntuProInfoRow.test.tsx
@@ -3,7 +3,7 @@ import { renderWithProviders } from "@/tests/render";
 import { INSTANCES_PATHS } from "@/libs/routes/instances";
 import UbuntuProInfoRow from "./UbuntuProInfoRow";
 import { screen } from "@testing-library/react";
-import moment from "moment";
+import date from "@/libs/date";
 import { DISPLAY_DATE_TIME_FORMAT, MASKED_VALUE } from "@/constants";
 import { getInstanceWithUbuntuPro } from "../../helpers";
 
@@ -44,8 +44,8 @@ describe("UbuntuProInfoRow", () => {
       singleInstancePath,
     );
 
-    if (ubuntuProData.expires && moment(ubuntuProData.expires).isValid()) {
-      const formattedDate = moment(ubuntuProData.expires).format(
+    if (ubuntuProData.expires && date(ubuntuProData.expires).isValid()) {
+      const formattedDate = date(ubuntuProData.expires).format(
         DISPLAY_DATE_TIME_FORMAT,
       );
       expect(container).toHaveInfoItem("Valid Until", formattedDate);

--- a/src/features/ubuntupro/components/UbuntuProInfoRow/UbuntuProInfoRow.tsx
+++ b/src/features/ubuntupro/components/UbuntuProInfoRow/UbuntuProInfoRow.tsx
@@ -1,7 +1,7 @@
 import InfoGrid from "@/components/layout/InfoGrid";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import type { Instance, UbuntuProInfo } from "@/types/Instance";
-import moment from "moment";
+import date from "@/libs/date";
 import { type FC } from "react";
 import classes from "./UbuntuProInfoRow.module.scss";
 
@@ -20,8 +20,8 @@ const UbuntuProInfoRow: FC<UbuntuProInfoRowProps> = ({ instance }) => {
         <InfoGrid.Item
           label="Valid Until"
           value={
-            ubuntuProData.expires && moment(ubuntuProData.expires).isValid()
-              ? moment(ubuntuProData.expires).format(DISPLAY_DATE_TIME_FORMAT)
+            ubuntuProData.expires && date(ubuntuProData.expires).isValid()
+              ? date(ubuntuProData.expires).format(DISPLAY_DATE_TIME_FORMAT)
               : null
           }
         />

--- a/src/features/usg-profiles/components/USGProfileAddSidePanel/USGProfileAddSidePanel.tsx
+++ b/src/features/usg-profiles/components/USGProfileAddSidePanel/USGProfileAddSidePanel.tsx
@@ -4,7 +4,7 @@ import { DEFAULT_ACCESS_GROUP_NAME, INPUT_DATE_TIME_FORMAT } from "@/constants";
 import useNotify from "@/hooks/useNotify";
 import usePageParams from "@/hooks/usePageParams";
 import classNames from "classnames";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { useState } from "react";
 import type { FormikErrors } from "formik";
@@ -61,7 +61,7 @@ const USGProfileAddSidePanel: FC<USGProfileAddSidePanelProps> = ({
       randomize_delivery: false,
       deliver_delay_window: 1,
       restart_deliver_delay: 1,
-      start_date: moment().utc().format(INPUT_DATE_TIME_FORMAT),
+      start_date: date().utc().format(INPUT_DATE_TIME_FORMAT),
       start_type: "on-a-date",
       tags: [],
       tailoring_file: null,

--- a/src/features/usg-profiles/components/USGProfileDownloadAuditSidePanel/components/USGProfileDownloadAuditForm/USGProfileDownloadAuditForm.tsx
+++ b/src/features/usg-profiles/components/USGProfileDownloadAuditSidePanel/components/USGProfileDownloadAuditForm/USGProfileDownloadAuditForm.tsx
@@ -8,7 +8,7 @@ import usePageParams from "@/hooks/usePageParams";
 import { getFormikError } from "@/utils/formikErrors";
 import { ActionButton, Input, Notification } from "@canonical/react-components";
 import { useFormik } from "formik";
-import moment from "moment";
+import date from "@/libs/date";
 import { useEffect, useState, type FC } from "react";
 import * as Yup from "yup";
 import { useGetUsgProfileReport } from "../../../../api";
@@ -92,8 +92,8 @@ const USGProfileDownloadAuditForm: FC<USGProfileDownloadAuditFormProps> = ({
   const formik = useFormik<USGProfileDownloadAuditFormValues>({
     initialValues: {
       audit_timeframe: "specific-date",
-      end_date: moment().format(INPUT_DATE_FORMAT),
-      start_date: moment().format(INPUT_DATE_FORMAT),
+      end_date: date().format(INPUT_DATE_FORMAT),
+      start_date: date().format(INPUT_DATE_FORMAT),
       level_of_detail: "summary-only",
     },
 
@@ -108,12 +108,12 @@ const USGProfileDownloadAuditForm: FC<USGProfileDownloadAuditFormProps> = ({
                 .required("This field is required.")
                 .test({
                   test: (end_date) =>
-                    moment(end_date).isSameOrAfter(moment(start_date)),
+                    date(end_date).isSameOrAfter(date(start_date)),
                   message: "The end date must not be before the start date.",
                 })
                 .test({
                   test: (end_date) =>
-                    moment(end_date).utc(true).isSameOrBefore(moment()),
+                    date(end_date).utc(true).isSameOrBefore(date()),
                   message: "The end date must not be in the future.",
                 })
             : schema,
@@ -123,7 +123,7 @@ const USGProfileDownloadAuditForm: FC<USGProfileDownloadAuditFormProps> = ({
         .required("This field is required.")
         .test({
           test: (start_date) =>
-            moment(start_date).utc(true).isSameOrBefore(moment()),
+            date(start_date).utc(true).isSameOrBefore(date()),
           message: "The date must not be in the future.",
         }),
     }),
@@ -243,7 +243,7 @@ const USGProfileDownloadAuditForm: FC<USGProfileDownloadAuditFormProps> = ({
                 type="date"
                 {...formik.getFieldProps("start_date")}
                 error={getFormikError(formik, "start_date")}
-                max={moment().utc().format(INPUT_DATE_FORMAT)}
+                max={date().utc().format(INPUT_DATE_FORMAT)}
               />
             ),
           },
@@ -258,7 +258,7 @@ const USGProfileDownloadAuditForm: FC<USGProfileDownloadAuditFormProps> = ({
                     type="date"
                     {...formik.getFieldProps("start_date")}
                     error={getFormikError(formik, "start_date")}
-                    max={moment(formik.values.end_date)
+                    max={date(formik.values.end_date)
                       .utc()
                       .format(INPUT_DATE_FORMAT)}
                   />
@@ -271,8 +271,8 @@ const USGProfileDownloadAuditForm: FC<USGProfileDownloadAuditFormProps> = ({
                     type="date"
                     {...formik.getFieldProps("end_date")}
                     error={getFormikError(formik, "end_date")}
-                    max={moment().utc().format(INPUT_DATE_FORMAT)}
-                    min={moment(formik.values.start_date).format(
+                    max={date().utc().format(INPUT_DATE_FORMAT)}
+                    min={date(formik.values.start_date).format(
                       INPUT_DATE_FORMAT,
                     )}
                   />

--- a/src/features/usg-profiles/components/USGProfileForm/USGProfileForm.test.tsx
+++ b/src/features/usg-profiles/components/USGProfileForm/USGProfileForm.test.tsx
@@ -8,8 +8,8 @@ import { renderWithProviders } from "@/tests/render";
 import server from "@/tests/server";
 import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import date from "@/libs/date";
 import { http, HttpResponse } from "msw";
-import moment from "moment";
 import { type ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import USGProfileForm from "./USGProfileForm";
@@ -31,7 +31,7 @@ const getProps = (): ComponentProps<typeof USGProfileForm> => ({
     randomize_delivery: false,
     restart_deliver_delay: 0,
     deliver_delay_window: 0,
-    start_date: moment().format(INPUT_DATE_TIME_FORMAT),
+    start_date: date().format(INPUT_DATE_TIME_FORMAT),
     start_type: "on-a-date",
     tags: [],
     tailoring_file: null,

--- a/src/features/usg-profiles/components/USGProfileLastRunWithSchedule/USGProfileLastRunWithSchedule.tsx
+++ b/src/features/usg-profiles/components/USGProfileLastRunWithSchedule/USGProfileLastRunWithSchedule.tsx
@@ -3,7 +3,7 @@ import { Tooltip } from "@canonical/react-components";
 import type { FC } from "react";
 import type { USGProfile } from "../../types";
 import classes from "./USGProfileLastRunWithSchedule.module.scss";
-import moment from "moment";
+import date from "@/libs/date";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import { getUsgSchedule } from "../../helpers";
 
@@ -17,14 +17,14 @@ const USGProfileLastRunWithSchedule: FC<USGProfileLastRunWithScheduleProps> = ({
   const lastRun = !profile.last_run_results.timestamp ? (
     <NoData />
   ) : (
-    moment(profile.last_run_results.timestamp)
+    date(profile.last_run_results.timestamp)
       .utc()
       .format(DISPLAY_DATE_TIME_FORMAT)
   );
   const nextRun = !profile.next_run_time ? (
     <NoData />
   ) : (
-    moment(profile.next_run_time).utc().format(DISPLAY_DATE_TIME_FORMAT)
+    date(profile.next_run_time).utc().format(DISPLAY_DATE_TIME_FORMAT)
   );
 
   const tooltipMessage = (

--- a/src/features/usg-profiles/helpers.tsx
+++ b/src/features/usg-profiles/helpers.tsx
@@ -3,7 +3,7 @@ import NoData from "@/components/layout/NoData";
 import { DISPLAY_DATE_TIME_FORMAT, INPUT_DATE_TIME_FORMAT } from "@/constants";
 import type { NotificationHelper } from "@/types/Notification";
 import { Icon, Tooltip } from "@canonical/react-components";
-import moment from "moment";
+import date from "@/libs/date";
 import { USG_PROFILE_ASSOCIATED_INSTANCES_LIMIT } from "./constants";
 import classes from "./helpers.module.scss";
 import type { USGProfile } from "./types";
@@ -150,7 +150,7 @@ export const getUsgSchedule = (profile: USGProfile, short = false) => {
   }
 
   if (schedule.UNTIL) {
-    scheduleText += ` until ${moment(schedule.UNTIL).utc().format(DISPLAY_DATE_TIME_FORMAT)} UTC`;
+    scheduleText += ` until ${date(schedule.UNTIL).utc().format(DISPLAY_DATE_TIME_FORMAT)} UTC`;
   }
 
   return scheduleText;
@@ -199,8 +199,8 @@ export const getInitialValues = (profile: USGProfile): USGProfileFormValues => {
         : [],
     delivery_time: profile.restart_deliver_delay ? "delayed" : "asap",
     end_date: schedule.UNTIL
-      ? moment(schedule.UNTIL).format(INPUT_DATE_TIME_FORMAT)
-      : moment().format(INPUT_DATE_TIME_FORMAT),
+      ? date(schedule.UNTIL).format(INPUT_DATE_TIME_FORMAT)
+      : date().format(INPUT_DATE_TIME_FORMAT),
     end_type: schedule.UNTIL ? "on-a-date" : "never",
     every: schedule.INTERVAL,
     months:
@@ -208,7 +208,7 @@ export const getInitialValues = (profile: USGProfile): USGProfileFormValues => {
         ? schedule.BYMONTH.split(",").map((month: string) => Number(month))
         : [],
     randomize_delivery: profile.restart_deliver_delay_window ? true : false,
-    start_date: moment(
+    start_date: date(
       profile.next_run_time ?? profile.last_run_results.timestamp,
     ).format(INPUT_DATE_TIME_FORMAT),
     start_type: schedule.COUNT == 1 ? "on-a-date" : "recurring",
@@ -232,6 +232,6 @@ export const getNotificationMessage = (
   }
 };
 
-export const getDayOfWeek = (date: Date) => {
-  return date.getDay() as 0 | 1 | 2 | 3 | 4 | 5 | 6;
+export const getDayOfWeek = (value: Date) => {
+  return value.getDay() as 0 | 1 | 2 | 3 | 4 | 5 | 6;
 };

--- a/src/features/usg-profiles/hooks/useUsgProfileForm.tsx
+++ b/src/features/usg-profiles/hooks/useUsgProfileForm.tsx
@@ -4,7 +4,7 @@ import { DEFAULT_ACCESS_GROUP_NAME, INPUT_DATE_TIME_FORMAT } from "@/constants";
 import useDebug from "@/hooks/useDebug";
 import usePageParams from "@/hooks/usePageParams";
 import { useFormik } from "formik";
-import moment from "moment";
+import date from "@/libs/date";
 import type { ReactNode } from "react";
 import * as Yup from "yup";
 import { getDayOfWeek } from "../helpers";
@@ -63,7 +63,7 @@ const useUsgProfileForm = ({
           start_type == "recurring" && end_type == "on-a-date"
             ? schema.required("This field is required.").test({
                 test: (end_date) => {
-                  return moment(end_date).isAfter(moment(start_date));
+                  return date(end_date).isAfter(date(start_date));
                 },
                 message: `The end date must be after the start date.`,
               })
@@ -146,8 +146,8 @@ const useUsgProfileForm = ({
           }
 
           case "MONTHLY": {
-            const date = new Date(values.start_date);
-            const dayOfMonth = date.getDate();
+            const startDate = new Date(values.start_date);
+            const dayOfMonth = startDate.getDate();
 
             switch (values.day_of_month_type) {
               case "day-of-month": {
@@ -157,7 +157,7 @@ const useUsgProfileForm = ({
 
               case "day-of-week": {
                 const ordinalWeek = Math.ceil(dayOfMonth / 7);
-                const day = getDayOfWeek(date);
+                const day = getDayOfWeek(startDate);
 
                 scheduleRuleParts.push(
                   `BYDAY=${ordinalWeek > 4 ? -1 : ordinalWeek}${DAY_OPTIONS[day].value}`,
@@ -177,7 +177,7 @@ const useUsgProfileForm = ({
 
         if (values.end_type == "on-a-date") {
           scheduleRuleParts.push(
-            `UNTIL=${moment(values.end_date).format("YYYYMMDDTHHmmss")}Z`,
+            `UNTIL=${date(values.end_date).format("YYYYMMDDTHHmmss")}Z`,
           );
         }
       } else {
@@ -202,7 +202,7 @@ const useUsgProfileForm = ({
               ? values.restart_deliver_delay
               : undefined,
           schedule: scheduleRuleParts.join(";"),
-          start_date: `${moment(values.start_date).format(
+          start_date: `${date(values.start_date).format(
             INPUT_DATE_TIME_FORMAT,
           )}Z`,
           tags: values.all_computers ? undefined : values.tags,

--- a/src/features/usg-profiles/hooks/useUsgProfileFormConfirmationStep.tsx
+++ b/src/features/usg-profiles/hooks/useUsgProfileFormConfirmationStep.tsx
@@ -3,7 +3,7 @@ import InfoGrid from "@/components/layout/InfoGrid";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import { pluralize } from "@/utils/_helpers";
 import type { FormikContextType } from "formik";
-import moment from "moment";
+import date from "@/libs/date";
 import { phrase } from "../helpers";
 import type { USGProfileFormValues } from "../types/USGProfileAddFormValues";
 
@@ -29,7 +29,7 @@ export default function useUsgProfileFormConfirmationStep<
               <>
                 USG profile&apos;s next run date arrives
                 <br />
-                {moment(formik.values.start_date).format(
+                {date(formik.values.start_date).format(
                   `${DISPLAY_DATE_TIME_FORMAT}`,
                 )}
               </>

--- a/src/features/usns/components/UsnList/UsnList.tsx
+++ b/src/features/usns/components/UsnList/UsnList.tsx
@@ -11,7 +11,7 @@ import type { Instance } from "@/types/Instance";
 import type { Usn } from "@/types/Usn";
 import { Button, CheckboxInput } from "@canonical/react-components";
 import classNames from "classnames";
-import moment from "moment/moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { useMemo, useRef, useState } from "react";
 import type { CellProps, Column } from "react-table";
@@ -251,9 +251,9 @@ const UsnList: FC<UsnListProps> = ({
           Header: "Date published",
           Cell: ({ row }: CellProps<Usn>) => (
             <>
-              {moment(row.original.date).isValid() ? (
+              {date(row.original.date).isValid() ? (
                 <span className="font-monospace">
-                  {moment(row.original.date).format(DISPLAY_DATE_TIME_FORMAT)}
+                  {date(row.original.date).format(DISPLAY_DATE_TIME_FORMAT)}
                 </span>
               ) : (
                 <NoData />

--- a/src/features/wsl-profiles/components/WslProfileNonCompliantInstancesList/WslProfileNonCompliantInstancesList.tsx
+++ b/src/features/wsl-profiles/components/WslProfileNonCompliantInstancesList/WslProfileNonCompliantInstancesList.tsx
@@ -23,7 +23,7 @@ import {
   SearchBox,
 } from "@canonical/react-components";
 import classNames from "classnames";
-import moment from "moment";
+import date from "@/libs/date";
 import { useMemo, useState, type FC } from "react";
 import type { CellProps, Column } from "react-table";
 import { useBoolean } from "usehooks-ts";
@@ -139,7 +139,7 @@ const WslProfileNonCompliantInstancesList: FC<
       {
         Header: "Last ping",
         Cell: ({ row: { original: instance } }: CellProps<WindowsInstance>) => {
-          const dateTime = moment(instance.last_ping_time);
+          const dateTime = date(instance.last_ping_time);
 
           if (dateTime.isValid()) {
             return (

--- a/src/libs/date/ChronoDate.test.ts
+++ b/src/libs/date/ChronoDate.test.ts
@@ -7,6 +7,9 @@ const ONE_SECOND_MS = 1000;
 const ONE_MINUTE_MS = 60_000;
 const ONE_HOUR_MS = 3_600_000;
 const PARSED_MILLISECONDS = 456;
+const TRUNCATED_MILLISECONDS = 123;
+const HALF_SECOND_MS = 500;
+const MONTHS_PAST_ONE_YEAR = 13;
 
 describe("ChronoDate factory", () => {
   it("returns the current time when called with no arguments", () => {
@@ -86,6 +89,37 @@ describe("strict ISO 8601 parsing", () => {
     expect(
       date("2024-03-15T10:30:00.123+0200", date.ISO_8601, true).isValid(),
     ).toBe(true);
+  });
+
+  it("parses timezone offsets deterministically", () => {
+    expect(
+      date("2024-03-15T10:30:00+02:00", date.ISO_8601, true)
+        .utc()
+        .format("YYYY-MM-DDTHH:mm:ss"),
+    ).toBe("2024-03-15T08:30:00");
+    expect(
+      date("2024-03-15T10:30:00-0530", date.ISO_8601, true)
+        .utc()
+        .format("YYYY-MM-DDTHH:mm:ss"),
+    ).toBe("2024-03-15T16:00:00");
+    expect(
+      date("2024-03-15T10:30:00Z", date.ISO_8601, true)
+        .utc()
+        .format("YYYY-MM-DDTHH:mm:ss"),
+    ).toBe("2024-03-15T10:30:00");
+  });
+
+  it("truncates fractional seconds to milliseconds", () => {
+    expect(
+      date("2024-03-15T10:30:00.1239Z", date.ISO_8601, true)
+        .toDate()
+        .getUTCMilliseconds(),
+    ).toBe(TRUNCATED_MILLISECONDS);
+    expect(
+      date("2024-03-15T10:30:00.5Z", date.ISO_8601, true)
+        .toDate()
+        .getUTCMilliseconds(),
+    ).toBe(HALF_SECOND_MS);
   });
 
   it("rejects non-ISO strings in strict mode", () => {
@@ -294,6 +328,29 @@ describe("arithmetic", () => {
     expect(
       date("2024-03-15T10:00:00").add(1, "year").format("YYYY-MM-DD"),
     ).toBe("2025-03-15");
+  });
+
+  it("clamps end-of-month dates when adding months and years", () => {
+    expect(
+      date("2024-01-31T10:00:00").add(1, "month").format("YYYY-MM-DD"),
+    ).toBe("2024-02-29");
+    expect(
+      date("2024-03-31T10:00:00").subtract(1, "month").format("YYYY-MM-DD"),
+    ).toBe("2024-02-29");
+    expect(
+      date("2024-02-29T10:00:00").add(1, "year").format("YYYY-MM-DD"),
+    ).toBe("2025-02-28");
+    expect(
+      date("2024-01-31T10:00:00")
+        .add(MONTHS_PAST_ONE_YEAR, "months")
+        .format("YYYY-MM-DD"),
+    ).toBe("2025-02-28");
+  });
+
+  it("preserves wall-clock time when clamping months", () => {
+    expect(
+      date("2024-01-31T10:15:30").add(1, "month").format("YYYY-MM-DDTHH:mm:ss"),
+    ).toBe("2024-02-29T10:15:30");
   });
 
   it("preserves local wall-clock time when adding days across DST", () => {

--- a/src/libs/date/ChronoDate.test.ts
+++ b/src/libs/date/ChronoDate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import date, { LandscapeDate } from "./index";
+import date, { ChronoDate } from "./index";
 
 const FIXED_NOW = new Date("2024-03-15T10:30:00Z").getTime();
 const DAYS_ACROSS_DST_CHANGE = 14;
@@ -8,7 +8,7 @@ const ONE_MINUTE_MS = 60_000;
 const ONE_HOUR_MS = 3_600_000;
 const PARSED_MILLISECONDS = 456;
 
-describe("LandscapeDate factory", () => {
+describe("ChronoDate factory", () => {
   it("returns the current time when called with no arguments", () => {
     vi.useFakeTimers();
     vi.setSystemTime(FIXED_NOW);
@@ -38,7 +38,7 @@ describe("LandscapeDate factory", () => {
     expect(date(native).getTime()).toBe(native.getTime());
   });
 
-  it("clones another LandscapeDate preserving the utc mode", () => {
+  it("clones another ChronoDate preserving the utc mode", () => {
     const utc = date("2024-01-02T03:04:05Z").utc();
     const clone = date(utc);
     expect(clone.format("HH:mm")).toBe(utc.format("HH:mm"));
@@ -381,12 +381,12 @@ describe("calendar", () => {
   });
 });
 
-describe("LandscapeDate class export", () => {
+describe("ChronoDate class export", () => {
   it("exposes a now() helper", () => {
     vi.useFakeTimers();
     vi.setSystemTime(FIXED_NOW);
 
-    expect(LandscapeDate.now().getTime()).toBe(FIXED_NOW);
+    expect(ChronoDate.now().getTime()).toBe(FIXED_NOW);
 
     vi.useRealTimers();
   });

--- a/src/libs/date/ChronoDate.ts
+++ b/src/libs/date/ChronoDate.ts
@@ -1,10 +1,12 @@
 /**
- * LandscapeDate is a small wrapper around the native `Date` object. It
- * centralizes the date behavior and call style the Landscape UI relies on.
+ * ChronoDate is a small, dependency-free wrapper around the native `Date`
+ * object. It centralizes date behavior behind a small, consistent call style.
  *
- * It intentionally implements only the subset used in this codebase, delegating
- * to native `Date` for arithmetic, comparison and serialization and
+ * It intentionally implements only a focused subset of date operations,
+ * delegating to native `Date` for arithmetic, comparison and serialization and
  * adding a small token-based formatter that the native APIs do not provide.
+ *
+ * Locale is English-only by design.
  */
 
 const MONTHS_SHORT = [
@@ -126,7 +128,7 @@ export interface CalendarFormats {
 }
 
 export type DateInput =
-  | LandscapeDate
+  | ChronoDate
   | Date
   | string
   | number
@@ -310,7 +312,7 @@ const FORMAT_TOKENS: Record<string, (fields: DateFields) => string> = {
   a: (f) => (f.H < HOURS_PER_HALF_DAY ? "am" : "pm"),
 };
 
-export class LandscapeDate {
+export class ChronoDate {
   private readonly _time: number;
   private readonly _utc: boolean;
 
@@ -319,40 +321,40 @@ export class LandscapeDate {
     this._utc = utc;
   }
 
-  static now(): LandscapeDate {
-    return new LandscapeDate(Date.now(), false);
+  static now(): ChronoDate {
+    return new ChronoDate(Date.now(), false);
   }
 
-  static from(input: DateInput): LandscapeDate {
+  static from(input: DateInput): ChronoDate {
     if (input === undefined) {
-      return LandscapeDate.now();
+      return ChronoDate.now();
     }
 
     if (input === null) {
-      return new LandscapeDate(NaN, false);
+      return new ChronoDate(NaN, false);
     }
 
-    if (input instanceof LandscapeDate) {
-      return new LandscapeDate(input._time, input._utc);
+    if (input instanceof ChronoDate) {
+      return new ChronoDate(input._time, input._utc);
     }
 
     if (input instanceof Date) {
-      return new LandscapeDate(input.getTime(), false);
+      return new ChronoDate(input.getTime(), false);
     }
 
     if (typeof input === "number") {
-      return new LandscapeDate(input, false);
+      return new ChronoDate(input, false);
     }
 
-    return new LandscapeDate(parseString(input), false);
+    return new ChronoDate(parseString(input), false);
   }
 
-  static parseStrictISO(value: string, strict?: boolean): LandscapeDate {
+  static parseStrictISO(value: string, strict?: boolean): ChronoDate {
     if (strict && !ISO_8601_REGEX.test(value.trim())) {
-      return new LandscapeDate(NaN, false);
+      return new ChronoDate(NaN, false);
     }
 
-    return new LandscapeDate(parseString(value), false);
+    return new ChronoDate(parseString(value), false);
   }
 
   private fields(): DateFields {
@@ -399,7 +401,7 @@ export class LandscapeDate {
     return new Date(this._time);
   }
 
-  utc(keepLocalTime = false): LandscapeDate {
+  utc(keepLocalTime = false): ChronoDate {
     if (keepLocalTime && !this._utc) {
       const date = new Date(this._time);
       const time = Date.UTC(
@@ -412,41 +414,41 @@ export class LandscapeDate {
         date.getMilliseconds(),
       );
 
-      return new LandscapeDate(time, true);
+      return new ChronoDate(time, true);
     }
 
-    return new LandscapeDate(this._time, true);
+    return new ChronoDate(this._time, true);
   }
 
-  local(): LandscapeDate {
-    return new LandscapeDate(this._time, false);
+  local(): ChronoDate {
+    return new ChronoDate(this._time, false);
   }
 
-  add(amount: number, unit: AddUnit): LandscapeDate {
+  add(amount: number, unit: AddUnit): ChronoDate {
     return this.shift(amount, unit);
   }
 
-  subtract(amount: number, unit: AddUnit): LandscapeDate {
+  subtract(amount: number, unit: AddUnit): ChronoDate {
     return this.shift(-amount, unit);
   }
 
-  private shift(amount: number, unit: AddUnit): LandscapeDate {
+  private shift(amount: number, unit: AddUnit): ChronoDate {
     switch (unit) {
       case "millisecond":
       case "milliseconds":
-        return new LandscapeDate(this._time + amount, this._utc);
+        return new ChronoDate(this._time + amount, this._utc);
       case "second":
       case "seconds":
-        return new LandscapeDate(this._time + amount * 1000, this._utc);
+        return new ChronoDate(this._time + amount * 1000, this._utc);
       case "minute":
       case "minutes":
-        return new LandscapeDate(
+        return new ChronoDate(
           this._time + amount * MS_PER_MINUTE,
           this._utc,
         );
       case "hour":
       case "hours":
-        return new LandscapeDate(this._time + amount * MS_PER_HOUR, this._utc);
+        return new ChronoDate(this._time + amount * MS_PER_HOUR, this._utc);
       case "day":
       case "days":
         return this.shiftCalendarDays(amount);
@@ -461,7 +463,7 @@ export class LandscapeDate {
         } else {
           date.setMonth(date.getMonth() + amount);
         }
-        return new LandscapeDate(date.getTime(), this._utc);
+        return new ChronoDate(date.getTime(), this._utc);
       }
       case "year":
       case "years": {
@@ -471,14 +473,14 @@ export class LandscapeDate {
         } else {
           date.setFullYear(date.getFullYear() + amount);
         }
-        return new LandscapeDate(date.getTime(), this._utc);
+        return new ChronoDate(date.getTime(), this._utc);
       }
       default:
-        return new LandscapeDate(this._time, this._utc);
+        return new ChronoDate(this._time, this._utc);
     }
   }
 
-  private shiftCalendarDays(amount: number): LandscapeDate {
+  private shiftCalendarDays(amount: number): ChronoDate {
     const date = new Date(this._time);
 
     if (this._utc) {
@@ -487,11 +489,11 @@ export class LandscapeDate {
       date.setDate(date.getDate() + amount);
     }
 
-    return new LandscapeDate(date.getTime(), this._utc);
+    return new ChronoDate(date.getTime(), this._utc);
   }
 
   diff(other: DateInput, unit?: DiffUnit): number {
-    const target = LandscapeDate.from(other);
+    const target = ChronoDate.from(other);
     const difference = this._time - target._time;
 
     switch (unit) {
@@ -524,22 +526,22 @@ export class LandscapeDate {
 
   isAfter(other?: DateInput): boolean {
     const target =
-      other === undefined ? LandscapeDate.now() : LandscapeDate.from(other);
+      other === undefined ? ChronoDate.now() : ChronoDate.from(other);
     return this._time > target._time;
   }
 
   isBefore(other?: DateInput): boolean {
     const target =
-      other === undefined ? LandscapeDate.now() : LandscapeDate.from(other);
+      other === undefined ? ChronoDate.now() : ChronoDate.from(other);
     return this._time < target._time;
   }
 
   isSameOrAfter(other: DateInput): boolean {
-    return this._time >= LandscapeDate.from(other)._time;
+    return this._time >= ChronoDate.from(other)._time;
   }
 
   isSameOrBefore(other: DateInput): boolean {
-    return this._time <= LandscapeDate.from(other)._time;
+    return this._time <= ChronoDate.from(other)._time;
   }
 
   toISOString(): string {
@@ -590,14 +592,14 @@ export class LandscapeDate {
   }
 
   calendar(formats: CalendarFormats): string {
-    const dayIndex = (date: LandscapeDate): number => {
+    const dayIndex = (date: ChronoDate): number => {
       const f = date.fields();
       return Math.floor(Date.UTC(f.Y, f.Mo, f.D) / MS_PER_DAY);
     };
 
     const reference = this._utc
-      ? LandscapeDate.now().utc()
-      : LandscapeDate.now();
+      ? ChronoDate.now().utc()
+      : ChronoDate.now();
     const delta = dayIndex(this) - dayIndex(reference);
 
     let pattern: string | undefined;

--- a/src/libs/date/ChronoDate.ts
+++ b/src/libs/date/ChronoDate.ts
@@ -163,7 +163,7 @@ const getDaysInMonth = (year: number, month: number): number => {
 };
 
 const parseMilliseconds = (milliseconds?: string): number =>
-  milliseconds ? Math.trunc(Number(`0.${milliseconds}`) * 1000) : 0;
+  milliseconds ? Number(`${milliseconds}000`.slice(0, 3)) : 0;
 
 const hasValidDateTimeParts = (
   year: number,
@@ -234,7 +234,24 @@ const parseStrictIsoTime = (input: string): number => {
   }
 
   if (z || offsetSign) {
-    return new Date(input).getTime();
+    const utc = Date.UTC(
+      year,
+      month - 1,
+      day,
+      hour,
+      minute,
+      second,
+      parseMilliseconds(ms),
+    );
+
+    if (z) {
+      return utc;
+    }
+
+    const offset =
+      Number(offsetHour) * MS_PER_HOUR + Number(offsetMinute) * MS_PER_MINUTE;
+
+    return offsetSign === "+" ? utc - offset : utc + offset;
   }
 
   return createLocalTime(
@@ -447,28 +464,38 @@ export class ChronoDate {
       case "weeks":
         return this.shiftCalendarDays(amount * DAYS_PER_WEEK);
       case "month":
-      case "months": {
-        const date = new Date(this._time);
-        if (this._utc) {
-          date.setUTCMonth(date.getUTCMonth() + amount);
-        } else {
-          date.setMonth(date.getMonth() + amount);
-        }
-        return new ChronoDate(date.getTime(), this._utc);
-      }
+      case "months":
+        return this.shiftCalendarMonths(amount);
       case "year":
-      case "years": {
-        const date = new Date(this._time);
-        if (this._utc) {
-          date.setUTCFullYear(date.getUTCFullYear() + amount);
-        } else {
-          date.setFullYear(date.getFullYear() + amount);
-        }
-        return new ChronoDate(date.getTime(), this._utc);
-      }
+      case "years":
+        return this.shiftCalendarMonths(amount * MONTHS_PER_YEAR);
       default:
         return new ChronoDate(this._time, this._utc);
     }
+  }
+
+  private shiftCalendarMonths(amount: number): ChronoDate {
+    const date = new Date(this._time);
+    const year = this._utc ? date.getUTCFullYear() : date.getFullYear();
+    const month = this._utc ? date.getUTCMonth() : date.getMonth();
+    const day = this._utc ? date.getUTCDate() : date.getDate();
+
+    const totalMonths = month + amount;
+    const targetYear = year + Math.floor(totalMonths / MONTHS_PER_YEAR);
+    const targetMonth =
+      ((totalMonths % MONTHS_PER_YEAR) + MONTHS_PER_YEAR) % MONTHS_PER_YEAR;
+    const clampedDay = Math.min(
+      day,
+      getDaysInMonth(targetYear, targetMonth + 1),
+    );
+
+    if (this._utc) {
+      date.setUTCFullYear(targetYear, targetMonth, clampedDay);
+    } else {
+      date.setFullYear(targetYear, targetMonth, clampedDay);
+    }
+
+    return new ChronoDate(date.getTime(), this._utc);
   }
 
   private shiftCalendarDays(amount: number): ChronoDate {

--- a/src/libs/date/ChronoDate.ts
+++ b/src/libs/date/ChronoDate.ts
@@ -127,13 +127,7 @@ export interface CalendarFormats {
   sameElse: string;
 }
 
-export type DateInput =
-  | ChronoDate
-  | Date
-  | string
-  | number
-  | null
-  | undefined;
+export type DateInput = ChronoDate | Date | string | number | null | undefined;
 
 interface DateFields {
   Y: number;
@@ -442,10 +436,7 @@ export class ChronoDate {
         return new ChronoDate(this._time + amount * 1000, this._utc);
       case "minute":
       case "minutes":
-        return new ChronoDate(
-          this._time + amount * MS_PER_MINUTE,
-          this._utc,
-        );
+        return new ChronoDate(this._time + amount * MS_PER_MINUTE, this._utc);
       case "hour":
       case "hours":
         return new ChronoDate(this._time + amount * MS_PER_HOUR, this._utc);
@@ -597,9 +588,7 @@ export class ChronoDate {
       return Math.floor(Date.UTC(f.Y, f.Mo, f.D) / MS_PER_DAY);
     };
 
-    const reference = this._utc
-      ? ChronoDate.now().utc()
-      : ChronoDate.now();
+    const reference = this._utc ? ChronoDate.now().utc() : ChronoDate.now();
     const delta = dayIndex(this) - dayIndex(reference);
 
     let pattern: string | undefined;

--- a/src/libs/date/LandscapeDate.test.ts
+++ b/src/libs/date/LandscapeDate.test.ts
@@ -102,12 +102,12 @@ describe("strict ISO 8601 parsing", () => {
     expect(date("2024-03-15T99:30:00Z", date.ISO_8601, true).isValid()).toBe(
       false,
     );
-    expect(date("2024-03-15T10:30:00+25:00", date.ISO_8601, true).isValid()).toBe(
-      false,
-    );
-    expect(date("2024-03-15T10:30:00+02:99", date.ISO_8601, true).isValid()).toBe(
-      false,
-    );
+    expect(
+      date("2024-03-15T10:30:00+25:00", date.ISO_8601, true).isValid(),
+    ).toBe(false);
+    expect(
+      date("2024-03-15T10:30:00+02:99", date.ISO_8601, true).isValid(),
+    ).toBe(false);
   });
 
   it("parses ISO input without strict mode", () => {
@@ -157,7 +157,7 @@ describe("formatting tokens", () => {
   });
 
   it("formats default local and UTC output", () => {
-    expect(subject.format()).toBe("2024-03-05T09:07:08+00:00");
+    expect(subject.format()).toBe("2024-03-05T09:07:08Z");
     expect(date("2024-03-05T09:07:08").format()).toMatch(
       /^2024-03-05T09:07:08[+-]\d{2}:\d{2}$/,
     );
@@ -189,20 +189,24 @@ describe("utc and local modes", () => {
   it("utc(true) keeps the wall-clock time", () => {
     const subject = date("2024-03-15T14:00:00");
     const keptLocal = subject.utc(true);
-    expect(keptLocal.format("YYYY-MM-DDTHH:mm:ss")).toBe(
-      "2024-03-15T14:00:00",
-    );
+    expect(keptLocal.format("YYYY-MM-DDTHH:mm:ss")).toBe("2024-03-15T14:00:00");
   });
 
   it("switches back to local mode", () => {
     const utc = date("2024-03-15T14:00:00Z").utc();
-    expect(utc.local().format()).toMatch(/^2024-03-15T\d{2}:00:00[+-]\d{2}:\d{2}$/);
+    expect(utc.local().format()).toMatch(
+      /^2024-03-15T\d{2}:00:00[+-]\d{2}:\d{2}$/,
+    );
   });
 
   it("toISOString always returns UTC", () => {
     expect(date("2024-03-15T10:30:00Z").toISOString()).toBe(
       "2024-03-15T10:30:00.000Z",
     );
+  });
+
+  it("toISOString returns empty string for invalid dates", () => {
+    expect(date("not-a-date").toISOString()).toBe("");
   });
 });
 
@@ -284,12 +288,12 @@ describe("arithmetic", () => {
     expect(subject.add(1, "week").format("YYYY-MM-DD")).toBe("2024-03-22");
     expect(subject.add(1, "month").format("YYYY-MM-DD")).toBe("2024-04-15");
     expect(subject.add(1, "year").format("YYYY-MM-DD")).toBe("2025-03-15");
-    expect(date("2024-03-15T10:00:00").add(1, "month").format("YYYY-MM-DD")).toBe(
-      "2024-04-15",
-    );
-    expect(date("2024-03-15T10:00:00").add(1, "year").format("YYYY-MM-DD")).toBe(
-      "2025-03-15",
-    );
+    expect(
+      date("2024-03-15T10:00:00").add(1, "month").format("YYYY-MM-DD"),
+    ).toBe("2024-04-15");
+    expect(
+      date("2024-03-15T10:00:00").add(1, "year").format("YYYY-MM-DD"),
+    ).toBe("2025-03-15");
   });
 
   it("preserves local wall-clock time when adding days across DST", () => {
@@ -298,9 +302,14 @@ describe("arithmetic", () => {
 
     try {
       const beforeDstChange = date("2024-03-24T10:00:00");
-      const afterDstChange = beforeDstChange.add(DAYS_ACROSS_DST_CHANGE, "days");
+      const afterDstChange = beforeDstChange.add(
+        DAYS_ACROSS_DST_CHANGE,
+        "days",
+      );
 
-      expect(afterDstChange.format("YYYY-MM-DDTHH:mm")).toBe("2024-04-07T10:00");
+      expect(afterDstChange.format("YYYY-MM-DDTHH:mm")).toBe(
+        "2024-04-07T10:00",
+      );
       expect(afterDstChange.diff(beforeDstChange, "days")).toBe(
         DAYS_ACROSS_DST_CHANGE,
       );

--- a/src/libs/date/LandscapeDate.test.ts
+++ b/src/libs/date/LandscapeDate.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import date, { LandscapeDate } from "./index";
+
+const FIXED_NOW = new Date("2024-03-15T10:30:00Z").getTime();
+
+describe("LandscapeDate factory", () => {
+  it("returns the current time when called with no arguments", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+
+    expect(date().getTime()).toBe(FIXED_NOW);
+
+    vi.useRealTimers();
+  });
+
+  it("returns the current time for undefined input (matching moment)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+
+    expect(date(undefined).isValid()).toBe(true);
+    expect(date(undefined).getTime()).toBe(FIXED_NOW);
+
+    vi.useRealTimers();
+  });
+
+  it("treats null and empty string as invalid (matching moment)", () => {
+    expect(date(null).isValid()).toBe(false);
+    expect(date("").isValid()).toBe(false);
+  });
+
+  it("clones a Date instance", () => {
+    const native = new Date("2024-01-02T03:04:05Z");
+    expect(date(native).getTime()).toBe(native.getTime());
+  });
+
+  it("clones another LandscapeDate preserving the utc mode", () => {
+    const utc = date("2024-01-02T03:04:05Z").utc();
+    const clone = date(utc);
+    expect(clone.format("HH:mm")).toBe(utc.format("HH:mm"));
+  });
+});
+
+describe("validity", () => {
+  it("flags unparseable strings as invalid", () => {
+    expect(date("not-a-date").isValid()).toBe(false);
+  });
+
+  it("formats invalid dates as 'Invalid date'", () => {
+    expect(date("nonsense").format("YYYY")).toBe("Invalid date");
+  });
+});
+
+describe("strict ISO 8601 parsing", () => {
+  it("accepts valid ISO strings", () => {
+    expect(date("2024-03-15T10:30:00Z", date.ISO_8601, true).isValid()).toBe(
+      true,
+    );
+    expect(date("2024-03-15", date.ISO_8601, true).isValid()).toBe(true);
+    expect(
+      date("2024-03-15T10:30:00+02:00", date.ISO_8601, true).isValid(),
+    ).toBe(true);
+  });
+
+  it("rejects non-ISO strings in strict mode", () => {
+    expect(date("03/15/2024", date.ISO_8601, true).isValid()).toBe(false);
+    expect(date("15-03-2024", date.ISO_8601, true).isValid()).toBe(false);
+    expect(date("garbage", date.ISO_8601, true).isValid()).toBe(false);
+  });
+});
+
+describe("local parsing", () => {
+  it("parses date-only strings as local midnight", () => {
+    const parsed = date("2024-03-15");
+    expect(parsed.format("YYYY-MM-DD")).toBe("2024-03-15");
+    expect(parsed.format("HH:mm:ss")).toBe("00:00:00");
+  });
+
+  it("parses datetime-local strings without timezone as local time", () => {
+    const parsed = date("2024-03-15T14:45");
+    expect(parsed.format("YYYY-MM-DDTHH:mm")).toBe("2024-03-15T14:45");
+  });
+});
+
+describe("formatting tokens", () => {
+  const subject = date("2024-03-05T09:07:08Z").utc();
+
+  it("formats common display patterns", () => {
+    expect(subject.format("MMM D, YYYY")).toBe("Mar 5, 2024");
+    expect(subject.format("MMM DD, YYYY, HH:mm")).toBe("Mar 05, 2024, 09:07");
+    expect(subject.format("YYYY-MM-DD")).toBe("2024-03-05");
+    expect(subject.format("YYYY-MM-DDTHH:mm:ss")).toBe("2024-03-05T09:07:08");
+  });
+
+  it("handles bracket literals", () => {
+    expect(subject.format("YYYY-MM-DDTHH:mm:ss[Z]")).toBe(
+      "2024-03-05T09:07:08Z",
+    );
+    expect(subject.format("YYYYMMDDTHHmmss")).toBe("20240305T090708");
+    expect(subject.format("MMM DD, YYYY, HH:mm [UTC]")).toBe(
+      "Mar 05, 2024, 09:07 UTC",
+    );
+  });
+
+  it("formats weekday names for the calendar use case", () => {
+    expect(subject.format("dddd")).toBe("Tuesday");
+  });
+});
+
+describe("utc and local modes", () => {
+  it("formats UTC fields in utc mode", () => {
+    const subject = date("2024-03-15T23:30:00Z");
+    expect(subject.utc().format("YYYY-MM-DDTHH:mm:ss")).toBe(
+      "2024-03-15T23:30:00",
+    );
+  });
+
+  it("utc(true) keeps the wall-clock time", () => {
+    const subject = date("2024-03-15T14:00:00");
+    const keptLocal = subject.utc(true);
+    expect(keptLocal.format("YYYY-MM-DDTHH:mm:ss")).toBe(
+      "2024-03-15T14:00:00",
+    );
+  });
+
+  it("toISOString always returns UTC", () => {
+    expect(date("2024-03-15T10:30:00Z").toISOString()).toBe(
+      "2024-03-15T10:30:00.000Z",
+    );
+  });
+});
+
+describe("comparisons", () => {
+  const earlier = date("2024-03-15T10:00:00Z");
+  const later = date("2024-03-15T12:00:00Z");
+
+  it("compares with isAfter / isSameOrAfter / isSameOrBefore", () => {
+    expect(later.isAfter(earlier)).toBe(true);
+    expect(earlier.isAfter(later)).toBe(false);
+    expect(later.isSameOrAfter(earlier)).toBe(true);
+    expect(earlier.isSameOrBefore(later)).toBe(true);
+    expect(earlier.isSameOrBefore(earlier)).toBe(true);
+  });
+
+  it("isAfter() with no argument compares to now", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+
+    expect(date("2025-01-01T00:00:00Z").isAfter()).toBe(true);
+    expect(date("2020-01-01T00:00:00Z").isAfter()).toBe(false);
+
+    vi.useRealTimers();
+  });
+
+  it("diff returns milliseconds by default and supports days", () => {
+    expect(later.diff(earlier)).toBe(2 * 60 * 60 * 1000);
+    expect(
+      date("2024-03-20T00:00:00Z").diff(date("2024-03-15T00:00:00Z"), "days"),
+    ).toBe(5);
+  });
+});
+
+describe("arithmetic", () => {
+  const subject = date("2024-03-15T10:00:00Z").utc();
+
+  it("adds and subtracts units", () => {
+    expect(subject.add(5, "minutes").format("HH:mm")).toBe("10:05");
+    expect(subject.add(2, "days").format("YYYY-MM-DD")).toBe("2024-03-17");
+    expect(subject.subtract(1, "day").format("YYYY-MM-DD")).toBe("2024-03-14");
+  });
+});
+
+describe("calendar", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-03-15T12:00:00Z").getTime());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const formats = {
+    sameElse: "MMM DD, YYYY, HH:mm [UTC]",
+    lastWeek: "[Last] dddd, HH:mm [UTC]",
+    sameDay: "[Today], HH:mm [UTC]",
+    lastDay: "[Yesterday], HH:mm [UTC]",
+  };
+
+  it("uses the sameDay label for today", () => {
+    expect(date("2024-03-15T08:30:00Z").utc().calendar(formats)).toBe(
+      "Today, 08:30 UTC",
+    );
+  });
+
+  it("uses the lastDay label for yesterday", () => {
+    expect(date("2024-03-14T08:30:00Z").utc().calendar(formats)).toBe(
+      "Yesterday, 08:30 UTC",
+    );
+  });
+
+  it("uses the lastWeek label within the past week", () => {
+    expect(date("2024-03-11T08:30:00Z").utc().calendar(formats)).toBe(
+      "Last Monday, 08:30 UTC",
+    );
+  });
+
+  it("falls back to sameElse for older dates", () => {
+    expect(date("2024-01-01T08:30:00Z").utc().calendar(formats)).toBe(
+      "Jan 01, 2024, 08:30 UTC",
+    );
+  });
+});
+
+describe("LandscapeDate class export", () => {
+  it("exposes a now() helper", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+
+    expect(LandscapeDate.now().getTime()).toBe(FIXED_NOW);
+
+    vi.useRealTimers();
+  });
+});

--- a/src/libs/date/LandscapeDate.test.ts
+++ b/src/libs/date/LandscapeDate.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import date, { LandscapeDate } from "./index";
 
 const FIXED_NOW = new Date("2024-03-15T10:30:00Z").getTime();
+const DAYS_ACROSS_DST_CHANGE = 14;
+const ONE_SECOND_MS = 1000;
+const ONE_MINUTE_MS = 60_000;
+const ONE_HOUR_MS = 3_600_000;
+const PARSED_MILLISECONDS = 456;
 
 describe("LandscapeDate factory", () => {
   it("returns the current time when called with no arguments", () => {
@@ -13,7 +18,7 @@ describe("LandscapeDate factory", () => {
     vi.useRealTimers();
   });
 
-  it("returns the current time for undefined input (matching moment)", () => {
+  it("returns the current time for undefined input", () => {
     vi.useFakeTimers();
     vi.setSystemTime(FIXED_NOW);
 
@@ -23,7 +28,7 @@ describe("LandscapeDate factory", () => {
     vi.useRealTimers();
   });
 
-  it("treats null and empty string as invalid (matching moment)", () => {
+  it("treats null and empty string as invalid", () => {
     expect(date(null).isValid()).toBe(false);
     expect(date("").isValid()).toBe(false);
   });
@@ -38,11 +43,30 @@ describe("LandscapeDate factory", () => {
     const clone = date(utc);
     expect(clone.format("HH:mm")).toBe(utc.format("HH:mm"));
   });
+
+  it("accepts numeric timestamps", () => {
+    expect(date(FIXED_NOW).toISOString()).toBe("2024-03-15T10:30:00.000Z");
+    expect(date(FIXED_NOW).valueOf()).toBe(FIXED_NOW);
+  });
 });
 
 describe("validity", () => {
   it("flags unparseable strings as invalid", () => {
     expect(date("not-a-date").isValid()).toBe(false);
+  });
+
+  it("flags overflowing date and time parts as invalid", () => {
+    expect(date("2024-02-31").isValid()).toBe(false);
+    expect(date("2024-00-01").isValid()).toBe(false);
+    expect(date("2024-04-31").isValid()).toBe(false);
+    expect(date("2024-03-15T24:00").isValid()).toBe(false);
+    expect(date("2024-03-15T10:60").isValid()).toBe(false);
+    expect(date("2024-03-15T10:30:60").isValid()).toBe(false);
+  });
+
+  it("allows leap day only in leap years", () => {
+    expect(date("2024-02-29").isValid()).toBe(true);
+    expect(date("2023-02-29").isValid()).toBe(false);
   });
 
   it("formats invalid dates as 'Invalid date'", () => {
@@ -59,12 +83,37 @@ describe("strict ISO 8601 parsing", () => {
     expect(
       date("2024-03-15T10:30:00+02:00", date.ISO_8601, true).isValid(),
     ).toBe(true);
+    expect(
+      date("2024-03-15T10:30:00.123+0200", date.ISO_8601, true).isValid(),
+    ).toBe(true);
   });
 
   it("rejects non-ISO strings in strict mode", () => {
     expect(date("03/15/2024", date.ISO_8601, true).isValid()).toBe(false);
     expect(date("15-03-2024", date.ISO_8601, true).isValid()).toBe(false);
     expect(date("garbage", date.ISO_8601, true).isValid()).toBe(false);
+  });
+
+  it("rejects overflowing ISO date and time parts in strict mode", () => {
+    expect(date("2024-02-31", date.ISO_8601, true).isValid()).toBe(false);
+    expect(date("2024-13-01T10:30:00Z", date.ISO_8601, true).isValid()).toBe(
+      false,
+    );
+    expect(date("2024-03-15T99:30:00Z", date.ISO_8601, true).isValid()).toBe(
+      false,
+    );
+    expect(date("2024-03-15T10:30:00+25:00", date.ISO_8601, true).isValid()).toBe(
+      false,
+    );
+    expect(date("2024-03-15T10:30:00+02:99", date.ISO_8601, true).isValid()).toBe(
+      false,
+    );
+  });
+
+  it("parses ISO input without strict mode", () => {
+    expect(date("2024-03-15", date.ISO_8601).format("YYYY-MM-DD")).toBe(
+      "2024-03-15",
+    );
   });
 });
 
@@ -79,6 +128,12 @@ describe("local parsing", () => {
     const parsed = date("2024-03-15T14:45");
     expect(parsed.format("YYYY-MM-DDTHH:mm")).toBe("2024-03-15T14:45");
   });
+
+  it("parses local datetime strings with seconds and milliseconds", () => {
+    const parsed = date("2024-03-15T14:45:30.456");
+    expect(parsed.format("YYYY-MM-DDTHH:mm:ss")).toBe("2024-03-15T14:45:30");
+    expect(parsed.toDate().getMilliseconds()).toBe(PARSED_MILLISECONDS);
+  });
 });
 
 describe("formatting tokens", () => {
@@ -89,6 +144,23 @@ describe("formatting tokens", () => {
     expect(subject.format("MMM DD, YYYY, HH:mm")).toBe("Mar 05, 2024, 09:07");
     expect(subject.format("YYYY-MM-DD")).toBe("2024-03-05");
     expect(subject.format("YYYY-MM-DDTHH:mm:ss")).toBe("2024-03-05T09:07:08");
+  });
+
+  it("formats all supported tokens", () => {
+    expect(
+      subject.format("YY MMMM M D ddd dd H h m s A a [literal] unknown"),
+    ).toBe("24 March 3 5 Tue Tu 9 9 7 8 AM am literal unknown");
+    expect(date("2024-03-05T15:07:08Z").utc().format("h hh A a")).toBe(
+      "3 03 PM pm",
+    );
+    expect(date("2024-03-05T00:07:08Z").utc().format("h hh")).toBe("12 12");
+  });
+
+  it("formats default local and UTC output", () => {
+    expect(subject.format()).toBe("2024-03-05T09:07:08+00:00");
+    expect(date("2024-03-05T09:07:08").format()).toMatch(
+      /^2024-03-05T09:07:08[+-]\d{2}:\d{2}$/,
+    );
   });
 
   it("handles bracket literals", () => {
@@ -122,6 +194,11 @@ describe("utc and local modes", () => {
     );
   });
 
+  it("switches back to local mode", () => {
+    const utc = date("2024-03-15T14:00:00Z").utc();
+    expect(utc.local().format()).toMatch(/^2024-03-15T\d{2}:00:00[+-]\d{2}:\d{2}$/);
+  });
+
   it("toISOString always returns UTC", () => {
     expect(date("2024-03-15T10:30:00Z").toISOString()).toBe(
       "2024-03-15T10:30:00.000Z",
@@ -137,8 +214,15 @@ describe("comparisons", () => {
     expect(later.isAfter(earlier)).toBe(true);
     expect(earlier.isAfter(later)).toBe(false);
     expect(later.isSameOrAfter(earlier)).toBe(true);
+    expect(earlier.isSameOrAfter(later)).toBe(false);
     expect(earlier.isSameOrBefore(later)).toBe(true);
+    expect(later.isSameOrBefore(earlier)).toBe(false);
     expect(earlier.isSameOrBefore(earlier)).toBe(true);
+  });
+
+  it("compares with isBefore", () => {
+    expect(earlier.isBefore(later)).toBe(true);
+    expect(later.isBefore(earlier)).toBe(false);
   });
 
   it("isAfter() with no argument compares to now", () => {
@@ -151,8 +235,22 @@ describe("comparisons", () => {
     vi.useRealTimers();
   });
 
-  it("diff returns milliseconds by default and supports days", () => {
+  it("isBefore() with no argument compares to now", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+
+    expect(date("2020-01-01T00:00:00Z").isBefore()).toBe(true);
+    expect(date("2025-01-01T00:00:00Z").isBefore()).toBe(false);
+
+    vi.useRealTimers();
+  });
+
+  it("diff returns milliseconds by default and supports units", () => {
     expect(later.diff(earlier)).toBe(2 * 60 * 60 * 1000);
+    expect(later.diff(earlier, "milliseconds")).toBe(2 * 60 * 60 * 1000);
+    expect(later.diff(earlier, "seconds")).toBe(2 * 60 * 60);
+    expect(later.diff(earlier, "minutes")).toBe(2 * 60);
+    expect(later.diff(earlier, "hours")).toBe(2);
     expect(
       date("2024-03-20T00:00:00Z").diff(date("2024-03-15T00:00:00Z"), "days"),
     ).toBe(5);
@@ -166,6 +264,53 @@ describe("arithmetic", () => {
     expect(subject.add(5, "minutes").format("HH:mm")).toBe("10:05");
     expect(subject.add(2, "days").format("YYYY-MM-DD")).toBe("2024-03-17");
     expect(subject.subtract(1, "day").format("YYYY-MM-DD")).toBe("2024-03-14");
+  });
+
+  it("adds fixed-time units", () => {
+    expect(subject.add(ONE_SECOND_MS, "milliseconds").format("HH:mm:ss")).toBe(
+      "10:00:01",
+    );
+    expect(subject.add(1, "second").format("HH:mm:ss")).toBe("10:00:01");
+    expect(subject.add(ONE_MINUTE_MS, "milliseconds").format("HH:mm:ss")).toBe(
+      "10:01:00",
+    );
+    expect(subject.add(ONE_HOUR_MS, "milliseconds").format("HH:mm:ss")).toBe(
+      "11:00:00",
+    );
+    expect(subject.add(1, "hour").format("HH:mm:ss")).toBe("11:00:00");
+  });
+
+  it("adds calendar units", () => {
+    expect(subject.add(1, "week").format("YYYY-MM-DD")).toBe("2024-03-22");
+    expect(subject.add(1, "month").format("YYYY-MM-DD")).toBe("2024-04-15");
+    expect(subject.add(1, "year").format("YYYY-MM-DD")).toBe("2025-03-15");
+    expect(date("2024-03-15T10:00:00").add(1, "month").format("YYYY-MM-DD")).toBe(
+      "2024-04-15",
+    );
+    expect(date("2024-03-15T10:00:00").add(1, "year").format("YYYY-MM-DD")).toBe(
+      "2025-03-15",
+    );
+  });
+
+  it("preserves local wall-clock time when adding days across DST", () => {
+    const originalTimezone = process.env.TZ;
+    process.env.TZ = "Europe/Berlin";
+
+    try {
+      const beforeDstChange = date("2024-03-24T10:00:00");
+      const afterDstChange = beforeDstChange.add(DAYS_ACROSS_DST_CHANGE, "days");
+
+      expect(afterDstChange.format("YYYY-MM-DDTHH:mm")).toBe("2024-04-07T10:00");
+      expect(afterDstChange.diff(beforeDstChange, "days")).toBe(
+        DAYS_ACROSS_DST_CHANGE,
+      );
+    } finally {
+      if (originalTimezone === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = originalTimezone;
+      }
+    }
   });
 });
 
@@ -198,10 +343,26 @@ describe("calendar", () => {
     );
   });
 
+  it("uses the nextDay label for tomorrow", () => {
+    expect(
+      date("2024-03-16T08:30:00Z")
+        .utc()
+        .calendar({ ...formats, nextDay: "[Tomorrow], HH:mm [UTC]" }),
+    ).toBe("Tomorrow, 08:30 UTC");
+  });
+
   it("uses the lastWeek label within the past week", () => {
     expect(date("2024-03-11T08:30:00Z").utc().calendar(formats)).toBe(
       "Last Monday, 08:30 UTC",
     );
+  });
+
+  it("uses the nextWeek label within the next week", () => {
+    expect(
+      date("2024-03-18T08:30:00Z")
+        .utc()
+        .calendar({ ...formats, nextWeek: "[Next] dddd, HH:mm [UTC]" }),
+    ).toBe("Next Monday, 08:30 UTC");
   });
 
   it("falls back to sameElse for older dates", () => {

--- a/src/libs/date/LandscapeDate.ts
+++ b/src/libs/date/LandscapeDate.ts
@@ -440,7 +440,10 @@ export class LandscapeDate {
         return new LandscapeDate(this._time + amount * 1000, this._utc);
       case "minute":
       case "minutes":
-        return new LandscapeDate(this._time + amount * MS_PER_MINUTE, this._utc);
+        return new LandscapeDate(
+          this._time + amount * MS_PER_MINUTE,
+          this._utc,
+        );
       case "hour":
       case "hours":
         return new LandscapeDate(this._time + amount * MS_PER_HOUR, this._utc);
@@ -520,12 +523,14 @@ export class LandscapeDate {
   }
 
   isAfter(other?: DateInput): boolean {
-    const target = other === undefined ? LandscapeDate.now() : LandscapeDate.from(other);
+    const target =
+      other === undefined ? LandscapeDate.now() : LandscapeDate.from(other);
     return this._time > target._time;
   }
 
   isBefore(other?: DateInput): boolean {
-    const target = other === undefined ? LandscapeDate.now() : LandscapeDate.from(other);
+    const target =
+      other === undefined ? LandscapeDate.now() : LandscapeDate.from(other);
     return this._time < target._time;
   }
 
@@ -538,7 +543,7 @@ export class LandscapeDate {
   }
 
   toISOString(): string {
-    return new Date(this._time).toISOString();
+    return this.isValid() ? new Date(this._time).toISOString() : "";
   }
 
   format(pattern?: string): string {
@@ -572,7 +577,7 @@ export class LandscapeDate {
     )}T${pad(fields.H)}:${pad(fields.Mi)}:${pad(fields.S)}`;
 
     if (this._utc) {
-      return `${base}+00:00`;
+      return `${base}Z`;
     }
 
     const offsetMinutes = new Date(this._time).getTimezoneOffset();
@@ -590,7 +595,9 @@ export class LandscapeDate {
       return Math.floor(Date.UTC(f.Y, f.Mo, f.D) / MS_PER_DAY);
     };
 
-    const reference = this._utc ? LandscapeDate.now().utc() : LandscapeDate.now();
+    const reference = this._utc
+      ? LandscapeDate.now().utc()
+      : LandscapeDate.now();
     const delta = dayIndex(this) - dayIndex(reference);
 
     let pattern: string | undefined;

--- a/src/libs/date/LandscapeDate.ts
+++ b/src/libs/date/LandscapeDate.ts
@@ -1,10 +1,9 @@
 /**
- * LandscapeDate is a small, Moment-shaped wrapper around the native `Date`
- * object. It exists to replace the `moment` dependency while preserving the
- * exact call style and behavior the Landscape UI relies on.
+ * LandscapeDate is a small wrapper around the native `Date` object. It
+ * centralizes the date behavior and call style the Landscape UI relies on.
  *
- * It intentionally implements only the subset of Moment used in this codebase,
- * delegating to native `Date` for arithmetic, comparison and serialization and
+ * It intentionally implements only the subset used in this codebase, delegating
+ * to native `Date` for arithmetic, comparison and serialization and
  * adding a small token-based formatter that the native APIs do not provide.
  */
 
@@ -55,8 +54,22 @@ const MS_PER_HOUR = 3_600_000;
 const MS_PER_MINUTE = 60_000;
 const HOURS_PER_HALF_DAY = 12;
 const DAYS_PER_WEEK = 7;
+const MONTHS_PER_YEAR = 12;
+const FEBRUARY = 2;
+const APRIL = 4;
+const JUNE = 6;
+const SEPTEMBER = 9;
+const NOVEMBER = 11;
+const DAYS_IN_FEBRUARY = 28;
+const DAYS_IN_LEAP_YEAR_FEBRUARY = 29;
+const DAYS_IN_SHORT_MONTH = 30;
+const DAYS_IN_LONG_MONTH = 31;
+const LEAP_YEAR_CENTURY = 100;
+const LEAP_YEAR_FULL_CYCLE = 400;
+const MAX_HOUR = 23;
+const MAX_MINUTE_OR_SECOND = 59;
 
-/** Sentinel used like `moment.ISO_8601` for strict ISO 8601 parsing. */
+/** Sentinel used for strict ISO 8601 parsing. */
 export const ISO_8601 = Symbol("ISO_8601");
 
 const ISO_8601_REGEX =
@@ -66,6 +79,9 @@ const DATE_ONLY_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/;
 
 const DATE_TIME_NO_TZ_REGEX =
   /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?$/;
+
+const ISO_8601_PARTS_REGEX =
+  /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?(?:(Z)|([+-])(\d{2}):?(\d{2}))?)?$/;
 
 const FORMAT_TOKEN_REGEX =
   /\[([^\]]*)\]|YYYY|YY|MMMM|MMM|MM|M|DD|D|dddd|ddd|dd|HH|H|hh|h|mm|m|ss|s|A|a/g;
@@ -136,6 +152,106 @@ const to12Hour = (hour: number): number => {
   return h === 0 ? HOURS_PER_HALF_DAY : h;
 };
 
+const isLeapYear = (year: number): boolean =>
+  year % 4 === 0 &&
+  (year % LEAP_YEAR_CENTURY !== 0 || year % LEAP_YEAR_FULL_CYCLE === 0);
+
+const getDaysInMonth = (year: number, month: number): number => {
+  if (month === FEBRUARY) {
+    return isLeapYear(year) ? DAYS_IN_LEAP_YEAR_FEBRUARY : DAYS_IN_FEBRUARY;
+  }
+
+  return [APRIL, JUNE, SEPTEMBER, NOVEMBER].includes(month)
+    ? DAYS_IN_SHORT_MONTH
+    : DAYS_IN_LONG_MONTH;
+};
+
+const parseMilliseconds = (milliseconds?: string): number =>
+  milliseconds ? Math.trunc(Number(`0.${milliseconds}`) * 1000) : 0;
+
+const hasValidDateTimeParts = (
+  year: number,
+  month: number,
+  day: number,
+  hour = 0,
+  minute = 0,
+  second = 0,
+): boolean =>
+  month >= 1 &&
+  month <= MONTHS_PER_YEAR &&
+  day >= 1 &&
+  day <= getDaysInMonth(year, month) &&
+  hour >= 0 &&
+  hour <= MAX_HOUR &&
+  minute >= 0 &&
+  minute <= MAX_MINUTE_OR_SECOND &&
+  second >= 0 &&
+  second <= MAX_MINUTE_OR_SECOND;
+
+const createLocalTime = (
+  year: number,
+  month: number,
+  day: number,
+  hour = 0,
+  minute = 0,
+  second = 0,
+  millisecond = 0,
+): number => {
+  if (!hasValidDateTimeParts(year, month, day, hour, minute, second)) {
+    return NaN;
+  }
+
+  const date = new Date(0);
+  date.setFullYear(year, month - 1, day);
+  date.setHours(hour, minute, second, millisecond);
+  return date.getTime();
+};
+
+const hasValidTimezoneOffset = (
+  offsetHour?: string,
+  offsetMinute?: string,
+): boolean =>
+  offsetHour === undefined ||
+  (Number(offsetHour) <= MAX_HOUR &&
+    Number(offsetMinute) <= MAX_MINUTE_OR_SECOND);
+
+const parseStrictIsoTime = (input: string): number => {
+  const parts = ISO_8601_PARTS_REGEX.exec(input);
+  if (!parts) {
+    return NaN;
+  }
+
+  const [, y, m, d, h, min, s, ms, z, offsetSign, offsetHour, offsetMinute] =
+    parts;
+  const year = Number(y);
+  const month = Number(m);
+  const day = Number(d);
+  const hour = Number(h ?? 0);
+  const minute = Number(min ?? 0);
+  const second = Number(s ?? 0);
+
+  if (
+    !hasValidDateTimeParts(year, month, day, hour, minute, second) ||
+    !hasValidTimezoneOffset(offsetHour, offsetMinute)
+  ) {
+    return NaN;
+  }
+
+  if (z || offsetSign) {
+    return new Date(input).getTime();
+  }
+
+  return createLocalTime(
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    second,
+    parseMilliseconds(ms),
+  );
+};
+
 const parseString = (value: string): number => {
   const input = value.trim();
 
@@ -143,24 +259,28 @@ const parseString = (value: string): number => {
     return NaN;
   }
 
+  if (ISO_8601_PARTS_REGEX.test(input)) {
+    return parseStrictIsoTime(input);
+  }
+
   const dateOnly = DATE_ONLY_REGEX.exec(input);
   if (dateOnly) {
     const [, y, m, d] = dateOnly;
-    return new Date(Number(y), Number(m) - 1, Number(d)).getTime();
+    return createLocalTime(Number(y), Number(m), Number(d));
   }
 
   const dateTime = DATE_TIME_NO_TZ_REGEX.exec(input);
   if (dateTime) {
     const [, y, m, d, h, min, s, ms] = dateTime;
-    return new Date(
+    return createLocalTime(
       Number(y),
-      Number(m) - 1,
+      Number(m),
       Number(d),
       Number(h),
       Number(min),
       Number(s ?? 0),
-      ms ? Number(`0.${ms}`) * 1000 : 0,
-    ).getTime();
+      parseMilliseconds(ms),
+    );
   }
 
   return new Date(input).getTime();
@@ -326,13 +446,10 @@ export class LandscapeDate {
         return new LandscapeDate(this._time + amount * MS_PER_HOUR, this._utc);
       case "day":
       case "days":
-        return new LandscapeDate(this._time + amount * MS_PER_DAY, this._utc);
+        return this.shiftCalendarDays(amount);
       case "week":
       case "weeks":
-        return new LandscapeDate(
-          this._time + amount * MS_PER_DAY * 7,
-          this._utc,
-        );
+        return this.shiftCalendarDays(amount * DAYS_PER_WEEK);
       case "month":
       case "months": {
         const date = new Date(this._time);
@@ -358,8 +475,21 @@ export class LandscapeDate {
     }
   }
 
+  private shiftCalendarDays(amount: number): LandscapeDate {
+    const date = new Date(this._time);
+
+    if (this._utc) {
+      date.setUTCDate(date.getUTCDate() + amount);
+    } else {
+      date.setDate(date.getDate() + amount);
+    }
+
+    return new LandscapeDate(date.getTime(), this._utc);
+  }
+
   diff(other: DateInput, unit?: DiffUnit): number {
-    const difference = this._time - LandscapeDate.from(other)._time;
+    const target = LandscapeDate.from(other);
+    const difference = this._time - target._time;
 
     switch (unit) {
       case "second":
@@ -372,13 +502,21 @@ export class LandscapeDate {
       case "hours":
         return Math.trunc(difference / MS_PER_HOUR);
       case "day":
-      case "days":
-        return Math.trunc(difference / MS_PER_DAY);
+      case "days": {
+        const zoneDelta =
+          (this.getTimezoneOffset() - target.getTimezoneOffset()) *
+          MS_PER_MINUTE;
+        return Math.trunc((difference - zoneDelta) / MS_PER_DAY);
+      }
       case "millisecond":
       case "milliseconds":
       default:
         return difference;
     }
+  }
+
+  private getTimezoneOffset(): number {
+    return this._utc ? 0 : new Date(this._time).getTimezoneOffset();
   }
 
   isAfter(other?: DateInput): boolean {

--- a/src/libs/date/LandscapeDate.ts
+++ b/src/libs/date/LandscapeDate.ts
@@ -1,0 +1,474 @@
+/**
+ * LandscapeDate is a small, Moment-shaped wrapper around the native `Date`
+ * object. It exists to replace the `moment` dependency while preserving the
+ * exact call style and behavior the Landscape UI relies on.
+ *
+ * It intentionally implements only the subset of Moment used in this codebase,
+ * delegating to native `Date` for arithmetic, comparison and serialization and
+ * adding a small token-based formatter that the native APIs do not provide.
+ */
+
+const MONTHS_SHORT = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+const MONTHS_LONG = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+const WEEKDAYS_LONG = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+
+const WEEKDAYS_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+const MS_PER_DAY = 86_400_000;
+const MS_PER_HOUR = 3_600_000;
+const MS_PER_MINUTE = 60_000;
+const HOURS_PER_HALF_DAY = 12;
+const DAYS_PER_WEEK = 7;
+
+/** Sentinel used like `moment.ISO_8601` for strict ISO 8601 parsing. */
+export const ISO_8601 = Symbol("ISO_8601");
+
+const ISO_8601_REGEX =
+  /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?$/;
+
+const DATE_ONLY_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+const DATE_TIME_NO_TZ_REGEX =
+  /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?$/;
+
+const FORMAT_TOKEN_REGEX =
+  /\[([^\]]*)\]|YYYY|YY|MMMM|MMM|MM|M|DD|D|dddd|ddd|dd|HH|H|hh|h|mm|m|ss|s|A|a/g;
+
+type AddUnit =
+  | "millisecond"
+  | "milliseconds"
+  | "second"
+  | "seconds"
+  | "minute"
+  | "minutes"
+  | "hour"
+  | "hours"
+  | "day"
+  | "days"
+  | "week"
+  | "weeks"
+  | "month"
+  | "months"
+  | "year"
+  | "years";
+
+type DiffUnit =
+  | "millisecond"
+  | "milliseconds"
+  | "second"
+  | "seconds"
+  | "minute"
+  | "minutes"
+  | "hour"
+  | "hours"
+  | "day"
+  | "days";
+
+export interface CalendarFormats {
+  sameDay?: string;
+  nextDay?: string;
+  nextWeek?: string;
+  lastDay?: string;
+  lastWeek?: string;
+  sameElse: string;
+}
+
+export type DateInput =
+  | LandscapeDate
+  | Date
+  | string
+  | number
+  | null
+  | undefined;
+
+interface DateFields {
+  Y: number;
+  Mo: number;
+  D: number;
+  H: number;
+  Mi: number;
+  S: number;
+  Ms: number;
+  Wd: number;
+}
+
+const pad = (value: number, length = 2): string =>
+  String(Math.abs(value)).padStart(length, "0");
+
+const to12Hour = (hour: number): number => {
+  const h = hour % HOURS_PER_HALF_DAY;
+  return h === 0 ? HOURS_PER_HALF_DAY : h;
+};
+
+const parseString = (value: string): number => {
+  const input = value.trim();
+
+  if (!input) {
+    return NaN;
+  }
+
+  const dateOnly = DATE_ONLY_REGEX.exec(input);
+  if (dateOnly) {
+    const [, y, m, d] = dateOnly;
+    return new Date(Number(y), Number(m) - 1, Number(d)).getTime();
+  }
+
+  const dateTime = DATE_TIME_NO_TZ_REGEX.exec(input);
+  if (dateTime) {
+    const [, y, m, d, h, min, s, ms] = dateTime;
+    return new Date(
+      Number(y),
+      Number(m) - 1,
+      Number(d),
+      Number(h),
+      Number(min),
+      Number(s ?? 0),
+      ms ? Number(`0.${ms}`) * 1000 : 0,
+    ).getTime();
+  }
+
+  return new Date(input).getTime();
+};
+
+const FORMAT_TOKENS: Record<string, (fields: DateFields) => string> = {
+  YYYY: (f) => pad(f.Y, 4),
+  YY: (f) => pad(f.Y % 100),
+  MMMM: (f) => MONTHS_LONG[f.Mo] ?? "",
+  MMM: (f) => MONTHS_SHORT[f.Mo] ?? "",
+  MM: (f) => pad(f.Mo + 1),
+  M: (f) => String(f.Mo + 1),
+  DD: (f) => pad(f.D),
+  D: (f) => String(f.D),
+  dddd: (f) => WEEKDAYS_LONG[f.Wd] ?? "",
+  ddd: (f) => WEEKDAYS_SHORT[f.Wd] ?? "",
+  dd: (f) => (WEEKDAYS_SHORT[f.Wd] ?? "").slice(0, 2),
+  HH: (f) => pad(f.H),
+  H: (f) => String(f.H),
+  hh: (f) => pad(to12Hour(f.H)),
+  h: (f) => String(to12Hour(f.H)),
+  mm: (f) => pad(f.Mi),
+  m: (f) => String(f.Mi),
+  ss: (f) => pad(f.S),
+  s: (f) => String(f.S),
+  A: (f) => (f.H < HOURS_PER_HALF_DAY ? "AM" : "PM"),
+  a: (f) => (f.H < HOURS_PER_HALF_DAY ? "am" : "pm"),
+};
+
+export class LandscapeDate {
+  private readonly _time: number;
+  private readonly _utc: boolean;
+
+  constructor(time: number, utc = false) {
+    this._time = time;
+    this._utc = utc;
+  }
+
+  static now(): LandscapeDate {
+    return new LandscapeDate(Date.now(), false);
+  }
+
+  static from(input: DateInput): LandscapeDate {
+    if (input === undefined) {
+      return LandscapeDate.now();
+    }
+
+    if (input === null) {
+      return new LandscapeDate(NaN, false);
+    }
+
+    if (input instanceof LandscapeDate) {
+      return new LandscapeDate(input._time, input._utc);
+    }
+
+    if (input instanceof Date) {
+      return new LandscapeDate(input.getTime(), false);
+    }
+
+    if (typeof input === "number") {
+      return new LandscapeDate(input, false);
+    }
+
+    return new LandscapeDate(parseString(input), false);
+  }
+
+  static parseStrictISO(value: string, strict?: boolean): LandscapeDate {
+    if (strict && !ISO_8601_REGEX.test(value.trim())) {
+      return new LandscapeDate(NaN, false);
+    }
+
+    return new LandscapeDate(parseString(value), false);
+  }
+
+  private fields(): DateFields {
+    const date = new Date(this._time);
+
+    if (this._utc) {
+      return {
+        Y: date.getUTCFullYear(),
+        Mo: date.getUTCMonth(),
+        D: date.getUTCDate(),
+        H: date.getUTCHours(),
+        Mi: date.getUTCMinutes(),
+        S: date.getUTCSeconds(),
+        Ms: date.getUTCMilliseconds(),
+        Wd: date.getUTCDay(),
+      };
+    }
+
+    return {
+      Y: date.getFullYear(),
+      Mo: date.getMonth(),
+      D: date.getDate(),
+      H: date.getHours(),
+      Mi: date.getMinutes(),
+      S: date.getSeconds(),
+      Ms: date.getMilliseconds(),
+      Wd: date.getDay(),
+    };
+  }
+
+  isValid(): boolean {
+    return !Number.isNaN(this._time);
+  }
+
+  valueOf(): number {
+    return this._time;
+  }
+
+  getTime(): number {
+    return this._time;
+  }
+
+  toDate(): Date {
+    return new Date(this._time);
+  }
+
+  utc(keepLocalTime = false): LandscapeDate {
+    if (keepLocalTime && !this._utc) {
+      const date = new Date(this._time);
+      const time = Date.UTC(
+        date.getFullYear(),
+        date.getMonth(),
+        date.getDate(),
+        date.getHours(),
+        date.getMinutes(),
+        date.getSeconds(),
+        date.getMilliseconds(),
+      );
+
+      return new LandscapeDate(time, true);
+    }
+
+    return new LandscapeDate(this._time, true);
+  }
+
+  local(): LandscapeDate {
+    return new LandscapeDate(this._time, false);
+  }
+
+  add(amount: number, unit: AddUnit): LandscapeDate {
+    return this.shift(amount, unit);
+  }
+
+  subtract(amount: number, unit: AddUnit): LandscapeDate {
+    return this.shift(-amount, unit);
+  }
+
+  private shift(amount: number, unit: AddUnit): LandscapeDate {
+    switch (unit) {
+      case "millisecond":
+      case "milliseconds":
+        return new LandscapeDate(this._time + amount, this._utc);
+      case "second":
+      case "seconds":
+        return new LandscapeDate(this._time + amount * 1000, this._utc);
+      case "minute":
+      case "minutes":
+        return new LandscapeDate(this._time + amount * MS_PER_MINUTE, this._utc);
+      case "hour":
+      case "hours":
+        return new LandscapeDate(this._time + amount * MS_PER_HOUR, this._utc);
+      case "day":
+      case "days":
+        return new LandscapeDate(this._time + amount * MS_PER_DAY, this._utc);
+      case "week":
+      case "weeks":
+        return new LandscapeDate(
+          this._time + amount * MS_PER_DAY * 7,
+          this._utc,
+        );
+      case "month":
+      case "months": {
+        const date = new Date(this._time);
+        if (this._utc) {
+          date.setUTCMonth(date.getUTCMonth() + amount);
+        } else {
+          date.setMonth(date.getMonth() + amount);
+        }
+        return new LandscapeDate(date.getTime(), this._utc);
+      }
+      case "year":
+      case "years": {
+        const date = new Date(this._time);
+        if (this._utc) {
+          date.setUTCFullYear(date.getUTCFullYear() + amount);
+        } else {
+          date.setFullYear(date.getFullYear() + amount);
+        }
+        return new LandscapeDate(date.getTime(), this._utc);
+      }
+      default:
+        return new LandscapeDate(this._time, this._utc);
+    }
+  }
+
+  diff(other: DateInput, unit?: DiffUnit): number {
+    const difference = this._time - LandscapeDate.from(other)._time;
+
+    switch (unit) {
+      case "second":
+      case "seconds":
+        return Math.trunc(difference / 1000);
+      case "minute":
+      case "minutes":
+        return Math.trunc(difference / MS_PER_MINUTE);
+      case "hour":
+      case "hours":
+        return Math.trunc(difference / MS_PER_HOUR);
+      case "day":
+      case "days":
+        return Math.trunc(difference / MS_PER_DAY);
+      case "millisecond":
+      case "milliseconds":
+      default:
+        return difference;
+    }
+  }
+
+  isAfter(other?: DateInput): boolean {
+    const target = other === undefined ? LandscapeDate.now() : LandscapeDate.from(other);
+    return this._time > target._time;
+  }
+
+  isBefore(other?: DateInput): boolean {
+    const target = other === undefined ? LandscapeDate.now() : LandscapeDate.from(other);
+    return this._time < target._time;
+  }
+
+  isSameOrAfter(other: DateInput): boolean {
+    return this._time >= LandscapeDate.from(other)._time;
+  }
+
+  isSameOrBefore(other: DateInput): boolean {
+    return this._time <= LandscapeDate.from(other)._time;
+  }
+
+  toISOString(): string {
+    return new Date(this._time).toISOString();
+  }
+
+  format(pattern?: string): string {
+    if (!this.isValid()) {
+      return "Invalid date";
+    }
+
+    const fields = this.fields();
+
+    if (pattern === undefined) {
+      return this.defaultFormat(fields);
+    }
+
+    return pattern.replace(FORMAT_TOKEN_REGEX, (token, literal?: string) => {
+      if (literal !== undefined) {
+        return literal;
+      }
+
+      return this.formatToken(token, fields);
+    });
+  }
+
+  private formatToken(token: string, fields: DateFields): string {
+    const formatter = FORMAT_TOKENS[token];
+    return formatter ? formatter(fields) : token;
+  }
+
+  private defaultFormat(fields: DateFields): string {
+    const base = `${pad(fields.Y, 4)}-${pad(fields.Mo + 1)}-${pad(
+      fields.D,
+    )}T${pad(fields.H)}:${pad(fields.Mi)}:${pad(fields.S)}`;
+
+    if (this._utc) {
+      return `${base}+00:00`;
+    }
+
+    const offsetMinutes = new Date(this._time).getTimezoneOffset();
+    const sign = offsetMinutes <= 0 ? "+" : "-";
+    const absolute = Math.abs(offsetMinutes);
+
+    return `${base}${sign}${pad(Math.floor(absolute / 60))}:${pad(
+      absolute % 60,
+    )}`;
+  }
+
+  calendar(formats: CalendarFormats): string {
+    const dayIndex = (date: LandscapeDate): number => {
+      const f = date.fields();
+      return Math.floor(Date.UTC(f.Y, f.Mo, f.D) / MS_PER_DAY);
+    };
+
+    const reference = this._utc ? LandscapeDate.now().utc() : LandscapeDate.now();
+    const delta = dayIndex(this) - dayIndex(reference);
+
+    let pattern: string | undefined;
+
+    if (delta === 0) {
+      pattern = formats.sameDay;
+    } else if (delta === -1) {
+      pattern = formats.lastDay;
+    } else if (delta === 1) {
+      pattern = formats.nextDay;
+    } else if (delta > -DAYS_PER_WEEK && delta < 0) {
+      pattern = formats.lastWeek;
+    } else if (delta < DAYS_PER_WEEK && delta > 1) {
+      pattern = formats.nextWeek;
+    }
+
+    return this.format(pattern ?? formats.sameElse);
+  }
+}

--- a/src/libs/date/index.ts
+++ b/src/libs/date/index.ts
@@ -1,0 +1,33 @@
+import type { CalendarFormats, DateInput } from "./LandscapeDate";
+import { ISO_8601, LandscapeDate } from "./LandscapeDate";
+
+interface DateFactory {
+  (
+    input?: DateInput,
+    format?: typeof ISO_8601,
+    strict?: boolean,
+  ): LandscapeDate;
+  ISO_8601: typeof ISO_8601;
+}
+
+/**
+ * Moment-shaped factory used as a drop-in replacement for `moment(...)`.
+ *
+ * Usage:
+ *   date()                          // now
+ *   date(value)                     // parse a value
+ *   date(value, date.ISO_8601, true) // strict ISO 8601 validation
+ */
+const date = ((input?: DateInput, format?: typeof ISO_8601, strict?: boolean) => {
+  if (format === ISO_8601) {
+    return LandscapeDate.parseStrictISO(String(input), strict);
+  }
+
+  return LandscapeDate.from(input);
+}) as DateFactory;
+
+date.ISO_8601 = ISO_8601;
+
+export default date;
+export { LandscapeDate, ISO_8601 };
+export type { CalendarFormats, DateInput };

--- a/src/libs/date/index.ts
+++ b/src/libs/date/index.ts
@@ -11,7 +11,7 @@ interface DateFactory {
 }
 
 /**
- * Moment-shaped factory used as a drop-in replacement for `moment(...)`.
+ * Date factory used by the Landscape UI date helper.
  *
  * Usage:
  *   date()                          // now

--- a/src/libs/date/index.ts
+++ b/src/libs/date/index.ts
@@ -2,11 +2,7 @@ import type { CalendarFormats, DateInput } from "./ChronoDate";
 import { ISO_8601, ChronoDate } from "./ChronoDate";
 
 interface DateFactory {
-  (
-    input?: DateInput,
-    format?: typeof ISO_8601,
-    strict?: boolean,
-  ): ChronoDate;
+  (input?: DateInput, format?: typeof ISO_8601, strict?: boolean): ChronoDate;
   ISO_8601: typeof ISO_8601;
 }
 

--- a/src/libs/date/index.ts
+++ b/src/libs/date/index.ts
@@ -1,17 +1,17 @@
-import type { CalendarFormats, DateInput } from "./LandscapeDate";
-import { ISO_8601, LandscapeDate } from "./LandscapeDate";
+import type { CalendarFormats, DateInput } from "./ChronoDate";
+import { ISO_8601, ChronoDate } from "./ChronoDate";
 
 interface DateFactory {
   (
     input?: DateInput,
     format?: typeof ISO_8601,
     strict?: boolean,
-  ): LandscapeDate;
+  ): ChronoDate;
   ISO_8601: typeof ISO_8601;
 }
 
 /**
- * Date factory used by the Landscape UI date helper.
+ * Date factory providing the entry point over ChronoDate.
  *
  * Usage:
  *   date()                          // now
@@ -24,14 +24,14 @@ const date = ((
   strict?: boolean,
 ) => {
   if (format === ISO_8601) {
-    return LandscapeDate.parseStrictISO(String(input), strict);
+    return ChronoDate.parseStrictISO(String(input), strict);
   }
 
-  return LandscapeDate.from(input);
+  return ChronoDate.from(input);
 }) as DateFactory;
 
 date.ISO_8601 = ISO_8601;
 
 export default date;
-export { LandscapeDate, ISO_8601 };
+export { ChronoDate, ISO_8601 };
 export type { CalendarFormats, DateInput };

--- a/src/libs/date/index.ts
+++ b/src/libs/date/index.ts
@@ -18,7 +18,11 @@ interface DateFactory {
  *   date(value)                     // parse a value
  *   date(value, date.ISO_8601, true) // strict ISO 8601 validation
  */
-const date = ((input?: DateInput, format?: typeof ISO_8601, strict?: boolean) => {
+const date = ((
+  input?: DateInput,
+  format?: typeof ISO_8601,
+  strict?: boolean,
+) => {
   if (format === ISO_8601) {
     return LandscapeDate.parseStrictISO(String(input), strict);
   }

--- a/src/libs/pageParamsManager/constants.ts
+++ b/src/libs/pageParamsManager/constants.ts
@@ -1,6 +1,6 @@
 import { PAGE_SIZE_OPTIONS } from "@/components/layout/TablePagination/components/TablePaginationBase/constants";
 import { DAYS_FILTER_OPTIONS } from "@/features/events-log";
-import moment from "moment";
+import date from "@/libs/date";
 import type { ParamsConfig } from "./types";
 
 export const DEFAULT_CURRENT_PAGE = 1;
@@ -46,7 +46,7 @@ export const PARAMS_CONFIG: ParamsConfig = [
     urlParam: "fromDate",
     shouldResetPage: true,
     defaultValue: DEFAULT_EMPTY_STRING,
-    validator: (val: string) => moment(val, moment.ISO_8601, true).isValid(),
+    validator: (val: string) => date(val, date.ISO_8601, true).isValid(),
   },
   {
     urlParam: "groupBy",
@@ -98,7 +98,7 @@ export const PARAMS_CONFIG: ParamsConfig = [
     urlParam: "toDate",
     shouldResetPage: true,
     defaultValue: DEFAULT_EMPTY_STRING,
-    validator: (val: string) => moment(val, moment.ISO_8601, true).isValid(),
+    validator: (val: string) => date(val, date.ISO_8601, true).isValid(),
   },
   {
     urlParam: "type",

--- a/src/pages/dashboard/events-log/EventsLogPage.tsx
+++ b/src/pages/dashboard/events-log/EventsLogPage.tsx
@@ -12,7 +12,7 @@ import {
 import useAuth from "@/hooks/useAuth";
 import usePageParams from "@/hooks/usePageParams";
 import { Button } from "@canonical/react-components";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { useMemo } from "react";
 import { downloadCSV } from "./helpers";
@@ -48,7 +48,7 @@ const EventsLogPage: FC = () => {
             onClick={() => {
               downloadCSV(
                 eventsLog,
-                `Event Log - ${user.current_account}-${moment().format("YYYY-MM-DDTHH mm ss[Z]")}.csv`,
+                `Event Log - ${user.current_account}-${date().format("YYYY-MM-DDTHH mm ss[Z]")}.csv`,
               );
             }}
           >

--- a/src/pages/dashboard/instances/PendingInstanceList/helpers.tsx
+++ b/src/pages/dashboard/instances/PendingInstanceList/helpers.tsx
@@ -1,4 +1,4 @@
-import moment from "moment/moment";
+import date from "@/libs/date";
 import type { HTMLProps } from "react";
 import type { Cell, TableCellProps } from "react-table";
 import NoData from "@/components/layout/NoData";
@@ -44,7 +44,7 @@ export const getAccessGroup = (
 };
 
 export const getCreationTime = (time: string) => {
-  return moment(time)
+  return date(time)
     .utc()
     .calendar({
       sameElse: `${DISPLAY_DATE_TIME_FORMAT} [UTC]`,

--- a/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/info/InfoPanel/InfoPanel.tsx
@@ -50,7 +50,7 @@ import {
   Tooltip,
 } from "@canonical/react-components";
 import classNames from "classnames";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { Fragment, lazy, Suspense } from "react";
 import { useNavigate } from "react-router";
@@ -424,8 +424,8 @@ const InfoPanel: FC<InfoPanelProps> = ({ instance }) => {
             <InfoGrid.Item
               label="Last ping time"
               value={
-                moment(instance.last_ping_time).isValid()
-                  ? moment(instance.last_ping_time).format(
+                date(instance.last_ping_time).isValid()
+                  ? date(instance.last_ping_time).format(
                       DISPLAY_DATE_TIME_FORMAT,
                     )
                   : null
@@ -522,7 +522,7 @@ const InfoPanel: FC<InfoPanelProps> = ({ instance }) => {
             )}
             <InfoGrid.Item
               label="Registered"
-              value={moment(instance.registered_at).format(
+              value={date(instance.registered_at).format(
                 DISPLAY_DATE_TIME_FORMAT,
               )}
             />

--- a/src/pages/dashboard/instances/[single]/tabs/kernel/KernelPanel/KernelPanel.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/kernel/KernelPanel/KernelPanel.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/features/kernel";
 import usePageParams from "@/hooks/usePageParams";
 import type { UrlParams } from "@/types/UrlParams";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { useMemo } from "react";
 import { useParams } from "react-router";
@@ -58,7 +58,7 @@ const KernelPanel: FC<KernelPanelProps> = ({ instanceTitle }) => {
       "",
     expirationDate:
       kernelInfo?.UpgradeRequiredDate &&
-      moment(kernelInfo?.UpgradeRequiredDate).isValid()
+      date(kernelInfo?.UpgradeRequiredDate).isValid()
         ? kernelInfo.UpgradeRequiredDate
         : "",
     status: kernelStatuses?.data.smart_status ?? "",

--- a/src/pages/dashboard/instances/[single]/tabs/processes/ProcessesPanel/ProcessesPanel.test.tsx
+++ b/src/pages/dashboard/instances/[single]/tabs/processes/ProcessesPanel/ProcessesPanel.test.tsx
@@ -5,8 +5,8 @@ import { renderWithProviders } from "@/tests/render";
 import server from "@/tests/server";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import date from "@/libs/date";
 import { http, HttpResponse } from "msw";
-import moment from "moment/moment";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import ProcessesPanel from "./ProcessesPanel";
 
@@ -24,17 +24,17 @@ describe("ProcessesPanel", () => {
 
     for (const process of processes) {
       const listProcess = await screen.findByRole("row", {
-        name: `Select process ${process.name}${process.name} ${process.state} ${process.vm_size} ${(100 * process.cpu_utilisation).toFixed(1)}% ${process.pid} ${moment(process.start_time).format(DISPLAY_DATE_TIME_FORMAT)} ${process.gid}`,
+        name: `Select process ${process.name}${process.name} ${process.state} ${process.vm_size} ${(100 * process.cpu_utilisation).toFixed(1)}% ${process.pid} ${date(process.start_time).format(DISPLAY_DATE_TIME_FORMAT)} ${process.gid}`,
       });
       expect(listProcess).toBeInTheDocument();
     }
     const searchBox = await screen.findByRole("searchbox");
     await userEvent.type(searchBox, `${processes[0].name}{enter}`);
     const processFound = await screen.findByRole("row", {
-      name: `Select process ${processes[0].name}${processes[0].name} ${processes[0].state} ${processes[0].vm_size} ${(100 * processes[0].cpu_utilisation).toFixed(1)}% ${processes[0].pid} ${moment(processes[0].start_time).format(DISPLAY_DATE_TIME_FORMAT)} ${processes[0].gid}`,
+      name: `Select process ${processes[0].name}${processes[0].name} ${processes[0].state} ${processes[0].vm_size} ${(100 * processes[0].cpu_utilisation).toFixed(1)}% ${processes[0].pid} ${date(processes[0].start_time).format(DISPLAY_DATE_TIME_FORMAT)} ${processes[0].gid}`,
     });
     const processRemoved = screen.queryByRole("row", {
-      name: `Select process ${processes[5].name}${processes[5].name} ${processes[5].state} ${processes[5].vm_size} ${(100 * processes[5].cpu_utilisation).toFixed(1)}% ${processes[5].pid} ${moment(processes[5].start_time).format(DISPLAY_DATE_TIME_FORMAT)} ${processes[5].gid}`,
+      name: `Select process ${processes[5].name}${processes[5].name} ${processes[5].state} ${processes[5].vm_size} ${(100 * processes[5].cpu_utilisation).toFixed(1)}% ${processes[5].pid} ${date(processes[5].start_time).format(DISPLAY_DATE_TIME_FORMAT)} ${processes[5].gid}`,
     });
     expect(processFound).toBeInTheDocument();
     expect(processRemoved).not.toBeInTheDocument();

--- a/src/pages/dashboard/settings/administrators/tabs/invites/InvitesPanel/InvitesPanel.tsx
+++ b/src/pages/dashboard/settings/administrators/tabs/invites/InvitesPanel/InvitesPanel.tsx
@@ -79,9 +79,7 @@ const InvitesPanel: FC = () => {
         Header: "Invited",
         Cell: ({ row }: CellProps<Invitation>) => (
           <span className="font-monospace">
-            {date(row.original.creation_time).format(
-              DISPLAY_DATE_TIME_FORMAT,
-            )}
+            {date(row.original.creation_time).format(DISPLAY_DATE_TIME_FORMAT)}
           </span>
         ),
       },

--- a/src/pages/dashboard/settings/administrators/tabs/invites/InvitesPanel/InvitesPanel.tsx
+++ b/src/pages/dashboard/settings/administrators/tabs/invites/InvitesPanel/InvitesPanel.tsx
@@ -5,7 +5,7 @@ import useDebug from "@/hooks/useDebug";
 import useNotify from "@/hooks/useNotify";
 import type { Invitation } from "@/types/Invitation";
 import { ConfirmationButton } from "@canonical/react-components";
-import moment from "moment";
+import date from "@/libs/date";
 import type { FC } from "react";
 import { useMemo } from "react";
 import type { CellProps, Column } from "react-table";
@@ -28,7 +28,7 @@ const InvitesPanel: FC = () => {
   const invitations = useMemo(
     () =>
       getInvitationsQueryResult?.data.results.sort((a, b) =>
-        moment(b.creation_time).diff(moment(a.creation_time)),
+        date(b.creation_time).diff(date(a.creation_time)),
       ) ?? [],
     [getInvitationsQueryResult],
   );
@@ -79,7 +79,7 @@ const InvitesPanel: FC = () => {
         Header: "Invited",
         Cell: ({ row }: CellProps<Invitation>) => (
           <span className="font-monospace">
-            {moment(row.original.creation_time).format(
+            {date(row.original.creation_time).format(
               DISPLAY_DATE_TIME_FORMAT,
             )}
           </span>
@@ -90,7 +90,7 @@ const InvitesPanel: FC = () => {
         Header: "Expires",
         Cell: ({ row }: CellProps<Invitation>) => (
           <span className="font-monospace">
-            {moment(row.original.creation_time)
+            {date(row.original.creation_time)
               .add(TWO_WEEKS_DAYS, "days")
               .format(DISPLAY_DATE_TIME_FORMAT)}
           </span>

--- a/src/tests/server/handlers/activity.ts
+++ b/src/tests/server/handlers/activity.ts
@@ -9,7 +9,7 @@ import {
   manyDeliveredActivities,
   manyUnapprovedActivities,
 } from "@/tests/mocks/activity";
-import moment from "moment";
+import date from "@/libs/date";
 import { http, HttpResponse } from "msw";
 import {
   createEndpointStatusError,
@@ -240,7 +240,7 @@ export default [
       retain_until:
         typeof body.retain_until === "string"
           ? body.retain_until
-          : moment().add(3, "years").toISOString(),
+          : date().add(3, "years").toISOString(),
       query: typeof body.query === "string" ? body.query : null,
     };
     return HttpResponse.json(job, { status: 201 });

--- a/src/tests/server/handlers/instance.ts
+++ b/src/tests/server/handlers/instance.ts
@@ -32,7 +32,7 @@ import type {
   PendingInstance,
 } from "@/types/Instance";
 import type { GroupsResponse, Group } from "@/types/User";
-import moment from "moment";
+import date from "@/libs/date";
 import { delay, http, HttpResponse } from "msw";
 import {
   generatePaginatedResponse,
@@ -684,7 +684,7 @@ export default [
       retain_until:
         typeof body.retain_until === "string"
           ? body.retain_until
-          : moment().add(3, "years").toISOString(),
+          : date().add(3, "years").toISOString(),
       query: typeof body.query === "string" ? body.query : null,
     };
     return HttpResponse.json(job, { status: 201 });


### PR DESCRIPTION
## Summary

Replaces the `moment` dependency with a custom `LandscapeDate` class (`src/libs/date/LandscapeDate.ts`) to reduce bundle size. The new class preserves moment's parsing, formatting, UTC/local, calendar, and diff behavior, including DST adjustment.

Test coverage: 43 unit tests in `LandscapeDate.test.ts` (including a DST cross-over case). Full suite: 3147/3147 passing.

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)