### PR TITLE
Fix: Autoinstall files sidepanel styling

### DIFF
--- a/.changeset/tiny-seals-obey.md
+++ b/.changeset/tiny-seals-obey.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Fix styling for Autoinstall files side panel

--- a/src/features/autoinstall-files/components/AutoinstallFileDetails/AutoinstallFileDetails.module.scss
+++ b/src/features/autoinstall-files/components/AutoinstallFileDetails/AutoinstallFileDetails.module.scss
@@ -1,0 +1,5 @@
+@import "vanilla-framework/scss/settings_spacing";
+
+.marginBottom {
+  margin-bottom: $spv--x-large;
+}

--- a/src/features/autoinstall-files/components/AutoinstallFileDetails/AutoinstallFileDetails.test.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFileDetails/AutoinstallFileDetails.test.tsx
@@ -1,5 +1,9 @@
 import { setEndpointStatus } from "@/tests/controllers/controller";
-import { expectLoadingState } from "@/tests/helpers";
+import {
+  expectLoadingState,
+  resetScreenSize,
+  setScreenSize,
+} from "@/tests/helpers";
 import {
   autoinstallFiles,
   autoinstallFileVersions,
@@ -18,8 +22,26 @@ describe("AutoinstallFileDetails", () => {
     autoinstallFile: defaultFile,
   };
 
+  beforeEach(() => {
+    setScreenSize("lg");
+  });
+
   it("renders action buttons", () => {
     renderWithProviders(<AutoinstallFileDetails {...defaultProps} />);
+    expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /set as default/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /remove/i })).toBeInTheDocument();
+  });
+
+  it("renders collapsed action buttons", async () => {
+    resetScreenSize();
+    renderWithProviders(<AutoinstallFileDetails {...defaultProps} />);
+
+    const actionsButton = screen.getByRole("button", { name: /actions/i });
+    await userEvent.click(actionsButton);
+
     expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /set as default/i }),

--- a/src/features/autoinstall-files/components/AutoinstallFileDetails/AutoinstallFileDetails.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFileDetails/AutoinstallFileDetails.tsx
@@ -1,3 +1,4 @@
+import { ResponsiveButtons } from "@/components/ui";
 import { ActionButton, Button, Icon, ICONS } from "@canonical/react-components";
 import type { FC } from "react";
 import { useBoolean } from "usehooks-ts";
