### PR TITLE
feat: resolve API coverage routes from contracts instead of heuristics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ src/**/*.module.scss.d.ts
 .cert
 src/tests/msw-api-registry.jsonl
 src/tests/msw-contract-coverage.json
+src/tests/msw-handlers-manifest.json

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "test:ui": "pnpm exec playwright test --ui",
     "vitest": "vitest",
     "coverage": "vitest run --coverage",
+    "coverage-report": "tsx src/tests/aggregate-coverage.ts",
+    "coverage:full": "pnpm run coverage && pnpm run coverage-report",
     "test:codegen": "pnpm exec playwright codegen",
     "test:report": "pnpm exec playwright show-report",
     "tcm:run": "tcm \"src/**\" --pattern *.module.scss",
@@ -68,10 +70,12 @@
     "stylelint": "17.12.0",
     "stylelint-config-standard-scss": "17.0.0",
     "stylelint-order": "8.1.1",
+    "tsx": "^4.23.1",
     "typed-css-modules": "0.9.1",
     "typescript": "6.0.3",
     "typescript-eslint": "8.60.1",
     "vite": "8.0.16",
-    "vitest": "4.1.8"
+    "vitest": "4.1.8",
+    "yaml": "^2.9.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,7 +92,7 @@ importers:
         version: 7.7.20
       '@vitejs/plugin-react':
         specifier: 6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.7)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.8.1))
+        version: 6.0.2(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: 4.1.8
         version: 4.1.8(vitest@4.1.8)
@@ -135,6 +135,9 @@ importers:
       stylelint-order:
         specifier: 8.1.1
         version: 8.1.1(stylelint@17.12.0(typescript@6.0.3))
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
       typed-css-modules:
         specifier: 0.9.1
         version: 0.9.1
@@ -146,10 +149,13 @@ importers:
         version: 8.60.1(eslint@9.39.4)(typescript@6.0.3)
       vite:
         specifier: 8.0.16
-        version: 8.0.16(@types/node@24.12.4)(esbuild@0.27.7)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.8.1)
+        version: 8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: 4.1.8
-        version: 4.1.8(@types/node@24.12.4)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(msw@2.4.11(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.7)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.8.1))
+        version: 4.1.8(@types/node@24.12.4)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(msw@2.4.11(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)(yaml@2.9.0))
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
 packages:
 
@@ -433,158 +439,158 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1747,8 +1753,8 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3538,6 +3544,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.23.1:
+    resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -3839,8 +3850,8 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yaml@2.8.1:
-    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -4281,82 +4292,82 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.7':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.7':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.7':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.7':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.7':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.7':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.27.7':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
@@ -5027,10 +5038,10 @@ snapshots:
       '@typescript-eslint/types': 8.60.1
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.7)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.8.1))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@24.12.4)(esbuild@0.27.7)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.8.1)
+      vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
     dependencies:
@@ -5044,7 +5055,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@24.12.4)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(msw@2.4.11(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.7)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.8.1))
+      vitest: 4.1.8(@types/node@24.12.4)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(msw@2.4.11(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)(yaml@2.9.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -5055,14 +5066,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(msw@2.4.11(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.7)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.8.1))':
+  '@vitest/mocker@4.1.8(msw@2.4.11(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.4.11(typescript@6.0.3)
-      vite: 8.0.16(@types/node@24.12.4)(esbuild@0.27.7)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.8.1)
+      vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -5621,35 +5632,34 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
-  esbuild@0.27.7:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
-    optional: true
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -7524,6 +7534,12 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.23.1:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -7645,7 +7661,7 @@ snapshots:
 
   varint@6.0.0: {}
 
-  vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.7)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.8.1):
+  vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -7654,16 +7670,17 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.12.4
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       fsevents: 2.3.3
       sass: 1.100.0
       sass-embedded: 1.100.0
-      yaml: 2.8.1
+      tsx: 4.23.1
+      yaml: 2.9.0
 
