### PR TITLE
chore: remove buffer dependency

### DIFF
--- a/.changeset/shaky-trains-help.md
+++ b/.changeset/shaky-trains-help.md
@@ -1,0 +1,3 @@
+---
+"landscape-ui": patch
+---

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@sentry/react": "10.56.0",
     "@tanstack/react-query": "5.101.0",
     "axios": "1.17.0",
-    "buffer": "6.0.3",
     "classnames": "2.5.1",
     "downshift": "9.3.4",
     "formik": "2.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       axios:
         specifier: 1.17.0
         version: 1.17.0
-      buffer:
-        specifier: 6.0.3
-        version: 6.0.3
       classnames:
         specifier: 2.5.1
         version: 2.5.1
@@ -1433,9 +1430,6 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
   baseline-browser-mapping@2.10.34:
     resolution: {integrity: sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==}
     engines: {node: '>=6.0.0'}
@@ -1470,9 +1464,6 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  buffer@6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   cacheable@2.3.5:
     resolution: {integrity: sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==}
@@ -2157,9 +2148,6 @@ packages:
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
-
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -5260,8 +5248,6 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  base64-js@1.5.1: {}
-
   baseline-browser-mapping@2.10.34: {}
 
   better-path-resolve@1.0.0:
@@ -5298,11 +5284,6 @@ snapshots:
       electron-to-chromium: 1.5.368
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
-
-  buffer@6.0.3:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
 
   cacheable@2.3.5:
     dependencies:
@@ -6119,8 +6100,6 @@ snapshots:
   icss-utils@5.1.0(postcss@8.5.15):
     dependencies:
       postcss: 8.5.15
-
-  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 

--- a/src/features/scripts/helpers.ts
+++ b/src/features/scripts/helpers.ts
@@ -3,10 +3,23 @@ import type { CreateScriptAttachmentParams } from "./api";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import moment from "moment";
 
+const uint8ToBase64 = (bytes: Uint8Array): string => {
+  let binary = "";
+  const CHUNK_SIZE = 0x8000; // 32KB chunks
+
+  for (let i = 0; i < bytes.length; i += CHUNK_SIZE) {
+    const chunk = bytes.subarray(i, i + CHUNK_SIZE);
+    binary += String.fromCharCode(...Array.from(chunk));
+  }
+
+  return btoa(binary);
+};
+
 export const getEncodedCode = (code: string) => {
   const escapedCode = JSON.parse(JSON.stringify(code).replace(/\\r/g, ""));
 
-  return Buffer.from(escapedCode).toString("base64");
+  const bytes = new TextEncoder().encode(escapedCode);
+  return uint8ToBase64(bytes);
 };
 
 export const getCreateScriptParams = (values: ScriptFormValues) => {
@@ -55,12 +68,14 @@ export const getCreateAttachmentsPromises = async ({
 
   const buffers = await Promise.all(bufferPromises);
 
-  return buffers.map(async (buffer, index) =>
-    createScriptAttachment({
-      file: `${fileNames[index]}$$${Buffer.from(buffer).toString("base64")}`,
+  return buffers.map(async (buffer, index) => {
+    const bytes = new Uint8Array(buffer);
+
+    return createScriptAttachment({
+      file: `${fileNames[index]}$$${uint8ToBase64(bytes)}`,
       script_id,
-    }),
-  );
+    });
+  });
 };
 
 export const removeFileExtension = (filename: string): string => {

--- a/src/features/scripts/helpers.ts
+++ b/src/features/scripts/helpers.ts
@@ -1,4 +1,3 @@
-import { Buffer } from "buffer";
 import type { ScriptFormValues } from "./types";
 import type { CreateScriptAttachmentParams } from "./api";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";


### PR DESCRIPTION
## Summary

Remove buffer package dependency by using node's native global `Buffer` instead. Resolves LNDENG-4754

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [X] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [X] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [X] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [ ] **UI verified** — I have verified the changes locally.
- [X] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
