### PR TITLE
Fix: Notify timeout and deduplication

### DIFF
--- a/.changeset/itchy-lights-guess.md
+++ b/.changeset/itchy-lights-guess.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Fix success notification timing out too early and not updating properly

--- a/src/context/notify.test.tsx
+++ b/src/context/notify.test.tsx
@@ -1,114 +1,26 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { describe, it, expect } from "vitest";
-import { MemoryRouter } from "react-router";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter, useNavigate } from "react-router";
 import { useContext } from "react";
 import NotifyProvider, { NotifyContext } from "./notify";
 
+const NavigateToLogin = () => {
+  const navigate = useNavigate();
+
+  return (
+    <button
+      onClick={() => {
+        navigate("/login");
+      }}
+    >
+      Go to login
+    </button>
+  );
+};
+
 const TestConsumer = () => (
-  <NotifyContext.Consumer>
-    {({ notify }) => (
-      <div>
-        {notify.notification && (
-          <div data-testid="notification">
-            {notify.notification.message?.toString()}
-          </div>
-        )}
-        <button
-          onClick={() => {
-            notify.success({ title: "Done", message: "Success msg" });
-          }}
-        >
-          Trigger Success
-        </button>
-        <button
-          onClick={() => {
-            notify.error({ title: "Fail", message: "Error msg" });
-          }}
-        >
-          Trigger Error
-        </button>
-        <button
-          onClick={() => {
-            notify.clear();
-          }}
-        >
-          Clear
-        </button>
-      </div>
-    )}
-  </NotifyContext.Consumer>
-);
-
-describe("NotifyProvider", () => {
-  const user = userEvent.setup();
-
-  it("renders children", () => {
-    render(
-      <MemoryRouter>
-        <NotifyProvider>
-          <div data-testid="child">hello</div>
-        </NotifyProvider>
-      </MemoryRouter>,
-    );
-
-    expect(screen.getByTestId("child")).toBeInTheDocument();
-  });
-
-  it("shows a notification when notify.success is called", async () => {
-    render(
-      <MemoryRouter>
-        <NotifyProvider>
-          <TestConsumer />
-        </NotifyProvider>
-      </MemoryRouter>,
-    );
-
-    await user.click(screen.getByText("Trigger Success"));
-
-    await waitFor(() => {
-      expect(screen.getByTestId("notification")).toBeInTheDocument();
-    });
-  });
-
-  it("shows an error notification when notify.error is called", async () => {
-    render(
-      <MemoryRouter>
-        <NotifyProvider>
-          <TestConsumer />
-        </NotifyProvider>
-      </MemoryRouter>,
-    );
-
-    await user.click(screen.getByText("Trigger Error"));
-
-    await waitFor(() => {
-      expect(screen.getByTestId("notification")).toBeInTheDocument();
-    });
-  });
-
-  it("clears notification when notify.clear is called", async () => {
-    render(
-      <MemoryRouter>
-        <NotifyProvider>
-          <TestConsumer />
-        </NotifyProvider>
-      </MemoryRouter>,
-    );
-
-    await user.click(screen.getByText("Trigger Success"));
-    await waitFor(() => {
-      expect(screen.getByTestId("notification")).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByText("Clear"));
-    await waitFor(() => {
-      expect(screen.queryByTestId("notification")).not.toBeInTheDocument();
-    });
-  });
-
-  it("shows an info notification when notify.info is called", async () => {
-    const InfoConsumer = () => (
+  <MemoryRouter>
+    <NotifyProvider>
       <NotifyContext.Consumer>
         {({ notify }) => (
           <div>
@@ -119,104 +31,243 @@ describe("NotifyProvider", () => {
             )}
             <button
               onClick={() => {
+                notify.success({ title: "Done", message: "First success" });
+              }}
+            >
+              Trigger Success A
+            </button>
+            <button
+              onClick={() => {
+                notify.success({ title: "Done", message: "Second success" });
+              }}
+            >
+              Trigger Success B
+            </button>
+            <button
+              onClick={() => {
+                notify.error({ title: "Fail", message: "Error msg" });
+              }}
+            >
+              Trigger Error
+            </button>
+            <button
+              onClick={() => {
                 notify.info({ title: "Info", message: "Info msg" });
               }}
             >
               Trigger Info
             </button>
+            <button
+              onClick={() => {
+                notify.clear();
+              }}
+            >
+              Clear
+            </button>
+            <NavigateToLogin />
           </div>
         )}
       </NotifyContext.Consumer>
-    );
+    </NotifyProvider>
+  </MemoryRouter>
+);
 
-    render(
-      <MemoryRouter>
-        <NotifyProvider>
-          <InfoConsumer />
-        </NotifyProvider>
-      </MemoryRouter>,
-    );
+describe("NotifyProvider", () => {
+  it("shows success notification when notify.success is called", () => {
+    render(<TestConsumer />);
 
-    await user.click(screen.getByText("Trigger Info"));
+    fireEvent.click(screen.getByText("Trigger Success A"));
 
-    await waitFor(() => {
-      expect(screen.getByTestId("notification")).toBeInTheDocument();
-    });
+    expect(screen.getByText("First success")).toBeInTheDocument();
+  });
+
+  it("shows an error notification when notify.error is called", () => {
+    render(<TestConsumer />);
+
+    fireEvent.click(screen.getByText("Trigger Error"));
+
+    expect(screen.getByText("Error msg")).toBeInTheDocument();
+  });
+
+  it("clears notification when notify.clear is called", () => {
+    render(<TestConsumer />);
+
+    expect(screen.queryByTestId("notification")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Trigger Error"));
+    expect(screen.getByTestId("notification")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Clear"));
+    expect(screen.queryByTestId("notification")).not.toBeInTheDocument();
+  });
+
+  it("shows an info notification when notify.info is called", () => {
+    render(<TestConsumer />);
+
+    fireEvent.click(screen.getByText("Trigger Info"));
+
+    expect(screen.getByText("Info msg")).toBeInTheDocument();
   });
 
   it("does not clear notification when navigating to /login", () => {
-    render(
-      <MemoryRouter initialEntries={["/login"]}>
-        <NotifyProvider>
-          <div data-testid="child">hello</div>
-        </NotifyProvider>
-      </MemoryRouter>,
-    );
+    render(<TestConsumer />);
 
-    expect(screen.getByTestId("child")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Trigger Success A"));
+    expect(screen.getByText("First success")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Go to login"));
+    expect(screen.getByText("First success")).toBeInTheDocument();
   });
 
-  it("exposes sidePanel open state and setOpen through context", async () => {
+  it("exposes sidePanel open state and setOpen through context", () => {
     const SidePanelConsumer = () => (
-      <NotifyContext.Consumer>
-        {({ sidePanel }) => (
-          <div>
-            <span data-testid="open">{sidePanel.open ? "open" : "closed"}</span>
-            <button
-              onClick={() => {
-                sidePanel.setOpen(true);
-              }}
-            >
-              Open
-            </button>
-            <button
-              onClick={() => {
-                sidePanel.setOpen(false);
-              }}
-            >
-              Close
-            </button>
-          </div>
-        )}
-      </NotifyContext.Consumer>
-    );
-
-    render(
       <MemoryRouter>
         <NotifyProvider>
-          <SidePanelConsumer />
+          <NotifyContext.Consumer>
+            {({ sidePanel }) => (
+              <div>
+                {sidePanel.open && <div data-testid="sidePanel" />}
+                <button
+                  onClick={() => {
+                    sidePanel.setOpen(true);
+                  }}
+                >
+                  Open
+                </button>
+                <button
+                  onClick={() => {
+                    sidePanel.setOpen(false);
+                  }}
+                >
+                  Close
+                </button>
+              </div>
+            )}
+          </NotifyContext.Consumer>
         </NotifyProvider>
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
-    expect(screen.getByTestId("open")).toHaveTextContent("closed");
+    render(<SidePanelConsumer />);
 
-    await user.click(screen.getByText("Open"));
-    expect(screen.getByTestId("open")).toHaveTextContent("open");
+    expect(screen.queryByTestId("sidePanel")).not.toBeInTheDocument();
 
-    await user.click(screen.getByText("Close"));
-    expect(screen.getByTestId("open")).toHaveTextContent("closed");
+    fireEvent.click(screen.getByText("Open"));
+    expect(screen.getByTestId("sidePanel")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Close"));
+    expect(screen.queryByTestId("sidePanel")).not.toBeInTheDocument();
   });
 
-  it("default context functions are no-ops when used without provider", async () => {
+  it("default context functions are no-ops when used without provider", () => {
     const DefaultConsumer = () => {
       const { notify, sidePanel } = useContext(NotifyContext);
       return (
-        <button
-          onClick={() => {
-            notify.error({ title: "t", message: "m" });
-            notify.info({ title: "t", message: "m" });
-            notify.success({ title: "t", message: "m" });
-            notify.clear();
-            sidePanel.setOpen(true);
-          }}
-        >
-          call defaults
-        </button>
+        <div>
+          {notify.notification && (
+            <div data-testid="notification">
+              {notify.notification.message?.toString()}
+            </div>
+          )}
+          {sidePanel.open && <div data-testid="sidePanel" />}
+          <button
+            onClick={() => {
+              notify.error({ title: "t", message: "m" });
+              notify.info({ title: "t", message: "m" });
+              notify.success({ title: "t", message: "m" });
+              notify.clear();
+              sidePanel.setOpen(true);
+            }}
+          >
+            call defaults
+          </button>
+        </div>
       );
     };
 
     render(<DefaultConsumer />);
-    await user.click(screen.getByText("call defaults"));
+
+    fireEvent.click(screen.getByText("call defaults"));
+
+    expect(screen.queryByTestId("notification")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("sidePanel")).not.toBeInTheDocument();
+  });
+
+  describe("notification timeout", () => {
+    const TIMEOUT_MS = 5000;
+
+    beforeAll(() => {
+      vi.useFakeTimers();
+    });
+
+    afterAll(() => {
+      vi.useRealTimers();
+    });
+
+    it("auto-dismisses a success notification after the timeout", () => {
+      render(<TestConsumer />);
+
+      fireEvent.click(screen.getByText("Trigger Success A"));
+      expect(screen.getByTestId("notification")).toBeInTheDocument();
+
+      // Still visible right before the deadline.
+      act(() => {
+        vi.advanceTimersByTime(TIMEOUT_MS - 1);
+      });
+      expect(screen.getByTestId("notification")).toBeInTheDocument();
+
+      // Cleared exactly at the deadline.
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(screen.queryByTestId("notification")).not.toBeInTheDocument();
+    });
+
+    it("does not auto-dismiss an error notification", () => {
+      render(<TestConsumer />);
+
+      fireEvent.click(screen.getByText("Trigger Error"));
+      expect(screen.getByTestId("notification")).toBeInTheDocument();
+
+      // Errors have no duration, so no timer should ever clear them.
+      act(() => {
+        vi.advanceTimersByTime(TIMEOUT_MS * 2);
+      });
+      expect(screen.getByTestId("notification")).toBeInTheDocument();
+    });
+
+    it("resets the timeout when a second notification replaces the first", () => {
+      render(<TestConsumer />);
+
+      fireEvent.click(screen.getByText("Trigger Success A"));
+      expect(screen.getByTestId("notification")).toHaveTextContent(
+        "First success",
+      );
+
+      // Advance close to the first notification's deadline without reaching it.
+      act(() => {
+        vi.advanceTimersByTime(TIMEOUT_MS - 1000);
+      });
+
+      fireEvent.click(screen.getByText("Trigger Success B"));
+      expect(screen.getByTestId("notification")).toHaveTextContent(
+        "Second success",
+      );
+
+      // Pass the first notification's original deadline. If its timer had not
+      // been cleared, the notification would already be gone here.
+      act(() => {
+        vi.advanceTimersByTime(TIMEOUT_MS - 1000);
+      });
+      expect(screen.getByTestId("notification")).toHaveTextContent(
+        "Second success",
+      );
+
+      // Let the second notification's own timer elapse.
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(screen.queryByTestId("notification")).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/features/package-profiles/components/PackageProfileConstraintsEditSidePanel/components/PackageProfileConstraintsEditForm/PackageProfileConstraintsEditForm.test.tsx
+++ b/src/features/package-profiles/components/PackageProfileConstraintsEditSidePanel/components/PackageProfileConstraintsEditForm/PackageProfileConstraintsEditForm.test.tsx
@@ -17,9 +17,10 @@ const renderAndSubmit = async () => {
     <PackageProfileConstraintsEditForm profile={packageProfiles[0]} />,
   );
 
-  await expectLoadingState();
+  expect(screen.getByRole("status")).toBeInTheDocument();
+
   await user.click(
-    screen.getByRole("button", {
+    await screen.findByRole("button", {
       name: `Edit ${packageProfiles[0].constraints[0].package} constraint`,
     }),
   );

--- a/src/hooks/useNotificationHelper.ts
+++ b/src/hooks/useNotificationHelper.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { Notification, NotificationHelper } from "@/types/Notification";
 
 const DEFAULT_NOTIFICATION_TIMEOUT = 5000;
@@ -6,17 +6,25 @@ const DEFAULT_NOTIFICATION_TIMEOUT = 5000;
 const useNotificationHelper = (): NotificationHelper => {
   const [notification, setNotification] = useState<Notification | null>(null);
 
-  const setDeduplicated = (newValue: Notification | null) => {
-    if (newValue?.message !== notification?.message) {
-      setNotification(newValue);
+  useEffect(() => {
+    if (!notification?.duration) {
+      return;
     }
-  };
+
+    const timeoutId = setTimeout(() => {
+      setNotification(null);
+    }, notification.duration);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [notification]);
 
   return {
     notification,
 
     error: ({ message, error, actions, title }) => {
-      setDeduplicated({
+      setNotification({
         actions,
         error,
         message,
@@ -26,7 +34,7 @@ const useNotificationHelper = (): NotificationHelper => {
     },
 
     info: ({ message, actions, title }) => {
-      setDeduplicated({
+      setNotification({
         actions,
         message,
         title,
@@ -35,16 +43,13 @@ const useNotificationHelper = (): NotificationHelper => {
     },
 
     success: ({ message, actions, title }) => {
-      setDeduplicated({
+      setNotification({
         actions,
         message,
         title,
         type: "positive",
+        duration: DEFAULT_NOTIFICATION_TIMEOUT,
       });
-
-      setTimeout(() => {
-        setNotification(null);
-      }, DEFAULT_NOTIFICATION_TIMEOUT);
     },
 
     clear: () => {

--- a/src/types/Notification.ts
+++ b/src/types/Notification.ts
@@ -11,6 +11,7 @@ export interface Notification {
   actions?: NotificationAction[];
   error?: unknown;
   title?: string;
+  duration?: number;
 }
 
 export type NotificationMethodArgs<T extends "default" | "error" = "default"> =


### PR DESCRIPTION
## Summary

Summarize the changes made in this pull request. Include any relevant context or background information that would help reviewers understand the purpose and scope of the changes.

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