-  vitest@4.1.8(@types/node@24.12.4)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(msw@2.4.11(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.7)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.8.1)):
+  vitest@4.1.8(@types/node@24.12.4)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(msw@2.4.11(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(msw@2.4.11(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.7)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.8.1))
+      '@vitest/mocker': 4.1.8(msw@2.4.11(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -7680,7 +7697,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@24.12.4)(esbuild@0.27.7)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.8.1)
+      vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.4
@@ -7806,8 +7823,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@2.8.1:
-    optional: true
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/src/tests/aggregate-coverage.ts
+++ b/src/tests/aggregate-coverage.ts
@@ -1,195 +1,59 @@
 import fs from "fs";
-import path from "path";
-import crypto from "crypto";
+import { buildReport } from "./contract-coverage/aggregate";
+import { MIGRATION_MAP } from "./contract-coverage/migration-map";
+import { REGISTRY_PATH, REPORT_PATH } from "./contract-coverage/paths";
+import { createHeuristicSource } from "./contract-coverage/sources/heuristic";
+import { createMswHandlerSource } from "./contract-coverage/sources/msw";
+import { createOpenApiSource } from "./contract-coverage/sources/openapi";
+import { createV1ActionSource } from "./contract-coverage/sources/v1-actions";
+import type { Observation } from "./contract-coverage/types";
 
-const INPUT_PATH = path.resolve(import.meta.dirname, "msw-api-registry.jsonl");
-const OUTPUT_PATH = path.resolve(
-  import.meta.dirname,
-  "msw-contract-coverage.json",
-);
+// The Go debarchive service is mounted under this prefix in front of the
+// spec's own /v1beta1 (VITE_API_URL_DEB_ARCHIVE = /debarchive/v1beta1/).
+const DEB_ARCHIVE_MOUNT = "/debarchive";
 
-interface TrafficMetrics {
-  totalHits: number;
-  statuses: Record<number, number>;
-  // Only populated for state-mutating requests (POST, PUT, PATCH)
-  contracts?: {
-    status: number;
-    requestHash?: string;
-    responseHash?: string;
-    requestPayload: unknown;
-    responsePayload: unknown;
-  }[];
-}
-
-interface ContractCoverageReport {
-  generatedAt: string;
-  summary: {
-    totalInteractionsLogged: number;
-    uniqueRoutesFound: number;
-  };
-  routes: Record<string, Record<string, TrafficMetrics>>;
-}
-
-/**
- * Heuristically converts raw execution URLs into normalized route patterns
- * Strips query params, collapses UUIDs, hex values, and dynamic path slugs.
- */
-function normalizeRoute(rawUrl: string): string {
-  try {
-    const url = new URL(rawUrl);
-    let { pathname } = url;
-
-    // 1. Standardize trailing slashes
-    if (pathname.endsWith("/") && pathname.length > 1) {
-      pathname = pathname.slice(0, -1);
-    }
-
-    // 2. Normalize standard UUIDs -> :id
-    pathname = pathname.replace(
-      /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
-      "/:id",
-    );
-
-    // 3. Normalize known dynamic REST subpaths (e.g., /mirrors/third-party-mirror -> /mirrors/:id)
-    const dynamicParents = [
-      "mirrors",
-      "operations",
-      "computers",
-      "instances",
-      "users",
-      "repository",
-    ];
-    dynamicParents.forEach((parent) => {
-      const regex = new RegExp(`(?<=\\/${parent}\\/)[^\\/]+`, "g");
-      pathname = pathname.replace(regex, ":id");
-    });
-
-    // 4. Clean up trailing alphanumeric hashes/slugs with hyphens (e.g., mirror-ffff-llll-dddd)
-    pathname = pathname.replace(/\/[a-z0-9]+-[a-z0-9-]+/gi, "/:id");
-
-    return pathname;
-  } catch {
-    // Fixed: Handled potential undefined element accessor under strict noUncheckedIndexedAccess rule
-    return rawUrl.split("?")[0] ?? rawUrl;
-  }
-}
-
-/**
- * Generates a deterministic hash of payload structures to detect true mutations
- */
-// Fixed: Swapped explicit 'any' out for 'unknown'
-function hashPayload(payload: unknown): string {
-  if (!payload) return "empty";
-  const str = typeof payload === "string" ? payload : JSON.stringify(payload);
-  return crypto.createHash("sha1").update(str).digest("hex");
-}
-
-function generateReport() {
-  if (!fs.existsSync(INPUT_PATH)) {
-    console.error(
-      `[-] No registry file found at ${INPUT_PATH}. Ensure tests ran successfully.`,
-    );
-    process.exit(1);
-  }
-
-  const fileContent = fs.readFileSync(INPUT_PATH, "utf-8");
-  const lines = fileContent.split("\n").filter(Boolean);
-
-  const report: ContractCoverageReport = {
-    generatedAt: new Date().toISOString(),
-    summary: { totalInteractionsLogged: lines.length, uniqueRoutesFound: 0 },
-    routes: {},
-  };
-
-  for (const line of lines) {
-    try {
-      const log = JSON.parse(line) as {
-        url: string;
-        method: string;
-        type: string;
-        status: number;
-        requestPayload: unknown;
-        responsePayload: unknown;
-      };
-
-      const route = normalizeRoute(log.url);
-      const method = log.method.toUpperCase();
-
-      // Initialize route map block safely for Record styles
-      if (!report.routes[route]) {
-        report.routes[route] = {};
-      }
-
-      const routeMethods = report.routes[route];
-      if (!routeMethods) continue;
-
-      if (!routeMethods[method]) {
-        const baseMetric: TrafficMetrics = {
-          totalHits: 0,
-          statuses: {},
-        };
-        // Initialize dynamic payload tracking for writing endpoints
-        if (["POST", "PUT", "PATCH"].includes(method)) {
-          baseMetric.contracts = [];
-        }
-        routeMethods[method] = baseMetric;
-      }
-
-      const metric = routeMethods[method];
-      if (!metric) continue;
-
-      // Update counters
-      metric.totalHits++;
-      metric.statuses[log.status] = (metric.statuses[log.status] ?? 0) + 1;
-
-      // Handle contract payload deduplication for mutations
-      if (metric.contracts) {
-        const reqHash = hashPayload(log.requestPayload);
-        const resHash = hashPayload(log.responsePayload);
-
-        const structureExists = metric.contracts.some(
-          (c) =>
-            c.status === log.status &&
-            c.requestHash === reqHash &&
-            c.responseHash === resHash,
-        );
-
-        if (!structureExists) {
-          metric.contracts.push({
-            status: log.status,
-            requestHash: reqHash,
-            responseHash: resHash,
-            requestPayload: log.requestPayload,
-            responsePayload: log.responsePayload,
-          });
-        }
-      }
-    } catch {
-      // Gracefully handle potentially corrupted/half-written JSONL lines
-      continue;
-    }
-  }
-
-  // Before writing to disk, strip the tracking hashes to optimize file size
-  Object.values(report.routes).forEach((methods) => {
-    Object.values(methods).forEach((metric) => {
-      if (metric.contracts) {
-        metric.contracts = metric.contracts.map((contract) => {
-          const cleanContract = { ...contract };
-          delete cleanContract.requestHash;
-          delete cleanContract.responseHash;
-          return cleanContract;
-        });
-      }
-    });
-  });
-
-  report.summary.uniqueRoutesFound = Object.keys(report.routes).length;
-
-  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(report, null, 2), "utf-8");
-  console.warn(
-    `[+] Token-optimized contract report compiled successfully to: ${OUTPUT_PATH}`,
+if (!fs.existsSync(REGISTRY_PATH)) {
+  console.error(
+    `[-] No registry file found at ${REGISTRY_PATH}. Ensure tests ran successfully.`,
   );
+  process.exit(1);
 }
 
-generateReport();
+const observations: Observation[] = [];
+for (const line of fs.readFileSync(REGISTRY_PATH, "utf-8").split("\n")) {
+  if (!line) continue;
+  try {
+    observations.push(JSON.parse(line) as Observation);
+  } catch {
+    // Tolerate corrupted/half-written JSONL lines
+    continue;
+  }
+}
+
+// Contract connectors in priority order: the real BE contract wins where it
+// exists; mocks are the best-available contract elsewhere; heuristic guesses
+// are last and labeled as such. A future specced Python API slots in here.
+const sources = [
+  createOpenApiSource(DEB_ARCHIVE_MOUNT),
+  createV1ActionSource(),
+  createMswHandlerSource(),
+  createHeuristicSource(),
+];
+
+const report = buildReport(observations, sources, MIGRATION_MAP);
+
+fs.writeFileSync(REPORT_PATH, JSON.stringify(report, null, 2), "utf-8");
+
+const { summary } = report;
+console.warn(`[+] Contract coverage report written to: ${REPORT_PATH}`);
+console.warn(
+  `    ${summary.totalInteractionsLogged} interactions -> ${summary.routesExercised} routes exercised, ` +
+    `${summary.routesDeclared} declared, ${report.unexercised.length} unexercised, ${report.drift.length} drift`,
+);
+for (const backend of ["v1", "v2", "go"] as const) {
+  const { declared, exercised } = summary.byBackend[backend];
+  console.warn(`    ${backend}: ${exercised} exercised / ${declared} declared`);
+}
+for (const warning of report.warnings) {
+  console.warn(`[!] ${warning}`);
+}

--- a/src/tests/aggregate-coverage.ts
+++ b/src/tests/aggregate-coverage.ts
@@ -1,7 +1,11 @@
 import fs from "fs";
 import { buildReport } from "./contract-coverage/aggregate";
 import { MIGRATION_MAP } from "./contract-coverage/migration-map";
-import { REGISTRY_PATH, REPORT_PATH } from "./contract-coverage/paths";
+import {
+  MANIFEST_PATH,
+  REGISTRY_PATH,
+  REPORT_PATH,
+} from "./contract-coverage/paths";
 import { createHeuristicSource } from "./contract-coverage/sources/heuristic";
 import { createMswHandlerSource } from "./contract-coverage/sources/msw";
 import { createOpenApiSource } from "./contract-coverage/sources/openapi";
@@ -12,10 +16,16 @@ import type { Observation } from "./contract-coverage/types";
 // spec's own /v1beta1 (VITE_API_URL_DEB_ARCHIVE = /debarchive/v1beta1/).
 const DEB_ARCHIVE_MOUNT = "/debarchive";
 
-if (!fs.existsSync(REGISTRY_PATH)) {
-  console.error(
-    `[-] No registry file found at ${REGISTRY_PATH}. Ensure tests ran successfully.`,
-  );
+// Both inputs are produced by the test run: the registry by the traffic
+// recorder, the manifest by the handler dump (see setup.ts).
+const missingInputs = [REGISTRY_PATH, MANIFEST_PATH].filter(
+  (file) => !fs.existsSync(file),
+);
+if (missingInputs.length > 0) {
+  for (const file of missingInputs) {
+    console.error(`[-] Missing generated input: ${file}`);
+  }
+  console.error(`    Run the test suite first: pnpm vitest run`);
   process.exit(1);
 }
 

--- a/src/tests/contract-coverage/aggregate.test.ts
+++ b/src/tests/contract-coverage/aggregate.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+import { buildReport } from "./aggregate";
+import type { MigrationMapEntry } from "./migration-map";
+import type {
+  ContractSource,
+  Observation,
+  RouteDefinition,
+} from "./types";
+
+const HTTP_OK = 200;
+const HTTP_BAD_REQUEST = 400;
+const HTTP_SERVER_ERROR = 500;
+
+const route = (
+  id: string,
+  source: string,
+  backend: RouteDefinition["backend"] = "go",
+): RouteDefinition => {
+  const [method = "", pattern = ""] = [
+    id.slice(0, id.indexOf(" ")),
+    id.slice(id.indexOf(" ") + 1),
+  ];
+  return { id, method, pattern, backend, source };
+};
+
+/** A stub connector declaring fixed routes and matching by exact pathname. */
+const stubSource = (
+  name: string,
+  routes: RouteDefinition[],
+  matcher?: (method: string, url: URL) => RouteDefinition | null,
+): ContractSource => ({
+  name,
+  listRoutes: () => routes,
+  match: (method, url) =>
+    matcher?.(method, url) ??
+    routes.find(
+      (candidate) =>
+        candidate.method === method &&
+        candidate.pattern === url.pathname,
+    ) ??
+    null,
+});
+
+const observation = (
+  method: string,
+  url: string,
+  status = HTTP_OK,
+  requestPayload: unknown = null,
+  responsePayload: unknown = null,
+): Observation => ({
+  method,
+  url: `http://localhost:3000${url}`,
+  status,
+  requestPayload,
+  responsePayload,
+});
+
+describe("buildReport", () => {
+  it("counts hits and statuses per resolved route", () => {
+    const source = stubSource("s", [route("GET /v1/things", "openapi")]);
+    const report = buildReport(
+      [
+        observation("GET", "/v1/things"),
+        observation("GET", "/v1/things"),
+        observation("GET", "/v1/things", HTTP_SERVER_ERROR),
+      ],
+      [source],
+      [],
+    );
+
+    const metric = report.routes["GET /v1/things"];
+    expect(metric?.totalHits).toBe(3);
+    expect(metric?.statuses).toEqual({
+      [HTTP_OK]: 2,
+      [HTTP_SERVER_ERROR]: 1,
+    });
+    expect(report.summary.routesExercised).toBe(1);
+  });
+
+  it("dedupes structurally equal routes across sources, priority wins", () => {
+    const openapi = stubSource("openapi", [
+      route("GET /v1/mirrors/{mirror}", "openapi"),
+    ]);
+    // Same shape, different param name, lower priority — and its match()
+    // claims the traffic to prove remapping onto the canonical id.
+    const mswRoute = route("GET /v1/mirrors/{mirrorId}", "msw-handlers");
+    const msw = stubSource("msw", [mswRoute], (method, url) =>
+      method === "GET" && url.pathname.startsWith("/v1/mirrors/")
+        ? mswRoute
+        : null,
+    );
+
+    const report = buildReport(
+      [observation("GET", "/v1/mirrors/abc")],
+      [openapi, msw],
+      [],
+    );
+
+    expect(report.summary.routesDeclared).toBe(1);
+    expect(report.routes["GET /v1/mirrors/{mirror}"]?.totalHits).toBe(1);
+    expect(report.routes["GET /v1/mirrors/{mirrorId}"]).toBeUndefined();
+    expect(report.unexercised).toHaveLength(0);
+  });
+
+  it("collects contract examples for mutations, deduped by payload shape", () => {
+    const source = stubSource("s", [route("POST /v1/things", "openapi")]);
+    const report = buildReport(
+      [
+        observation("POST", "/v1/things", HTTP_OK, { a: 1 }, { ok: true }),
+        observation("POST", "/v1/things", HTTP_OK, { a: 1 }, { ok: true }),
+        observation(
+          "POST",
+          "/v1/things",
+          HTTP_BAD_REQUEST,
+          { a: 1 },
+          { error: "bad" },
+        ),
+      ],
+      [source],
+      [],
+    );
+
+    const contracts = report.routes["POST /v1/things"]?.contracts;
+    expect(contracts).toHaveLength(2);
+    expect(contracts?.map((contract) => contract.status)).toEqual([
+      HTTP_OK,
+      HTTP_BAD_REQUEST,
+    ]);
+    // Tracking hashes are stripped from the persisted report
+    expect(
+      contracts?.every(
+        (contract) =>
+          !("requestHash" in contract) && !("responseHash" in contract),
+      ),
+    ).toBe(true);
+    // GET routes carry no contracts at all
+    const getReport = buildReport(
+      [observation("GET", "/v1/things")],
+      [stubSource("s", [route("GET /v1/things", "openapi")])],
+      [],
+    );
+    expect(getReport.routes["GET /v1/things"]?.contracts).toBeUndefined();
+  });
+
+  it("reports declared routes with zero traffic as unexercised", () => {
+    const source = stubSource("s", [
+      route("GET /v1/hit", "openapi"),
+      route("GET /v1/missed", "openapi"),
+    ]);
+    const report = buildReport([observation("GET", "/v1/hit")], [source], []);
+
+    expect(report.unexercised).toEqual([
+      { id: "GET /v1/missed", backend: "go", source: "openapi" },
+    ]);
+  });
+
+  it("reports heuristic and observed-only matches as drift", () => {
+    const heuristicRoute = route("GET /v1/mystery", "heuristic", "unknown");
+    const source = stubSource("h", [], () => heuristicRoute);
+    const report = buildReport(
+      [observation("GET", "/v1/mystery")],
+      [source],
+      [],
+    );
+
+    expect(report.drift).toEqual([
+      {
+        id: "GET /v1/mystery",
+        backend: "unknown",
+        source: "heuristic",
+        totalHits: 1,
+      },
+    ]);
+  });
+
+  it("reports migration status per layer and warns on unknown ids", () => {
+    const source = stubSource("s", [
+      route("GET /api/?action=GetFoo", "msw-actions", "v1"),
+      route("GET /v1/foos", "openapi"),
+    ]);
+    const map: MigrationMapEntry[] = [
+      {
+        name: "Foo — list",
+        v1: "GET /api/?action=GetFoo",
+        go: "GET /v1/foos",
+      },
+      { name: "Broken entry", v2: "GET /api/v2/typo" },
+    ];
+    const report = buildReport(
+      [observation("GET", "/v1/foos")],
+      [source],
+      map,
+    );
+
+    const [foo, broken] = report.migration;
+    expect(foo?.layers.v1).toEqual({
+      routeId: "GET /api/?action=GetFoo",
+      declared: true,
+      totalHits: 0,
+    });
+    expect(foo?.layers.go?.totalHits).toBe(1);
+    expect(broken?.layers.v2?.declared).toBe(false);
+    expect(report.warnings).toHaveLength(1);
+    expect(report.warnings[0]).toContain("Broken entry");
+    expect(report.warnings[0]).toContain("GET /api/v2/typo");
+  });
+
+  it("summarizes declared and exercised counts per backend", () => {
+    const source = stubSource("s", [
+      route("GET /api/?action=GetFoo", "msw-actions", "v1"),
+      route("GET /v1/foos", "openapi"),
+    ]);
+    const report = buildReport(
+      [observation("GET", "/v1/foos")],
+      [source],
+      [],
+    );
+
+    expect(report.summary.byBackend.v1).toEqual({
+      declared: 1,
+      exercised: 0,
+    });
+    expect(report.summary.byBackend.go).toEqual({
+      declared: 1,
+      exercised: 1,
+    });
+  });
+});

--- a/src/tests/contract-coverage/aggregate.ts
+++ b/src/tests/contract-coverage/aggregate.ts
@@ -1,0 +1,224 @@
+import crypto from "crypto";
+import { structuralSignature } from "./matcher";
+import type { MigrationMapEntry } from "./migration-map";
+import type {
+  Backend,
+  ContractSource,
+  Observation,
+  RouteDefinition,
+} from "./types";
+
+interface ContractExample {
+  status: number;
+  requestHash?: string;
+  responseHash?: string;
+  requestPayload: unknown;
+  responsePayload: unknown;
+}
+
+export interface RouteMetrics {
+  method: string;
+  pattern: string;
+  backend: Backend;
+  source: string;
+  totalHits: number;
+  statuses: Record<number, number>;
+  // Only populated for state-mutating requests (POST, PUT, PATCH)
+  contracts?: ContractExample[];
+}
+
+type MigrationLayer = "v1" | "v2" | "go";
+
+interface MigrationLayerStatus {
+  routeId: string;
+  declared: boolean;
+  totalHits: number;
+}
+
+export interface CoverageReport {
+  generatedAt: string;
+  summary: {
+    totalInteractionsLogged: number;
+    routesExercised: number;
+    routesDeclared: number;
+    byBackend: Record<Backend, { declared: number; exercised: number }>;
+  };
+  /** Exercised routes keyed by canonical route id. */
+  routes: Record<string, RouteMetrics>;
+  /** Declared in a contract, zero traffic — the coverage gaps. */
+  unexercised: { id: string; backend: Backend; source: string }[];
+  /** Observed traffic no contract declares — guesses and undeclared actions. */
+  drift: { id: string; backend: Backend; source: string; totalHits: number }[];
+  /** Hand-maintained cross-generation equivalences with live traffic status. */
+  migration: {
+    name: string;
+    notes?: string;
+    layers: Partial<Record<MigrationLayer, MigrationLayerStatus>>;
+  }[];
+  warnings: string[];
+}
+
+function hashPayload(payload: unknown): string {
+  if (!payload) return "empty";
+  const str = typeof payload === "string" ? payload : JSON.stringify(payload);
+  return crypto.createHash("sha1").update(str).digest("hex");
+}
+
+const MUTATING_METHODS = ["POST", "PUT", "PATCH"];
+const BACKENDS: Backend[] = ["v1", "v2", "go", "unknown"];
+
+/**
+ * Pure aggregation: resolves every observation against the connectors in
+ * priority order and derives the covered / unexercised / drift triad plus
+ * migration-map status. Knows nothing about where contracts come from.
+ */
+export function buildReport(
+  observations: Observation[],
+  sources: ContractSource[],
+  migrationMap: MigrationMapEntry[],
+): CoverageReport {
+  const warnings: string[] = [];
+
+  // Declared universe, deduplicated structurally across connectors so e.g.
+  // OpenAPI's {name_1} and MSW's {mirrorId} count as one route (the
+  // higher-priority connector wins).
+  const declared = new Map<string, RouteDefinition>();
+  const signatureToId = new Map<string, string>();
+  for (const source of sources) {
+    for (const route of source.listRoutes()) {
+      const signature = structuralSignature(route.method, route.pattern);
+      if (signatureToId.has(signature)) continue;
+      signatureToId.set(signature, route.id);
+      declared.set(route.id, route);
+    }
+  }
+
+  const routes: Record<string, RouteMetrics> = {};
+
+  const resolve = (observation: Observation): RouteDefinition | null => {
+    const url = new URL(observation.url);
+    const method = observation.method.toUpperCase();
+    for (const source of sources) {
+      const route = source.match(method, url);
+      if (route) return route;
+    }
+    return null;
+  };
+
+  for (const observation of observations) {
+    const matched = resolve(observation);
+    if (!matched) continue;
+
+    // Map structurally-equal matches from lower-priority connectors onto the
+    // canonical (winning) route id.
+    const signature = structuralSignature(matched.method, matched.pattern);
+    const canonicalId = signatureToId.get(signature) ?? matched.id;
+    const route = declared.get(canonicalId) ?? matched;
+
+    const metric = (routes[route.id] ??= {
+      method: route.method,
+      pattern: route.pattern,
+      backend: route.backend,
+      source: route.source,
+      totalHits: 0,
+      statuses: {},
+      ...(MUTATING_METHODS.includes(route.method) ? { contracts: [] } : {}),
+    });
+
+    metric.totalHits++;
+    metric.statuses[observation.status] =
+      (metric.statuses[observation.status] ?? 0) + 1;
+
+    if (metric.contracts) {
+      const requestHash = hashPayload(observation.requestPayload);
+      const responseHash = hashPayload(observation.responsePayload);
+      const exists = metric.contracts.some(
+        (contract) =>
+          contract.status === observation.status &&
+          contract.requestHash === requestHash &&
+          contract.responseHash === responseHash,
+      );
+      if (!exists) {
+        metric.contracts.push({
+          status: observation.status,
+          requestHash,
+          responseHash,
+          requestPayload: observation.requestPayload,
+          responsePayload: observation.responsePayload,
+        });
+      }
+    }
+  }
+
+  // Strip the tracking hashes before writing to keep the report compact.
+  for (const metric of Object.values(routes)) {
+    metric.contracts = metric.contracts?.map(
+      ({ requestHash: _requestHash, responseHash: _responseHash, ...rest }) =>
+        rest,
+    );
+  }
+
+  const unexercised = [...declared.values()]
+    .filter((route) => !routes[route.id])
+    .map((route) => ({
+      id: route.id,
+      backend: route.backend,
+      source: route.source,
+    }));
+
+  const drift = Object.entries(routes)
+    .filter(
+      ([, metric]) =>
+        metric.source === "heuristic" || metric.source === "observed-only",
+    )
+    .map(([id, metric]) => ({
+      id,
+      backend: metric.backend,
+      source: metric.source,
+      totalHits: metric.totalHits,
+    }));
+
+  const migration = migrationMap.map((entry) => {
+    const layers: Partial<Record<MigrationLayer, MigrationLayerStatus>> = {};
+    for (const layer of ["v1", "v2", "go"] as const) {
+      const routeId = entry[layer];
+      if (!routeId) continue;
+      const isDeclared = declared.has(routeId);
+      const totalHits = routes[routeId]?.totalHits ?? 0;
+      if (!isDeclared && totalHits === 0) {
+        warnings.push(
+          `Migration map entry "${entry.name}": route id "${routeId}" (${layer}) matches no declared or observed route — possible typo.`,
+        );
+      }
+      layers[layer] = { routeId, declared: isDeclared, totalHits };
+    }
+    return { name: entry.name, notes: entry.notes, layers };
+  });
+
+  const byBackend = Object.fromEntries(
+    BACKENDS.map((backend) => [
+      backend,
+      {
+        declared: [...declared.values()].filter((r) => r.backend === backend)
+          .length,
+        exercised: Object.values(routes).filter((m) => m.backend === backend)
+          .length,
+      },
+    ]),
+  ) as Record<Backend, { declared: number; exercised: number }>;
+
+  return {
+    generatedAt: new Date().toISOString(),
+    summary: {
+      totalInteractionsLogged: observations.length,
+      routesExercised: Object.keys(routes).length,
+      routesDeclared: declared.size,
+      byBackend,
+    },
+    routes,
+    unexercised,
+    drift,
+    migration,
+    warnings,
+  };
+}

--- a/src/tests/contract-coverage/matcher.test.ts
+++ b/src/tests/contract-coverage/matcher.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalizeMswPath,
+  classifyBackend,
+  patternToRegExp,
+  structuralSignature,
+} from "./matcher";
+
+describe("classifyBackend", () => {
+  it("classifies the three API generations by prefix", () => {
+    expect(classifyBackend("/debarchive/v1beta1/mirrors")).toBe("go");
+    expect(classifyBackend("/api/v2/administrators")).toBe("v2");
+    expect(classifyBackend("/api/")).toBe("v1");
+    expect(classifyBackend("/something-else")).toBe("unknown");
+  });
+
+  it("matches exact prefixes without trailing path", () => {
+    expect(classifyBackend("/api/v2")).toBe("v2");
+    expect(classifyBackend("/api")).toBe("v1");
+  });
+
+  it("does not classify v2 traffic as v1 despite the shared /api prefix", () => {
+    expect(classifyBackend("/api/v2/users")).not.toBe("v1");
+  });
+});
+
+describe("canonicalizeMswPath", () => {
+  it("converts :param segments to {param}", () => {
+    expect(canonicalizeMswPath("/api/v2/users/:userId")).toBe(
+      "/api/v2/users/{userId}",
+    );
+    expect(
+      canonicalizeMswPath("/api/v2/employees/:id/computers/:computerId"),
+    ).toBe("/api/v2/employees/{id}/computers/{computerId}");
+  });
+
+  it("keeps unescaped mid-segment colons literal (custom verbs)", () => {
+    expect(canonicalizeMswPath("/debarchive/v1beta1/mirrors:batchGet")).toBe(
+      "/debarchive/v1beta1/mirrors:batchGet",
+    );
+  });
+
+  it("converts escaped colons to literal verb suffixes after params", () => {
+    expect(
+      canonicalizeMswPath("/debarchive/v1beta1/mirrors/:mirrorId\\:sync"),
+    ).toBe("/debarchive/v1beta1/mirrors/{mirrorId}:sync");
+    expect(canonicalizeMswPath("/api/v2/computers\\:delete")).toBe(
+      "/api/v2/computers:delete",
+    );
+  });
+
+  it("leaves static paths untouched", () => {
+    expect(canonicalizeMswPath("/api/v2/auth/supported-providers")).toBe(
+      "/api/v2/auth/supported-providers",
+    );
+  });
+});
+
+describe("patternToRegExp", () => {
+  it("matches single-segment params", () => {
+    const regExp = patternToRegExp("/api/v2/users/{userId}");
+    expect(regExp.test("/api/v2/users/42")).toBe(true);
+    expect(regExp.test("/api/v2/users/john-doe")).toBe(true);
+    expect(regExp.test("/api/v2/users/42/roles")).toBe(false);
+    expect(regExp.test("/api/v2/users")).toBe(false);
+  });
+
+  it("does not let params swallow custom verb suffixes", () => {
+    const regExp = patternToRegExp("/v1beta1/mirrors/{mirror}:sync");
+    expect(regExp.test("/v1beta1/mirrors/my-mirror:sync")).toBe(true);
+    expect(regExp.test("/v1beta1/mirrors/my-mirror")).toBe(false);
+    expect(patternToRegExp("/v1beta1/mirrors/{mirror}").test(
+      "/v1beta1/mirrors/my-mirror:sync",
+    )).toBe(false);
+  });
+
+  it("matches multi-segment {param...} across slashes", () => {
+    const regExp = patternToRegExp("/v1beta1/{operation...}");
+    expect(regExp.test("/v1beta1/operations/mirror-abc/123")).toBe(true);
+    expect(regExp.test("/v1beta1/operations/mirror-abc:cancel")).toBe(false);
+  });
+
+  it("treats regex metacharacters in literals literally", () => {
+    const regExp = patternToRegExp("/api/?action=GetFoo");
+    expect(regExp.test("/api/?action=GetFoo")).toBe(true);
+    expect(regExp.test("/apiXaction=GetFoo")).toBe(false);
+  });
+});
+
+describe("structuralSignature", () => {
+  it("equates patterns that differ only in param names", () => {
+    expect(
+      structuralSignature("GET", "/v1beta1/mirrors/{mirrorId}"),
+    ).toBe(structuralSignature("GET", "/v1beta1/mirrors/{name_1}"));
+  });
+
+  it("distinguishes methods and verbs", () => {
+    expect(structuralSignature("GET", "/v1beta1/mirrors/{m}")).not.toBe(
+      structuralSignature("DELETE", "/v1beta1/mirrors/{m}"),
+    );
+    expect(
+      structuralSignature("POST", "/v1beta1/mirrors/{m}:sync"),
+    ).not.toBe(structuralSignature("POST", "/v1beta1/mirrors/{m}"));
+  });
+
+  it("distinguishes single-segment from multi-segment params", () => {
+    expect(structuralSignature("GET", "/v1beta1/{name}")).not.toBe(
+      structuralSignature("GET", "/v1beta1/{name...}"),
+    );
+  });
+});

--- a/src/tests/contract-coverage/matcher.ts
+++ b/src/tests/contract-coverage/matcher.ts
@@ -43,7 +43,12 @@ export function patternToRegExp(pattern: string): RegExp {
  * deduplicate to the same signature.
  */
 export function structuralSignature(method: string, pattern: string): string {
-  return `${method} ${pattern.replace(/\{[^}]*\.\.\.\}/g, "{...}").replace(/\{[^}]+\}/g, "{}")}`;
+  // Single pass: a second regex pass would also erase the "{...}" token and
+  // wrongly merge multi-segment params with single-segment ones.
+  const erased = pattern.replace(/\{[^}]*?(\.\.\.)?\}/g, (_match, dots) =>
+    dots ? "{...}" : "{}",
+  );
+  return `${method} ${erased}`;
 }
 
 /**

--- a/src/tests/contract-coverage/matcher.ts
+++ b/src/tests/contract-coverage/matcher.ts
@@ -1,0 +1,59 @@
+import type { Backend } from "./types";
+
+/**
+ * Classifies a pathname into an API generation by prefix. Order matters:
+ * /api/v2 must be tested before the /api catch-all.
+ */
+export function classifyBackend(pathname: string): Backend {
+  if (pathname.startsWith("/debarchive/")) return "go";
+  if (pathname === "/api/v2" || pathname.startsWith("/api/v2/")) return "v2";
+  if (pathname === "/api" || pathname.startsWith("/api/")) return "v1";
+  return "unknown";
+}
+
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Compiles a canonical pattern into a matching RegExp.
+ * - "{param}" matches one path segment (never crosses "/" or ":")
+ * - "{param...}" matches across segments (gRPC resource names like
+ *   "operations/mirror-abc/123") but still stops at a ":verb" suffix
+ * - everything else, including ":verb" custom-method suffixes, is literal
+ */
+export function patternToRegExp(pattern: string): RegExp {
+  let compiled = "";
+  let lastIndex = 0;
+  const params = /\{([^}]+)\}/g;
+  let match = params.exec(pattern);
+  while (match !== null) {
+    compiled += escapeRegExp(pattern.slice(lastIndex, match.index));
+    compiled += match[1]?.endsWith("...") ? "[^:]+" : "[^/:]+";
+    lastIndex = match.index + match[0].length;
+    match = params.exec(pattern);
+  }
+  compiled += escapeRegExp(pattern.slice(lastIndex));
+  return new RegExp(`^${compiled}$`);
+}
+
+/**
+ * Erases parameter names so structurally identical routes declared by
+ * different connectors (e.g. MSW's "{mirrorId}" vs OpenAPI's "{name_1}")
+ * deduplicate to the same signature.
+ */
+export function structuralSignature(method: string, pattern: string): string {
+  return `${method} ${pattern.replace(/\{[^}]*\.\.\.\}/g, "{...}").replace(/\{[^}]+\}/g, "{}")}`;
+}
+
+/**
+ * Converts an MSW handler path (path-to-regexp dialect) into the canonical
+ * form: ":param" (only valid right after "/") becomes "{param}", and "\:verb"
+ * escapes become literal ":verb" custom-method suffixes.
+ */
+export function canonicalizeMswPath(mswPath: string): string {
+  return mswPath
+    .split("\\:")
+    .map((part) => part.replace(/(?<=\/):([A-Za-z0-9_]+)/g, "{$1}"))
+    .join(":");
+}

--- a/src/tests/contract-coverage/migration-map.ts
+++ b/src/tests/contract-coverage/migration-map.ts
@@ -1,0 +1,42 @@
+/**
+ * Hand-maintained equivalence table between backend generations.
+ *
+ * Route ids must use the canonical form produced by the connectors:
+ *   v1: "GET /api/?action=<ActionName>"
+ *   v2: "<METHOD> /api/v2/<path with {param} placeholders>"
+ *   go: "<METHOD> /debarchive/v1beta1/<path with {param} placeholders>"
+ *
+ * Leave a layer undefined when the operation does not (yet) exist there.
+ * The aggregator validates every id against the declared route universe and
+ * warns on typos, and reports observed traffic per layer for each entry —
+ * i.e. live migration progress measured from test traffic.
+ */
+export interface MigrationMapEntry {
+  /** Human-readable operation name. */
+  name: string;
+  v1?: string;
+  v2?: string;
+  go?: string;
+  notes?: string;
+}
+
+export const MIGRATION_MAP: MigrationMapEntry[] = [
+  {
+    name: "Administrators — list",
+    v1: "GET /api/?action=GetAdministrators",
+    notes:
+      "Still v1-only in useAdministrators.ts; no v2/go equivalent declared yet.",
+  },
+  {
+    name: "Administrators — update",
+    v2: "PUT /api/v2/administrators/{id}",
+    notes: "Already migrated to v2 (useAdministrators.ts); v1 had no editor.",
+  },
+  {
+    name: "Repository mirror — sync",
+    v1: "GET /api/?action=SyncMirrorPocket",
+    go: "POST /debarchive/v1beta1/mirrors/{name}:sync",
+    notes:
+      "Approximate equivalence: legacy sync is pocket-level, debarchive sync is mirror-level.",
+  },
+];

--- a/src/tests/contract-coverage/migration-map.ts
+++ b/src/tests/contract-coverage/migration-map.ts
@@ -35,7 +35,7 @@ export const MIGRATION_MAP: MigrationMapEntry[] = [
   {
     name: "Repository mirror — sync",
     v1: "GET /api/?action=SyncMirrorPocket",
-    go: "POST /debarchive/v1beta1/mirrors/{name}:sync",
+    go: "POST /debarchive/v1beta1/mirrors/{mirror}:sync",
     notes:
       "Approximate equivalence: legacy sync is pocket-level, debarchive sync is mirror-level.",
   },

--- a/src/tests/contract-coverage/paths.ts
+++ b/src/tests/contract-coverage/paths.ts
@@ -1,0 +1,19 @@
+import path from "path";
+
+const TESTS_DIR = path.resolve(import.meta.dirname, "..");
+
+/** Raw traffic log, appended by every vitest worker (see setup.ts). */
+export const REGISTRY_PATH = path.join(TESTS_DIR, "msw-api-registry.jsonl");
+
+/**
+ * Declared MSW handler patterns, dumped during the test run (see setup.ts).
+ * Needed because the handler modules read import.meta.env and therefore cannot
+ * be imported by the aggregator CLI outside of Vite/Vitest.
+ */
+export const MANIFEST_PATH = path.join(TESTS_DIR, "msw-handlers-manifest.json");
+
+/** Aggregated coverage report produced by aggregate-coverage.ts. */
+export const REPORT_PATH = path.join(TESTS_DIR, "msw-contract-coverage.json");
+
+/** Handler sources, scanned for v1 RPC action names. */
+export const HANDLERS_DIR = path.join(TESTS_DIR, "server", "handlers");

--- a/src/tests/contract-coverage/sources/heuristic.test.ts
+++ b/src/tests/contract-coverage/sources/heuristic.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { createHeuristicSource } from "./heuristic";
+
+const source = createHeuristicSource();
+
+const match = (method: string, url: string) =>
+  source.match(method, new URL(url));
+
+describe("createHeuristicSource", () => {
+  it("declares no route universe of its own", () => {
+    expect(source.listRoutes()).toHaveLength(0);
+  });
+
+  it("labels everything it emits as a guess", () => {
+    expect(
+      match("GET", "http://localhost:3000/api/v2/whatever")?.source,
+    ).toBe("heuristic");
+  });
+
+  it("collapses UUID and numeric segments to {id}", () => {
+    expect(
+      match(
+        "GET",
+        "http://localhost:3000/api/v2/things/7b1d5c2f-0c4e-4d8e-8f2f-99d4f2d9a123",
+      )?.pattern,
+    ).toBe("/api/v2/things/{id}");
+    expect(
+      match("GET", "http://localhost:3000/api/v2/invitations/1/summary")
+        ?.pattern,
+    ).toBe("/api/v2/invitations/{id}/summary");
+  });
+
+  it("keeps static hyphenated segments literal", () => {
+    expect(
+      match("GET", "http://localhost:3000/api/v2/auth/supported-providers")
+        ?.pattern,
+    ).toBe("/api/v2/auth/supported-providers");
+  });
+
+  it("preserves custom verb suffixes without double slashes", () => {
+    expect(
+      match(
+        "POST",
+        "http://localhost:3000/debarchive/v1beta1/publications/7b1d5c2f-0c4e-4d8e-8f2f-99d4f2d9a123:publish",
+      )?.pattern,
+    ).toBe("/debarchive/v1beta1/publications/{id}:publish");
+  });
+
+  it("classifies the backend and strips query and trailing slash", () => {
+    const matched = match(
+      "GET",
+      "http://localhost:3000/debarchive/v1beta1/mirrors/?pageSize=10",
+    );
+    expect(matched?.backend).toBe("go");
+    expect(matched?.pattern).toBe("/debarchive/v1beta1/mirrors");
+  });
+});

--- a/src/tests/contract-coverage/sources/heuristic.ts
+++ b/src/tests/contract-coverage/sources/heuristic.ts
@@ -1,0 +1,50 @@
+import { classifyBackend } from "../matcher";
+import type { ContractSource } from "../types";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Last-resort connector for traffic no declared contract matched. It guesses
+ * a route pattern from the URL shape (UUID and numeric segments -> {id}),
+ * and everything it emits is labeled source: "heuristic" so guesses are never
+ * mistaken for contract-backed routes. It declares no universe of its own.
+ */
+export function createHeuristicSource(): ContractSource {
+  return {
+    name: "heuristic",
+    listRoutes: () => [],
+    match: (method, url) => {
+      let { pathname } = url;
+      if (pathname.endsWith("/") && pathname.length > 1) {
+        pathname = pathname.slice(0, -1);
+      }
+
+      // Preserve gRPC-style custom verbs (/publications/{id}:publish)
+      let verb = "";
+      const colonIndex = pathname.lastIndexOf(":");
+      if (colonIndex > pathname.lastIndexOf("/")) {
+        verb = pathname.slice(colonIndex);
+        pathname = pathname.slice(0, colonIndex);
+      }
+
+      const segments = pathname.split("/");
+      const pattern =
+        segments
+          .map((segment) => {
+            if (UUID_RE.test(segment)) return "{id}";
+            if (/^\d+$/.test(segment)) return "{id}";
+            return segment;
+          })
+          .join("/") + verb;
+
+      return {
+        id: `${method} ${pattern}`,
+        method,
+        pattern,
+        backend: classifyBackend(url.pathname),
+        source: "heuristic",
+      };
+    },
+  };
+}

--- a/src/tests/contract-coverage/sources/msw.test.ts
+++ b/src/tests/contract-coverage/sources/msw.test.ts
@@ -1,0 +1,84 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { ContractSource } from "../types";
+import { createMswHandlerSource } from "./msw";
+
+const MANIFEST = [
+  { method: "GET", path: "/api/v2/administrators", isRegExpPath: false },
+  { method: "PUT", path: "/api/v2/administrators/:id", isRegExpPath: false },
+  {
+    method: "POST",
+    path: "/debarchive/v1beta1/mirrors/:mirrorId\\:sync",
+    isRegExpPath: false,
+  },
+  // v1 catch-alls must be skipped (identity is the action param, not the path)
+  { method: "GET", path: "/api/", isRegExpPath: false },
+  { method: "POST", path: "/api/", isRegExpPath: false },
+  // regexp paths cannot be canonicalized and must be skipped
+  { method: "GET", path: "/\\/api\\/v2\\/.*/", isRegExpPath: true },
+  // duplicate declarations collapse to one route
+  { method: "GET", path: "/api/v2/administrators", isRegExpPath: false },
+];
+
+let tempDir: string;
+let source: ContractSource;
+
+beforeAll(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "msw-manifest-"));
+  const manifestPath = path.join(tempDir, "manifest.json");
+  fs.writeFileSync(manifestPath, JSON.stringify(MANIFEST));
+  source = createMswHandlerSource(manifestPath);
+});
+
+afterAll(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("createMswHandlerSource", () => {
+  it("declares canonicalized routes with backend classification", () => {
+    const routes = source.listRoutes();
+    const byId = new Map(routes.map((route) => [route.id, route]));
+
+    expect(byId.get("GET /api/v2/administrators")?.backend).toBe("v2");
+    expect(byId.get("PUT /api/v2/administrators/{id}")?.backend).toBe("v2");
+    expect(
+      byId.get("POST /debarchive/v1beta1/mirrors/{mirrorId}:sync")?.backend,
+    ).toBe("go");
+    expect(
+      routes.every((route) => route.source === "msw-handlers"),
+    ).toBe(true);
+  });
+
+  it("skips v1 catch-alls, regexp paths, and duplicates", () => {
+    const ids = source.listRoutes().map((route) => route.id);
+    expect(ids).toHaveLength(3);
+    expect(ids.filter((id) => id.endsWith(" /api"))).toHaveLength(0);
+  });
+
+  it("matches concrete URLs, tolerating trailing slashes", () => {
+    const base = "http://localhost:3000";
+    expect(
+      source.match("PUT", new URL(`${base}/api/v2/administrators/7`))?.id,
+    ).toBe("PUT /api/v2/administrators/{id}");
+    expect(
+      source.match("GET", new URL(`${base}/api/v2/administrators/`))?.id,
+    ).toBe("GET /api/v2/administrators");
+    expect(
+      source.match(
+        "POST",
+        new URL(`${base}/debarchive/v1beta1/mirrors/my-mirror:sync`),
+      )?.id,
+    ).toBe("POST /debarchive/v1beta1/mirrors/{mirrorId}:sync");
+  });
+
+  it("returns null for undeclared traffic", () => {
+    expect(
+      source.match(
+        "DELETE",
+        new URL("http://localhost:3000/api/v2/administrators/7"),
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/tests/contract-coverage/sources/msw.ts
+++ b/src/tests/contract-coverage/sources/msw.ts
@@ -25,39 +25,34 @@ interface ManifestEntry {
 export function createMswHandlerSource(): ContractSource {
   const routes: { definition: RouteDefinition; regExp: RegExp }[] = [];
 
-  if (fs.existsSync(MANIFEST_PATH)) {
-    const entries = JSON.parse(
-      fs.readFileSync(MANIFEST_PATH, "utf-8"),
-    ) as ManifestEntry[];
+  // Existence is guarded by the aggregator CLI before any source is built.
+  const entries = JSON.parse(
+    fs.readFileSync(MANIFEST_PATH, "utf-8"),
+  ) as ManifestEntry[];
 
-    const seen = new Set<string>();
-    for (const entry of entries) {
-      if (entry.isRegExpPath) continue;
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    if (entry.isRegExpPath) continue;
 
-      const pathname = entry.path.replace(/\/$/, "");
-      if (pathname === "/api") continue;
+    const pathname = entry.path.replace(/\/$/, "");
+    if (pathname === "/api") continue;
 
-      const pattern = canonicalizeMswPath(pathname);
-      const method = entry.method.toUpperCase();
-      const id = `${method} ${pattern}`;
-      if (seen.has(id)) continue;
-      seen.add(id);
+    const pattern = canonicalizeMswPath(pathname);
+    const method = entry.method.toUpperCase();
+    const id = `${method} ${pattern}`;
+    if (seen.has(id)) continue;
+    seen.add(id);
 
-      routes.push({
-        definition: {
-          id,
-          method,
-          pattern,
-          backend: classifyBackend(pattern),
-          source: "msw-handlers",
-        },
-        regExp: patternToRegExp(pattern),
-      });
-    }
-  } else {
-    console.error(
-      `[-] MSW handler manifest not found at ${MANIFEST_PATH} — run the test suite first. Falling back to heuristics for v2/go traffic.`,
-    );
+    routes.push({
+      definition: {
+        id,
+        method,
+        pattern,
+        backend: classifyBackend(pattern),
+        source: "msw-handlers",
+      },
+      regExp: patternToRegExp(pattern),
+    });
   }
 
   return {

--- a/src/tests/contract-coverage/sources/msw.ts
+++ b/src/tests/contract-coverage/sources/msw.ts
@@ -22,12 +22,14 @@ interface ManifestEntry {
  * The v1 catch-all handlers (path === "/api/") are skipped here — v1 routes
  * are identified by RPC action, handled by the v1-actions connector.
  */
-export function createMswHandlerSource(): ContractSource {
+export function createMswHandlerSource(
+  manifestPath: string = MANIFEST_PATH,
+): ContractSource {
   const routes: { definition: RouteDefinition; regExp: RegExp }[] = [];
 
   // Existence is guarded by the aggregator CLI before any source is built.
   const entries = JSON.parse(
-    fs.readFileSync(MANIFEST_PATH, "utf-8"),
+    fs.readFileSync(manifestPath, "utf-8"),
   ) as ManifestEntry[];
 
   const seen = new Set<string>();

--- a/src/tests/contract-coverage/sources/msw.ts
+++ b/src/tests/contract-coverage/sources/msw.ts
@@ -1,0 +1,75 @@
+import fs from "fs";
+import {
+  canonicalizeMswPath,
+  classifyBackend,
+  patternToRegExp,
+} from "../matcher";
+import { MANIFEST_PATH } from "../paths";
+import type { ContractSource, RouteDefinition } from "../types";
+
+interface ManifestEntry {
+  method: string;
+  path: string;
+  isRegExpPath: boolean;
+}
+
+/**
+ * Connector for the MSW handler manifest dumped during the test run. For the
+ * unspecced Python v2 API this is the best machine-readable contract that
+ * exists; for the Go API it is the mocks' view (the OpenAPI connector
+ * out-prioritizes it in the composite).
+ *
+ * The v1 catch-all handlers (path === "/api/") are skipped here — v1 routes
+ * are identified by RPC action, handled by the v1-actions connector.
+ */
+export function createMswHandlerSource(): ContractSource {
+  const routes: { definition: RouteDefinition; regExp: RegExp }[] = [];
+
+  if (fs.existsSync(MANIFEST_PATH)) {
+    const entries = JSON.parse(
+      fs.readFileSync(MANIFEST_PATH, "utf-8"),
+    ) as ManifestEntry[];
+
+    const seen = new Set<string>();
+    for (const entry of entries) {
+      if (entry.isRegExpPath) continue;
+
+      const pathname = entry.path.replace(/\/$/, "");
+      if (pathname === "/api") continue;
+
+      const pattern = canonicalizeMswPath(pathname);
+      const method = entry.method.toUpperCase();
+      const id = `${method} ${pattern}`;
+      if (seen.has(id)) continue;
+      seen.add(id);
+
+      routes.push({
+        definition: {
+          id,
+          method,
+          pattern,
+          backend: classifyBackend(pattern),
+          source: "msw-handlers",
+        },
+        regExp: patternToRegExp(pattern),
+      });
+    }
+  } else {
+    console.error(
+      `[-] MSW handler manifest not found at ${MANIFEST_PATH} — run the test suite first. Falling back to heuristics for v2/go traffic.`,
+    );
+  }
+
+  return {
+    name: "msw-handlers",
+    listRoutes: () => routes.map((route) => route.definition),
+    match: (method, url) => {
+      const pathname = url.pathname.replace(/\/$/, "");
+      for (const route of routes) {
+        if (route.definition.method !== method) continue;
+        if (route.regExp.test(pathname)) return route.definition;
+      }
+      return null;
+    },
+  };
+}

--- a/src/tests/contract-coverage/sources/openapi.test.ts
+++ b/src/tests/contract-coverage/sources/openapi.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import type { OpenApiSpec } from "./openapi";
+import { createOpenApiSource } from "./openapi";
+
+const SPEC: OpenApiSpec = {
+  paths: {
+    "/v1beta1/mirrors": { get: {}, post: {} },
+    "/v1beta1/mirrors/{mirror}": {
+      get: { parameters: [{ name: "mirror", in: "path" }] },
+    },
+    "/v1beta1/mirrors/{mirror}:sync": {
+      post: { parameters: [{ name: "mirror", in: "path" }] },
+    },
+    // Old gnostic wildcard style: param resolved via its schema pattern
+    "/v1beta1/{name}": {
+      get: {
+        parameters: [
+          { name: "name", in: "path", schema: { pattern: "locals/[^/]+" } },
+        ],
+      },
+    },
+    "/v1beta1/{operation}": {
+      delete: {
+        parameters: [
+          {
+            name: "operation",
+            in: "path",
+            schema: { pattern: "operations/.+" },
+          },
+        ],
+      },
+    },
+  },
+};
+
+const source = createOpenApiSource("/debarchive", SPEC);
+
+describe("createOpenApiSource", () => {
+  it("declares routes mounted under the base path with go provenance", () => {
+    const ids = source.listRoutes().map((route) => route.id);
+    expect(ids).toContain("GET /debarchive/v1beta1/mirrors");
+    expect(ids).toContain("POST /debarchive/v1beta1/mirrors");
+    expect(ids).toContain("GET /debarchive/v1beta1/mirrors/{mirror}");
+    expect(
+      source.listRoutes().every((route) => route.backend === "go"),
+    ).toBe(true);
+    expect(
+      source.listRoutes().every((route) => route.source === "openapi"),
+    ).toBe(true);
+  });
+
+  it("resolves wildcard params from their schema patterns", () => {
+    const ids = source.listRoutes().map((route) => route.id);
+    expect(ids).toContain("GET /debarchive/v1beta1/locals/{name}");
+    expect(ids).toContain("DELETE /debarchive/v1beta1/operations/{operation...}");
+  });
+
+  it("matches concrete URLs to declared routes", () => {
+    const base = "http://localhost:3000";
+    expect(
+      source.match("GET", new URL(`${base}/debarchive/v1beta1/mirrors`))?.id,
+    ).toBe("GET /debarchive/v1beta1/mirrors");
+    expect(
+      source.match(
+        "GET",
+        new URL(`${base}/debarchive/v1beta1/mirrors/third-party-mirror`),
+      )?.id,
+    ).toBe("GET /debarchive/v1beta1/mirrors/{mirror}");
+    expect(
+      source.match(
+        "POST",
+        new URL(`${base}/debarchive/v1beta1/mirrors/my-mirror:sync`),
+      )?.id,
+    ).toBe("POST /debarchive/v1beta1/mirrors/{mirror}:sync");
+    expect(
+      source.match(
+        "GET",
+        new URL(`${base}/debarchive/v1beta1/locals/local-repo-1`),
+      )?.id,
+    ).toBe("GET /debarchive/v1beta1/locals/{name}");
+  });
+
+  it("matches multi-segment wildcard params across slashes", () => {
+    expect(
+      source.match(
+        "DELETE",
+        new URL(
+          "http://localhost:3000/debarchive/v1beta1/operations/mirror-abc/123",
+        ),
+      )?.id,
+    ).toBe("DELETE /debarchive/v1beta1/operations/{operation...}");
+  });
+
+  it("returns null for other methods, paths, and backends", () => {
+    const base = "http://localhost:3000";
+    expect(
+      source.match("DELETE", new URL(`${base}/debarchive/v1beta1/mirrors`)),
+    ).toBeNull();
+    expect(source.match("GET", new URL(`${base}/api/v2/mirrors`))).toBeNull();
+  });
+});

--- a/src/tests/contract-coverage/sources/openapi.ts
+++ b/src/tests/contract-coverage/sources/openapi.ts
@@ -1,0 +1,92 @@
+import { createRequire } from "module";
+import { patternToRegExp } from "../matcher";
+import type { ContractSource, RouteDefinition } from "../types";
+
+const require = createRequire(import.meta.url);
+
+interface OpenApiParameter {
+  name?: string;
+  in?: string;
+  schema?: { pattern?: string };
+}
+
+interface OpenApiOperation {
+  parameters?: OpenApiParameter[];
+}
+
+interface OpenApiSpec {
+  paths?: Record<string, Record<string, OpenApiOperation>>;
+}
+
+const HTTP_METHODS = ["get", "post", "put", "patch", "delete"];
+
+/**
+ * Resolves a gRPC-transcoded wildcard parameter into canonical segments,
+ * e.g. "{name_1}" with schema pattern "mirrors/[^/]+" -> "mirrors/{name_1}",
+ * and "operations/.+" -> "operations/{name_2...}" (multi-segment).
+ */
+function resolveWildcardParam(paramName: string, schemaPattern: string): string {
+  const resolved = schemaPattern
+    .replace(/\[\^\/\]\+/g, `{${paramName}}`)
+    .replace(/\.\+/g, `{${paramName}...}`);
+  if (/[[\]()\\^$+*?|]/.test(resolved)) {
+    console.warn(
+      `[!] Unrecognized regex construct in path param pattern "${schemaPattern}" — treating "${paramName}" as multi-segment.`,
+    );
+    return `{${paramName}...}`;
+  }
+  return resolved;
+}
+
+/**
+ * Connector for the Go backend's real contract: the OpenAPI document shipped
+ * in @canonical/landscape-openapi. `basePath` is the prefix the service is
+ * mounted under in the frontend (VITE_API_URL_DEB_ARCHIVE minus the spec's
+ * own /v1beta1 prefix).
+ */
+export function createOpenApiSource(basePath: string): ContractSource {
+  const spec = require("@canonical/landscape-openapi/openapi.json") as OpenApiSpec;
+
+  const routes: { definition: RouteDefinition; regExp: RegExp }[] = [];
+
+  for (const [specPath, operations] of Object.entries(spec.paths ?? {})) {
+    for (const [method, operation] of Object.entries(operations)) {
+      if (!HTTP_METHODS.includes(method)) continue;
+
+      let pattern = `${basePath}${specPath}`;
+      for (const param of operation.parameters ?? []) {
+        if (param.in !== "path" || !param.name) continue;
+        const schemaPattern = param.schema?.pattern;
+        if (!schemaPattern) continue;
+        pattern = pattern.replace(
+          `{${param.name}}`,
+          resolveWildcardParam(param.name, schemaPattern),
+        );
+      }
+
+      const upperMethod = method.toUpperCase();
+      routes.push({
+        definition: {
+          id: `${upperMethod} ${pattern}`,
+          method: upperMethod,
+          pattern,
+          backend: "go",
+          source: "openapi",
+        },
+        regExp: patternToRegExp(pattern),
+      });
+    }
+  }
+
+  return {
+    name: "openapi",
+    listRoutes: () => routes.map((route) => route.definition),
+    match: (method, url) => {
+      for (const route of routes) {
+        if (route.definition.method !== method) continue;
+        if (route.regExp.test(url.pathname)) return route.definition;
+      }
+      return null;
+    },
+  };
+}

--- a/src/tests/contract-coverage/sources/openapi.ts
+++ b/src/tests/contract-coverage/sources/openapi.ts
@@ -16,7 +16,7 @@ interface OpenApiOperation {
   parameters?: OpenApiParameter[];
 }
 
-interface OpenApiSpec {
+export interface OpenApiSpec {
   paths?: Record<string, Record<string, OpenApiOperation>>;
 }
 
@@ -70,9 +70,10 @@ function resolveWildcardParam(paramName: string, schemaPattern: string): string 
  * mounted under in the frontend (VITE_API_URL_DEB_ARCHIVE minus the spec's
  * own /v1beta1 prefix).
  */
-export function createOpenApiSource(basePath: string): ContractSource {
-  const spec = loadSpec();
-
+export function createOpenApiSource(
+  basePath: string,
+  spec: OpenApiSpec = loadSpec(),
+): ContractSource {
   const routes: { definition: RouteDefinition; regExp: RegExp }[] = [];
 
   for (const [specPath, operations] of Object.entries(spec.paths ?? {})) {

--- a/src/tests/contract-coverage/sources/openapi.ts
+++ b/src/tests/contract-coverage/sources/openapi.ts
@@ -1,4 +1,6 @@
+import fs from "fs";
 import { createRequire } from "module";
+import { parse as parseYaml } from "yaml";
 import { patternToRegExp } from "../matcher";
 import type { ContractSource, RouteDefinition } from "../types";
 
@@ -19,6 +21,30 @@ interface OpenApiSpec {
 }
 
 const HTTP_METHODS = ["get", "post", "put", "patch", "delete"];
+
+/**
+ * The packaged document format changed across @canonical/landscape-openapi
+ * versions (openapi.json up to 0.0.59, openapi.yaml from 0.0.70) — accept
+ * either.
+ */
+function loadSpec(): OpenApiSpec {
+  const candidates: [string, (raw: string) => unknown][] = [
+    ["openapi.yaml", parseYaml],
+    ["openapi.json", JSON.parse],
+  ];
+  for (const [file, parser] of candidates) {
+    let specPath: string;
+    try {
+      specPath = require.resolve(`@canonical/landscape-openapi/${file}`);
+    } catch {
+      continue;
+    }
+    return parser(fs.readFileSync(specPath, "utf-8")) as OpenApiSpec;
+  }
+  throw new Error(
+    "No OpenAPI document (openapi.yaml/openapi.json) found in @canonical/landscape-openapi",
+  );
+}
 
 /**
  * Resolves a gRPC-transcoded wildcard parameter into canonical segments,
@@ -45,7 +71,7 @@ function resolveWildcardParam(paramName: string, schemaPattern: string): string 
  * own /v1beta1 prefix).
  */
 export function createOpenApiSource(basePath: string): ContractSource {
-  const spec = require("@canonical/landscape-openapi/openapi.json") as OpenApiSpec;
+  const spec = loadSpec();
 
   const routes: { definition: RouteDefinition; regExp: RegExp }[] = [];
 

--- a/src/tests/contract-coverage/sources/v1-actions.test.ts
+++ b/src/tests/contract-coverage/sources/v1-actions.test.ts
@@ -1,0 +1,94 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { ContractSource } from "../types";
+import { createV1ActionSource } from "./v1-actions";
+
+const HANDLER_FIXTURE = `
+import { API_URL, API_URL_OLD } from "@/constants";
+import { http, HttpResponse } from "msw";
+import { isAction } from "./_helpers";
+
+export default [
+  http.get(API_URL_OLD, async ({ request }) => {
+    if (!isAction(request, "GetFoo")) {
+      return;
+    }
+    return HttpResponse.json([]);
+  }),
+
+  // generics between method name and call parenthesis
+  http.post<never, never, readonly string[]>(API_URL_OLD, async ({ request }) => {
+    if (!isAction(request, "CreateFoo")) {
+      return;
+    }
+    return HttpResponse.json([]);
+  }),
+
+  // array dispatch form covering several actions in one handler
+  http.get(API_URL_OLD, async ({ request }) => {
+    if (!isAction(request, ["RebootBar", "ShutdownBar"])) {
+      return;
+    }
+    return HttpResponse.json([]);
+  }),
+
+  // v2 handler in the same file — carries no v1 actions
+  http.get(\`\${API_URL}foos/:id\`, async () => {
+    return HttpResponse.json({});
+  }),
+];
+`;
+
+let tempDir: string;
+let source: ContractSource;
+
+beforeAll(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "v1-handlers-"));
+  fs.writeFileSync(path.join(tempDir, "foo.ts"), HANDLER_FIXTURE);
+  fs.writeFileSync(path.join(tempDir, "ignored.md"), "not a handler");
+  source = createV1ActionSource(tempDir);
+});
+
+afterAll(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("createV1ActionSource", () => {
+  it("declares actions from both dispatch forms with their HTTP method", () => {
+    const ids = source.listRoutes().map((route) => route.id);
+    expect(ids).toContain("GET /api/?action=GetFoo");
+    expect(ids).toContain("POST /api/?action=CreateFoo");
+    expect(ids).toContain("GET /api/?action=RebootBar");
+    expect(ids).toContain("GET /api/?action=ShutdownBar");
+    expect(ids).toHaveLength(4);
+  });
+
+  it("matches v1 traffic by its action query parameter", () => {
+    const matched = source.match(
+      "GET",
+      new URL("http://localhost:3000/api/?action=GetFoo&version=2011-08-01"),
+    );
+    expect(matched?.id).toBe("GET /api/?action=GetFoo");
+    expect(matched?.backend).toBe("v1");
+    expect(matched?.source).toBe("msw-actions");
+  });
+
+  it("claims undeclared actions but labels them observed-only", () => {
+    const matched = source.match(
+      "GET",
+      new URL("http://localhost:3000/api/?action=UnknownAction"),
+    );
+    expect(matched?.id).toBe("GET /api/?action=UnknownAction");
+    expect(matched?.source).toBe("observed-only");
+  });
+
+  it("ignores non-v1 traffic", () => {
+    const base = "http://localhost:3000";
+    expect(
+      source.match("GET", new URL(`${base}/api/v2/foos?action=GetFoo`)),
+    ).toBeNull();
+    expect(source.match("GET", new URL(`${base}/api/`))).toBeNull();
+  });
+});

--- a/src/tests/contract-coverage/sources/v1-actions.ts
+++ b/src/tests/contract-coverage/sources/v1-actions.ts
@@ -1,0 +1,73 @@
+import fs from "fs";
+import path from "path";
+import { HANDLERS_DIR } from "../paths";
+import type { ContractSource, RouteDefinition } from "../types";
+
+/**
+ * Connector for the legacy Python v1 RPC API. Requests all share the /api/
+ * path — the route identity is the `action` query parameter, so path-pattern
+ * matching cannot apply. The declared universe comes from scanning the MSW
+ * handler sources for `isAction(request, "...")` dispatches, paired with the
+ * enclosing `http.<method>(API_URL_OLD, ...)` call.
+ */
+export function createV1ActionSource(): ContractSource {
+  const declared = new Map<string, RouteDefinition>();
+
+  const defineAction = (method: string, action: string): RouteDefinition => ({
+    id: `${method} /api/?action=${action}`,
+    method,
+    pattern: `/api/?action=${action}`,
+    backend: "v1",
+    source: "msw-actions",
+  });
+
+  for (const file of fs.readdirSync(HANDLERS_DIR)) {
+    if (!file.endsWith(".ts")) continue;
+    const content = fs.readFileSync(path.join(HANDLERS_DIR, file), "utf-8");
+
+    // Each chunk after a split starts with the handler's method name and
+    // spans until the next `http.` call, so an `isAction` found in a chunk
+    // belongs to that handler. No "(" in the split — handlers may carry
+    // type generics between the method name and the call parenthesis.
+    const chunks = content.split(/http\.(get|post|put|patch|delete|all)\b/);
+    for (let i = 1; i < chunks.length - 1; i += 2) {
+      const method = chunks[i]?.toUpperCase();
+      const body = chunks[i + 1];
+      if (!method || !body || !body.includes("API_URL_OLD")) continue;
+
+      // Both dispatch forms: isAction(request, "X") and isAction(request, ["X", "Y"])
+      const calls = body.matchAll(
+        /isAction\(\s*\w+\s*,\s*(?:"([A-Za-z0-9]+)"|\[([^\]]*)\])/g,
+      );
+      for (const call of calls) {
+        const actions = call[1]
+          ? [call[1]]
+          : [...(call[2] ?? "").matchAll(/"([A-Za-z0-9]+)"/g)].map((m) => m[1]);
+        for (const action of actions) {
+          if (!action) continue;
+          declared.set(`${method} ${action}`, defineAction(method, action));
+        }
+      }
+    }
+  }
+
+  return {
+    name: "v1-actions",
+    listRoutes: () => [...declared.values()],
+    match: (method, url) => {
+      const pathname = url.pathname.replace(/\/$/, "");
+      if (pathname !== "/api") return null;
+      const action = url.searchParams.get("action");
+      if (!action) return null;
+
+      // Undeclared actions are still claimed (they are unambiguously v1
+      // traffic) but labeled so they show up in the drift report.
+      return (
+        declared.get(`${method} ${action}`) ?? {
+          ...defineAction(method, action),
+          source: "observed-only",
+        }
+      );
+    },
+  };
+}

--- a/src/tests/contract-coverage/sources/v1-actions.ts
+++ b/src/tests/contract-coverage/sources/v1-actions.ts
@@ -10,7 +10,9 @@ import type { ContractSource, RouteDefinition } from "../types";
  * handler sources for `isAction(request, "...")` dispatches, paired with the
  * enclosing `http.<method>(API_URL_OLD, ...)` call.
  */
-export function createV1ActionSource(): ContractSource {
+export function createV1ActionSource(
+  handlersDir: string = HANDLERS_DIR,
+): ContractSource {
   const declared = new Map<string, RouteDefinition>();
 
   const defineAction = (method: string, action: string): RouteDefinition => ({
@@ -21,9 +23,9 @@ export function createV1ActionSource(): ContractSource {
     source: "msw-actions",
   });
 
-  for (const file of fs.readdirSync(HANDLERS_DIR)) {
+  for (const file of fs.readdirSync(handlersDir)) {
     if (!file.endsWith(".ts")) continue;
-    const content = fs.readFileSync(path.join(HANDLERS_DIR, file), "utf-8");
+    const content = fs.readFileSync(path.join(handlersDir, file), "utf-8");
 
     // Each chunk after a split starts with the handler's method name and
     // spans until the next `http.` call, so an `isAction` found in a chunk

--- a/src/tests/contract-coverage/types.ts
+++ b/src/tests/contract-coverage/types.ts
@@ -1,0 +1,42 @@
+/**
+ * The three API generations the frontend talks to:
+ * - v1: legacy Python RPC API (`/api/?action=...`), route identity = action name
+ * - v2: current Python REST API (`/api/v2/...`)
+ * - go: new Go services (`/debarchive/v1beta1/...`), specced by
+ *   `@canonical/landscape-openapi`
+ */
+export type Backend = "v1" | "v2" | "go" | "unknown";
+
+/** One intercepted request/response pair from the JSONL registry. */
+export interface Observation {
+  method: string;
+  url: string;
+  status: number;
+  requestPayload: unknown;
+  responsePayload: unknown;
+}
+
+export interface RouteDefinition {
+  /** Canonical identity, e.g. "GET /debarchive/v1beta1/mirrors/{mirrorId}". */
+  id: string;
+  method: string;
+  /** Canonical path pattern using {param} placeholders; {param...} may span segments. */
+  pattern: string;
+  backend: Backend;
+  /** Which connector declared/resolved this route. */
+  source: string;
+}
+
+/**
+ * A pluggable contract connector. Implementations exist for the MSW handler
+ * manifest, the Go OpenAPI spec, and v1 RPC actions; a heuristic fallback
+ * catches everything else. A future real-BE contract (e.g. a specced Python
+ * API) only needs to implement this interface to join the composite.
+ */
+export interface ContractSource {
+  name: string;
+  /** The declared route universe (used for unexercised-route detection). */
+  listRoutes(): RouteDefinition[];
+  /** Resolve observed traffic to a declared route, or null if not ours. */
+  match(method: string, url: URL): RouteDefinition | null;
+}

--- a/src/tests/global-setup.ts
+++ b/src/tests/global-setup.ts
@@ -1,7 +1,5 @@
 import fs from "fs";
-import path from "path";
-
-export const REGISTRY_PATH = path.resolve(__dirname, "msw-api-registry.jsonl");
+import { REGISTRY_PATH } from "./contract-coverage/paths";
 
 export default function setup() {
   if (fs.existsSync(REGISTRY_PATH)) {

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -4,7 +4,7 @@ import { cleanup, configure } from "@testing-library/react";
 import fs from "fs";
 import { afterAll, afterEach, beforeAll, expect } from "vitest";
 import { setEndpointStatus } from "./controllers/controller";
-import { REGISTRY_PATH } from "./global-setup";
+import { MANIFEST_PATH, REGISTRY_PATH } from "./contract-coverage/paths";
 import {
   mockRangeBoundingClientRect,
   resetScreenSize,
@@ -67,6 +67,23 @@ const pendingLogs: Promise<void>[] = [];
 server.events.on("response:mocked", ({ request, response }) => {
   pendingLogs.push(logInteraction(request, response));
 });
+
+// Dump the declared handler patterns for the coverage aggregator, which runs
+// outside Vite and cannot import the handler modules (import.meta.env).
+// Content is identical across workers, so concurrent rewrites are harmless.
+try {
+  const manifest = server.listHandlers().map((handler) => {
+    const info = handler.info as { method?: unknown; path?: unknown };
+    return {
+      method: String(info.method ?? ""),
+      path: String(info.path ?? ""),
+      isRegExpPath: info.path instanceof RegExp,
+    };
+  });
+  fs.writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2));
+} catch (error) {
+  console.error("Failed to write MSW handler manifest:", error);
+}
 
 // ----------------------------------------
 

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -71,6 +71,8 @@ server.events.on("response:mocked", ({ request, response }) => {
 // Dump the declared handler patterns for the coverage aggregator, which runs
 // outside Vite and cannot import the handler modules (import.meta.env).
 // Content is identical across workers, so concurrent rewrites are harmless.
+// A failed write must fail hard — a stale manifest would silently skew the
+// coverage report.
 try {
   const manifest = server.listHandlers().map((handler) => {
     const info = handler.info as { method?: unknown; path?: unknown };
@@ -82,7 +84,9 @@ try {
   });
   fs.writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2));
 } catch (error) {
-  console.error("Failed to write MSW handler manifest:", error);
+  throw new Error(
+    `[FATAL] MSW manifest write failed at ${MANIFEST_PATH}: ${String(error)}`,
+  );
 }
 
 // ----------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to the API usage mapping POC (#703) — targets `feat/map-api-usage`, not `main`. This replaces the heuristic `normalizeRoute` with contract-backed route resolution and makes the contract layer pluggable, so the real BE contract can take over as endpoints migrate.

## Why

Running the POC over the full suite showed the regex heuristics misclassify routes in both directions, on the exact traffic this repo produces:

| Actual URL | Heuristic normalized it to | Problem |
|---|---|---|
| `/api/v2/auth/supported-providers` | `/api/v2/auth/:id` | Static endpoint erased (any hyphenated segment collapsed) |
| `/api/v2/auth/oidc-providers/1` | `/api/v2/auth/:id/1` | Inverted: static segment became `:id`, the real id stayed literal |
| `/api/v2/repository/ubuntu-archive-info` | `/api/v2/repository/:id` | Static endpoint erased by the `dynamicParents` list |
| `/publications/{uuid}:publish` | `/publications//:id:publish` | Double slash; custom verb handling inconsistent |

For a tool whose purpose is gap detection, false merges are worse than no normalization — untested endpoints get reported as covered. Meanwhile the exact patterns already exist: every MSW handler declares one, and the Go BE ships a real OpenAPI document in `@canonical/landscape-openapi`.

## Design

The recorder stays raw (unchanged, apart from dumping a handler-pattern manifest during runs). Route resolution happens at aggregation time via **contract connectors** consulted in priority order:

1. **`openapi`** — the Go BE's published contract, mounted under `/debarchive`. Authoritative where it exists.
2. **`v1-actions`** — the legacy Python RPC API (`/api/?action=...`); route identity is the `action` param, universe scanned from `isAction()` dispatches in the handlers.
3. **`msw-handlers`** — declared MSW patterns; for the unspecced Python v2 API these are the best machine-readable contract that exists today.
4. **`heuristic`** — last resort, and everything it emits is labeled a guess.

Every route carries `backend: "v1" | "v2" | "go"` and `source` provenance. Structurally identical declarations across connectors (OpenAPI `{name}` vs MSW `{mirrorId}`) dedupe, higher priority wins. When a Python endpoint migrates to Go, the new spec version simply out-prioritizes the mock — no config change.

`contract-coverage/migration-map.ts` is a hand-maintained equivalence table across generations; the report shows live per-layer traffic for each entry (e.g. mirror sync: v1 declared but unexercised, go exercised), and ids are validated against the declared universe to catch typos.

## Results (full suite, 3182 tests)

```
10482 interactions -> 202 routes exercised, 240 declared, 38 unexercised, 0 drift
v1: 50 exercised / 62 declared
v2: 126 exercised / 147 declared
go: 26 exercised / 31 declared
```

Zero drift: every observation resolved to a declared contract; the heuristic never fired. The provenance labels also immediately surfaced that `POST /debarchive/v1beta1/operations:batchGet` exists only in the mocks — the operations service is missing from the shipped Go spec.

## Notes

- `src/tests/coverage/` was not usable as a directory name — `.gitignore`'s `coverage` rule (vitest output) swallows it; hence `contract-coverage`.
- The report gained sections: `unexercised` (declared, zero traffic), `drift` (traffic no contract claims), `migration`, `warnings`.
- Usage unchanged: `npx vitest run`, then `npx tsx src/tests/aggregate-coverage.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
