### PR TITLE
Disable uneccessary API call in mirrors page [LNDENG-4391]

### DIFF
--- a/.changeset/stale-nails-read.md
+++ b/.changeset/stale-nails-read.md
@@ -1,5 +1,2 @@
 ---
-"landscape-ui": patch
 ---
-
-Disable unecessary API call in mirrors page

--- a/.changeset/stale-nails-read.md
+++ b/.changeset/stale-nails-read.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Disable unecessary API call in mirrors page

--- a/src/features/mirrors/components/RemoveMirrorModal/RemoveMirrorModal.test.tsx
+++ b/src/features/mirrors/components/RemoveMirrorModal/RemoveMirrorModal.test.tsx
@@ -6,6 +6,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { publications } from "@/tests/mocks/publications";
 import { mirrors } from "@/tests/mocks/mirrors";
+import * as useFetchDebArchiveHook from "@/hooks/useFetchDebArchive";
 
 describe("RemoveMirrorModal", () => {
   const close = vi.fn();
@@ -22,12 +23,21 @@ describe("RemoveMirrorModal", () => {
     close.mockReset();
   });
 
-  it("doesn't render while closed", () => {
+  it("doesn't render or fetch while closed", () => {
+    const getPublications = vi.fn();
+    const useFetchDebArchiveSpy = vi
+      .spyOn(useFetchDebArchiveHook, "default")
+      .mockReturnValue({ get: getPublications } as never);
+
     renderWithProviders(<RemoveMirrorModal {...props} isOpen={false} />);
 
     expect(
       screen.queryByText(`Remove ${props.mirrorDisplayName}`),
     ).not.toBeInTheDocument();
+
+    expect(getPublications).not.toHaveBeenCalled();
+
+    useFetchDebArchiveSpy.mockRestore();
   });
 
   it("renders a list of publications", async () => {
@@ -76,15 +86,5 @@ describe("RemoveMirrorModal", () => {
       ),
     ).toBeInTheDocument();
     expect(close).toHaveBeenCalled();
-  });
-
-  it("does not fetch publications when the modal is closed", () => {
-    renderWithProviders(<RemoveMirrorModal {...props} isOpen={false} />);
-
-    expect(
-      screen.queryByText(
-        "This mirror is associated with the following publications:",
-      ),
-    ).not.toBeInTheDocument();
   });
 });

--- a/src/features/mirrors/components/RemoveMirrorModal/RemoveMirrorModal.test.tsx
+++ b/src/features/mirrors/components/RemoveMirrorModal/RemoveMirrorModal.test.tsx
@@ -77,4 +77,14 @@ describe("RemoveMirrorModal", () => {
     ).toBeInTheDocument();
     expect(close).toHaveBeenCalled();
   });
+
+  it("does not fetch publications when the modal is closed", () => {
+    renderWithProviders(<RemoveMirrorModal {...props} isOpen={false} />);
+
+    expect(
+      screen.queryByText(
+        "This mirror is associated with the following publications:",
+      ),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/features/mirrors/components/RemoveMirrorModal/RemoveMirrorModal.tsx
+++ b/src/features/mirrors/components/RemoveMirrorModal/RemoveMirrorModal.tsx
@@ -27,8 +27,10 @@ const RemoveMirrorModal: FC<RemoveMirrorModalProps> = ({
   const { notify } = useNotify();
   const { closeSidePanel } = usePageParams();
 
-  const { publications, isGettingPublications } =
-    useGetPublicationsBySource(mirrorName);
+  const { publications, isGettingPublications } = useGetPublicationsBySource(
+    mirrorName,
+    { enabled: isOpen },
+  );
 
   const { mutateAsync: deleteMirror, isPending: isDeletingMirror } =
     useDeleteMirror(mirrorName);

--- a/src/features/publications/api/useGetPublicationsBySource.ts
+++ b/src/features/publications/api/useGetPublicationsBySource.ts
@@ -25,7 +25,6 @@ export const useGetPublicationsBySource = (
     AxiosError<PublicationServiceListPublicationsError>
   >({
     queryKey: ["publications", source],
-    enabled: !!source,
     queryFn: async () => {
       let pageToken: string | undefined;
       const publications: Publication[] = [];
@@ -50,6 +49,7 @@ export const useGetPublicationsBySource = (
       return publications;
     },
     ...options,
+    enabled: !!source && options?.enabled !== false,
   });
 
   return {

--- a/src/features/publications/api/useGetPublicationsBySource.ts
+++ b/src/features/publications/api/useGetPublicationsBySource.ts
@@ -1,4 +1,5 @@
 import useFetchDebArchive from "@/hooks/useFetchDebArchive";
+import type { UseQueryOptions } from "@tanstack/react-query";
 import { useQuery } from "@tanstack/react-query";
 import type { AxiosError } from "axios";
 import type {
@@ -7,7 +8,16 @@ import type {
   ListPublicationsResponse,
 } from "@canonical/landscape-openapi";
 
-export const useGetPublicationsBySource = (source?: string) => {
+export const useGetPublicationsBySource = (
+  source?: string,
+  options?: Omit<
+    UseQueryOptions<
+      Publication[],
+      AxiosError<PublicationServiceListPublicationsError>
+    >,
+    "queryKey" | "queryFn"
+  >,
+) => {
   const authFetchDebArchive = useFetchDebArchive();
 
   const { data, isLoading } = useQuery<
@@ -39,6 +49,7 @@ export const useGetPublicationsBySource = (source?: string) => {
 
       return publications;
     },
+    ...options,
   });
 
   return {


### PR DESCRIPTION
## Summary

Summarize the changes made in this pull request. Include any relevant context or background information that would help reviewers understand the purpose and scope of the changes.

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