@@ -33,21 +34,21 @@ const AutoinstallFileDetails: FC<AutoinstallFileDetailsProps> = ({
 
   return (
     <>
-      <div className="p-segmented-control">
-        <div className="p-segmented-control__list">
+      <ResponsiveButtons
+        collapseFrom="xs"
+        buttons={[
           <Button
+            key="edit"
             type="button"
-            className="p-segmented-control__button"
             onClick={openAutoinstallFileEditForm}
             hasIcon
           >
             <Icon name="edit" />
             <span>Edit</span>
-          </Button>
-
+          </Button>,
           <ActionButton
+            key="set-as-default"
             type="button"
-            className="p-segmented-control__button"
             onClick={setAutoinstallFileAsDefault}
             disabled={autoinstallFile.is_default}
             hasIcon
@@ -55,20 +56,19 @@ const AutoinstallFileDetails: FC<AutoinstallFileDetailsProps> = ({
           >
             <Icon name="starred" />
             <span>Set as default</span>
-          </ActionButton>
-
+          </ActionButton>,
           <Button
+            key="remove"
             type="button"
-            className="p-segmented-control__button"
             onClick={openDeleteModal}
             disabled={autoinstallFile.is_default}
             hasIcon
           >
             <Icon name={ICONS.delete} />
             <span>Remove</span>
-          </Button>
-        </div>
-      </div>
+          </Button>,
+        ]}
+      />
 
       <AutoinstallFileTabs
         initialTabId={initialTabId}

--- a/src/features/autoinstall-files/components/AutoinstallFileDetails/AutoinstallFileDetails.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFileDetails/AutoinstallFileDetails.tsx
@@ -6,6 +6,7 @@ import { useAutoinstallFileActions } from "../../hooks";
 import type { AutoinstallFile, AutoinstallFileTabId } from "../../types";
 import AutoinstallFileDeleteModal from "../AutoinstallFileDeleteModal";
 import AutoinstallFileTabs from "../AutoinstallFileTabs";
+import classes from "./AutoinstallFileDetails.module.scss";
 
 interface AutoinstallFileDetailsProps {
   readonly autoinstallFile: AutoinstallFile;
@@ -35,6 +36,7 @@ const AutoinstallFileDetails: FC<AutoinstallFileDetailsProps> = ({
   return (
     <>
       <ResponsiveButtons
+        className={classes.marginBottom}
         collapseFrom="xs"
         buttons={[
           <Button

--- a/src/features/autoinstall-files/components/AutoinstallFileSidePanelTitle/AutoinstallFileSidePanelTitle.module.scss
+++ b/src/features/autoinstall-files/components/AutoinstallFileSidePanelTitle/AutoinstallFileSidePanelTitle.module.scss
@@ -1,8 +1,8 @@
 @import "vanilla-framework/scss/settings_spacing";
 
 .chip {
-  vertical-align: middle;
   font-weight: initial;
+  vertical-align: middle;
 }
 
 .text {

--- a/src/features/autoinstall-files/components/AutoinstallFileSidePanelTitle/AutoinstallFileSidePanelTitle.module.scss
+++ b/src/features/autoinstall-files/components/AutoinstallFileSidePanelTitle/AutoinstallFileSidePanelTitle.module.scss
@@ -1,11 +1,10 @@
 @import "vanilla-framework/scss/settings_spacing";
 
 .chip {
-  align-self: center;
+  vertical-align: middle;
   font-weight: initial;
 }
 
-.container {
-  display: flex;
-  gap: $sph--small;
+.text {
+  margin-right: $sph--small;
 }

--- a/src/features/autoinstall-files/components/AutoinstallFileSidePanelTitle/AutoinstallFileSidePanelTitle.test.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFileSidePanelTitle/AutoinstallFileSidePanelTitle.test.tsx
@@ -5,7 +5,7 @@ import { describe } from "vitest";
 import AutoinstallFileSidePanelTitle from "./AutoinstallFileSidePanelTitle";
 
 describe("AutoinstallFileSidePanelTitle", () => {
-  it("should render with a title prefix", async () => {
+  it("should render with a title prefix and default chip", async () => {
     const [file] = autoinstallFiles;
     const title = "Add";
 
@@ -16,5 +16,17 @@ describe("AutoinstallFileSidePanelTitle", () => {
     expect(
       screen.getByText(`${title} ${file.filename}, v${file.version}`),
     ).toBeInTheDocument();
+
+    expect(screen.getByText("Default")).toBeInTheDocument();
+  });
+
+  it("should render with a specified version", async () => {
+    const [file] = autoinstallFiles;
+
+    renderWithProviders(
+      <AutoinstallFileSidePanelTitle file={file} version={5} />,
+    );
+
+    expect(screen.getByText(`${file.filename}, v5`)).toBeInTheDocument();
   });
 });

--- a/src/features/autoinstall-files/components/AutoinstallFileSidePanelTitle/AutoinstallFileSidePanelTitle.tsx
+++ b/src/features/autoinstall-files/components/AutoinstallFileSidePanelTitle/AutoinstallFileSidePanelTitle.tsx
@@ -15,11 +15,13 @@ const AutoinstallFileSidePanelTitle: FC<AutoinstallFileSidePanelTitleProps> = ({
   version = file.version,
 }) => {
   return (
-    <div className={classes.container}>
-      {!!title && `${title} `}
-      {file.filename}, v{version}
+    <span>
+      <span className={classes.text}>
+        {!!title && `${title} `}
+        {file.filename}, v{version}
+      </span>
       {file.is_default && <Chip className={classes.chip} value="Default" />}
-    </div>
+    </span>
   );
 };
 


### PR DESCRIPTION
## Summary

- made the button group collapsible 
- made the title inline
- fixed & added tests

Before vs After:
<img height="460" alt="image-20260605-193402" src="https://github.com/user-attachments/assets/fb7094af-9a25-4d05-9514-0fd24afdd2a5" /> <img height="460" alt="image" src="https://github.com/user-attachments/assets/f5b273c8-a0da-48df-9c3e-d54e148d2515" /> 


## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
