### PR TITLE
fix: add feature flag gate for localRepository.lastImportTime

### DIFF
--- a/.changeset/neat-pillows-swim.md
+++ b/.changeset/neat-pillows-swim.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Gate the local repository import time field behind the server-driven `local-repository-last-import` feature flag.

--- a/src/features/local-repositories/components/LocalRepositoriesList/LocalRepositoriesList.test.tsx
+++ b/src/features/local-repositories/components/LocalRepositoriesList/LocalRepositoriesList.test.tsx
@@ -1,20 +1,35 @@
-import { API_URL } from "@/constants";
+import type { AuthContextProps } from "@/context/auth";
+import useAuth from "@/hooks/useAuth";
 import { renderWithProviders } from "@/tests/render";
 import { describe, it, expect } from "vitest";
 import LocalRepositoriesList from "./LocalRepositoriesList";
 import { repositories } from "@/tests/mocks/localRepositories";
-import { features } from "@/tests/mocks/features";
-import server from "@/tests/server";
-import { generatePaginatedResponse } from "@/tests/server/handlers/_helpers";
 import { getAllByRole, screen } from "@testing-library/react";
 import { NO_DATA_TEXT } from "@/components/layout/NoData";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
+
+vi.mock("@/hooks/useAuth");
+
+const authContextValues: AuthContextProps = {
+  logout: vi.fn(),
+  authorized: true,
+  authLoading: false,
+  setUser: vi.fn(),
+  user: null,
+  redirectToExternalUrl: vi.fn(),
+  safeRedirect: vi.fn(),
+  isFeatureEnabled: () => true,
+  hasAccounts: true,
+};
 
 describe("LocalRepositoriesList", () => {
   const user = userEvent.setup();
 
-  it("renders table with column headers and pagination", async () => {
+  beforeEach(() => {
+    vi.mocked(useAuth).mockReturnValue(authContextValues);
+  });
+
+  it("renders table with column headers and pagination", () => {
     renderWithProviders(<LocalRepositoriesList repositories={repositories} />);
 
     expect(
@@ -24,7 +39,7 @@ describe("LocalRepositoriesList", () => {
       screen.getByRole("columnheader", { name: "Status" }),
     ).toBeInTheDocument();
     expect(
-      await screen.findByRole("columnheader", { name: "Last import" }),
+      screen.getByRole("columnheader", { name: "Last import" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("columnheader", { name: "Packages" }),
@@ -39,27 +54,16 @@ describe("LocalRepositoriesList", () => {
     expect(screen.getByText(/showing.*of/i)).toBeInTheDocument();
   });
 
-  it("hides the Last import column when the feature flag is disabled", async () => {
-    server.use(
-      http.get(`${API_URL}features`, () =>
-        HttpResponse.json(
-          generatePaginatedResponse({
-            data: features.map((feature) =>
-              feature.key === "local-repository-last-import"
-                ? { ...feature, enabled: false }
-                : feature,
-            ),
-            offset: 0,
-            limit: 20,
-          }),
-        ),
-      ),
-    );
+  it("hides the Last import column when the feature flag is disabled", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      ...authContextValues,
+      isFeatureEnabled: () => false,
+    });
 
     renderWithProviders(<LocalRepositoriesList repositories={repositories} />);
 
     expect(
-      await screen.findByRole("columnheader", { name: "Packages" }),
+      screen.getByRole("columnheader", { name: "Packages" }),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("columnheader", { name: "Last import" }),
@@ -76,10 +80,10 @@ describe("LocalRepositoriesList", () => {
     }
   });
 
-  it("renders last import dates", async () => {
+  it("renders last import dates", () => {
     renderWithProviders(<LocalRepositoriesList repositories={repositories} />);
 
-    expect(await screen.findAllByText(/Jun \d{2}, 2024/)).toHaveLength(4);
+    expect(screen.getAllByText(/Jun \d{2}, 2024/)).toHaveLength(4);
     expect(screen.getByText(NO_DATA_TEXT)).toBeInTheDocument();
   });
 

--- a/src/features/local-repositories/components/LocalRepositoriesList/LocalRepositoriesList.test.tsx
+++ b/src/features/local-repositories/components/LocalRepositoriesList/LocalRepositoriesList.test.tsx
@@ -1,15 +1,20 @@
+import { API_URL } from "@/constants";
 import { renderWithProviders } from "@/tests/render";
 import { describe, it, expect } from "vitest";
 import LocalRepositoriesList from "./LocalRepositoriesList";
 import { repositories } from "@/tests/mocks/localRepositories";
+import { features } from "@/tests/mocks/features";
+import server from "@/tests/server";
+import { generatePaginatedResponse } from "@/tests/server/handlers/_helpers";
 import { getAllByRole, screen } from "@testing-library/react";
 import { NO_DATA_TEXT } from "@/components/layout/NoData";
 import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
 
 describe("LocalRepositoriesList", () => {
   const user = userEvent.setup();
 
-  it("renders table with column headers and pagination", () => {
+  it("renders table with column headers and pagination", async () => {
     renderWithProviders(<LocalRepositoriesList repositories={repositories} />);
 
     expect(
@@ -19,7 +24,7 @@ describe("LocalRepositoriesList", () => {
       screen.getByRole("columnheader", { name: "Status" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("columnheader", { name: "Last import" }),
+      await screen.findByRole("columnheader", { name: "Last import" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("columnheader", { name: "Packages" }),
@@ -34,6 +39,33 @@ describe("LocalRepositoriesList", () => {
     expect(screen.getByText(/showing.*of/i)).toBeInTheDocument();
   });
 
+  it("hides the Last import column when the feature flag is disabled", async () => {
+    server.use(
+      http.get(`${API_URL}features`, () =>
+        HttpResponse.json(
+          generatePaginatedResponse({
+            data: features.map((feature) =>
+              feature.key === "local-repository-last-import"
+                ? { ...feature, enabled: false }
+                : feature,
+            ),
+            offset: 0,
+            limit: 20,
+          }),
+        ),
+      ),
+    );
+
+    renderWithProviders(<LocalRepositoriesList repositories={repositories} />);
+
+    expect(
+      await screen.findByRole("columnheader", { name: "Packages" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("columnheader", { name: "Last import" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders repositories as buttons", () => {
     renderWithProviders(<LocalRepositoriesList repositories={repositories} />);
 
@@ -44,10 +76,10 @@ describe("LocalRepositoriesList", () => {
     }
   });
 
-  it("renders last import dates", () => {
+  it("renders last import dates", async () => {
     renderWithProviders(<LocalRepositoriesList repositories={repositories} />);
 
-    expect(screen.getAllByText(/Jun \d{2}, 2024/)).toHaveLength(4);
+    expect(await screen.findAllByText(/Jun \d{2}, 2024/)).toHaveLength(4);
     expect(screen.getByText(NO_DATA_TEXT)).toBeInTheDocument();
   });
 

--- a/src/features/local-repositories/components/LocalRepositoriesList/LocalRepositoriesList.test.tsx
+++ b/src/features/local-repositories/components/LocalRepositoriesList/LocalRepositoriesList.test.tsx
@@ -1,7 +1,7 @@
 import type { AuthContextProps } from "@/context/auth";
 import useAuth from "@/hooks/useAuth";
 import { renderWithProviders } from "@/tests/render";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import LocalRepositoriesList from "./LocalRepositoriesList";
 import { repositories } from "@/tests/mocks/localRepositories";
 import { getAllByRole, screen } from "@testing-library/react";

--- a/src/features/local-repositories/components/LocalRepositoriesList/LocalRepositoriesList.tsx
+++ b/src/features/local-repositories/components/LocalRepositoriesList/LocalRepositoriesList.tsx
@@ -26,6 +26,7 @@ const LocalRepositoriesList: FC<LocalRepositoriesListProps> = ({
   const { isFeatureEnabled } = useAuth();
   const { search, currentPage, pageSize, createPageParamsSetter } =
     usePageParams();
+  const LAST_IMPORT_FIELD = "last_import";
 
   const pagedRepositories = useMemo(
     () =>
@@ -72,7 +73,7 @@ const LocalRepositoriesList: FC<LocalRepositoriesListProps> = ({
       },
       {
         Header: "Last import",
-        id: "last_import",
+        id: LAST_IMPORT_FIELD,
         className: classes.datetime,
         Cell: ({ row: { original } }: CellProps<Local>) =>
           original.lastImportTime
@@ -103,7 +104,7 @@ const LocalRepositoriesList: FC<LocalRepositoriesListProps> = ({
 
     return isFeatureEnabled("local-repository-last-import")
       ? result
-      : result.filter((column) => column.id !== "last_import");
+      : result.filter((column) => column.id !== LAST_IMPORT_FIELD);
   }, [createPageParamsSetter, isFeatureEnabled]);
 
   return (

--- a/src/features/local-repositories/components/LocalRepositoriesList/LocalRepositoriesList.tsx
+++ b/src/features/local-repositories/components/LocalRepositoriesList/LocalRepositoriesList.tsx
@@ -5,6 +5,7 @@ import { Button } from "@canonical/react-components";
 import { useMemo, type FC } from "react";
 import type { Column, CellProps } from "react-table";
 import type { Local } from "@canonical/landscape-openapi";
+import useAuth from "@/hooks/useAuth";
 import usePageParams from "@/hooks/usePageParams";
 import LocalRepositoriesListActions from "./components/LocalRepositoriesListActions";
 import LocalRepositoryPackagesCount from "./components/LocalRepositoryPackagesCount";
@@ -22,6 +23,7 @@ interface LocalRepositoriesListProps {
 const LocalRepositoriesList: FC<LocalRepositoriesListProps> = ({
   repositories,
 }) => {
+  const { isFeatureEnabled } = useAuth();
   const { search, currentPage, pageSize, createPageParamsSetter } =
     usePageParams();
 
@@ -39,8 +41,8 @@ const LocalRepositoriesList: FC<LocalRepositoriesListProps> = ({
     [pagedRepositories],
   );
 
-  const columns = useMemo<Column<Local>[]>(
-    () => [
+  const columns = useMemo<Column<Local>[]>(() => {
+    const result: Column<Local>[] = [
       {
         accessor: "name",
         Header: "Name",
@@ -70,6 +72,7 @@ const LocalRepositoriesList: FC<LocalRepositoriesListProps> = ({
       },
       {
         Header: "Last import",
+        id: "last_import",
         className: classes.datetime,
         Cell: ({ row: { original } }: CellProps<Local>) =>
           original.lastImportTime
@@ -96,9 +99,12 @@ const LocalRepositoriesList: FC<LocalRepositoriesListProps> = ({
           <LocalRepositoriesListActions repository={repository} />
         ),
       },
-    ],
-    [createPageParamsSetter],
-  );
+    ];
+
+    return isFeatureEnabled("local-repository-last-import")
+      ? result
+      : result.filter((column) => column.id !== "last_import");
+  }, [createPageParamsSetter, isFeatureEnabled]);
 
   return (
     <OperationProvider operationNames={operationNames}>

--- a/src/features/local-repositories/components/ViewLocalRepositorySidePanel/components/ViewLocalRepositoryDetailsTab/ViewLocalRepositoryDetailsTab.test.tsx
+++ b/src/features/local-repositories/components/ViewLocalRepositorySidePanel/components/ViewLocalRepositoryDetailsTab/ViewLocalRepositoryDetailsTab.test.tsx
@@ -1,18 +1,23 @@
+import { API_URL } from "@/constants";
 import { renderWithProviders } from "@/tests/render";
 import { describe, it, expect } from "vitest";
 import ViewLocalRepositoryDetailsTab from "./ViewLocalRepositoryDetailsTab";
 import { repositories } from "@/tests/mocks/localRepositories";
+import { features } from "@/tests/mocks/features";
+import server from "@/tests/server";
+import { generatePaginatedResponse } from "@/tests/server/handlers/_helpers";
 import { screen } from "@testing-library/react";
 import { NO_DATA_TEXT } from "@/components/layout/NoData/constants";
 import { succeededOperation } from "@/tests/mocks/operations";
 import type { Local } from "@canonical/landscape-openapi";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import moment from "moment";
+import { http, HttpResponse } from "msw";
 
 const [repository] = repositories;
 
 describe("ViewLocalRepositoryDetailsTab", () => {
-  it("renders details block with repository information", () => {
+  it("renders details block with repository information", async () => {
     const { container } = renderWithProviders(
       <ViewLocalRepositoryDetailsTab
         repository={repository}
@@ -24,6 +29,7 @@ describe("ViewLocalRepositoryDetailsTab", () => {
 
     expect(container).toHaveInfoItem("Name", repository.displayName);
     expect(container).toHaveInfoItem("Status", "Packages imported");
+    expect(await screen.findByText("Last import")).toBeInTheDocument();
     expect(container).toHaveInfoItem(
       "Last import",
       moment(repository.lastImportTime).format(DISPLAY_DATE_TIME_FORMAT),
@@ -39,7 +45,32 @@ describe("ViewLocalRepositoryDetailsTab", () => {
     );
   });
 
-  it("renders description when present and fallback for last import", () => {
+  it("hides the Last import item when the feature flag is disabled", async () => {
+    server.use(
+      http.get(`${API_URL}features`, () =>
+        HttpResponse.json(
+          generatePaginatedResponse({
+            data: features.map((feature) =>
+              feature.key === "local-repository-last-import"
+                ? { ...feature, enabled: false }
+                : feature,
+            ),
+            offset: 0,
+            limit: 20,
+          }),
+        ),
+      ),
+    );
+
+    renderWithProviders(
+      <ViewLocalRepositoryDetailsTab repository={repository} />,
+    );
+
+    expect(await screen.findByText("Description")).toBeInTheDocument();
+    expect(screen.queryByText("Last import")).not.toBeInTheDocument();
+  });
+
+  it("renders description when present and fallback for last import", async () => {
     const noImportRepository = (repositories as Local[]).find(
       (repo) => !repo.lastImportTime,
     );
@@ -56,6 +87,7 @@ describe("ViewLocalRepositoryDetailsTab", () => {
       <ViewLocalRepositoryDetailsTab repository={noImportRepository} />,
     );
 
+    expect(await screen.findByText("Last import")).toBeInTheDocument();
     expect(container).toHaveInfoItem("Last import", NO_DATA_TEXT);
     expect(container).toHaveInfoItem("Description", noImportRepository.comment);
   });

--- a/src/features/local-repositories/components/ViewLocalRepositorySidePanel/components/ViewLocalRepositoryDetailsTab/ViewLocalRepositoryDetailsTab.test.tsx
+++ b/src/features/local-repositories/components/ViewLocalRepositorySidePanel/components/ViewLocalRepositoryDetailsTab/ViewLocalRepositoryDetailsTab.test.tsx
@@ -1,23 +1,38 @@
-import { API_URL } from "@/constants";
+import type { AuthContextProps } from "@/context/auth";
+import useAuth from "@/hooks/useAuth";
 import { renderWithProviders } from "@/tests/render";
 import { describe, it, expect } from "vitest";
 import ViewLocalRepositoryDetailsTab from "./ViewLocalRepositoryDetailsTab";
 import { repositories } from "@/tests/mocks/localRepositories";
-import { features } from "@/tests/mocks/features";
-import server from "@/tests/server";
-import { generatePaginatedResponse } from "@/tests/server/handlers/_helpers";
 import { screen } from "@testing-library/react";
 import { NO_DATA_TEXT } from "@/components/layout/NoData/constants";
 import { succeededOperation } from "@/tests/mocks/operations";
 import type { Local } from "@canonical/landscape-openapi";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
 import moment from "moment";
-import { http, HttpResponse } from "msw";
 
 const [repository] = repositories;
 
+vi.mock("@/hooks/useAuth");
+
+const authContextValues: AuthContextProps = {
+  logout: vi.fn(),
+  authorized: true,
+  authLoading: false,
+  setUser: vi.fn(),
+  user: null,
+  redirectToExternalUrl: vi.fn(),
+  safeRedirect: vi.fn(),
+  isFeatureEnabled: () => true,
+  hasAccounts: true,
+};
+
 describe("ViewLocalRepositoryDetailsTab", () => {
-  it("renders details block with repository information", async () => {
+  beforeEach(() => {
+    vi.mocked(useAuth).mockReturnValue(authContextValues);
+  });
+
+  it("renders details block with repository information", () => {
     const { container } = renderWithProviders(
       <ViewLocalRepositoryDetailsTab
         repository={repository}
@@ -29,7 +44,6 @@ describe("ViewLocalRepositoryDetailsTab", () => {
 
     expect(container).toHaveInfoItem("Name", repository.displayName);
     expect(container).toHaveInfoItem("Status", "Packages imported");
-    expect(await screen.findByText("Last import")).toBeInTheDocument();
     expect(container).toHaveInfoItem(
       "Last import",
       moment(repository.lastImportTime).format(DISPLAY_DATE_TIME_FORMAT),
@@ -45,32 +59,21 @@ describe("ViewLocalRepositoryDetailsTab", () => {
     );
   });
 
-  it("hides the Last import item when the feature flag is disabled", async () => {
-    server.use(
-      http.get(`${API_URL}features`, () =>
-        HttpResponse.json(
-          generatePaginatedResponse({
-            data: features.map((feature) =>
-              feature.key === "local-repository-last-import"
-                ? { ...feature, enabled: false }
-                : feature,
-            ),
-            offset: 0,
-            limit: 20,
-          }),
-        ),
-      ),
-    );
+  it("hides the Last import item when the feature flag is disabled", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      ...authContextValues,
+      isFeatureEnabled: () => false,
+    });
 
     renderWithProviders(
       <ViewLocalRepositoryDetailsTab repository={repository} />,
     );
 
-    expect(await screen.findByText("Description")).toBeInTheDocument();
+    expect(screen.getByText("Description")).toBeInTheDocument();
     expect(screen.queryByText("Last import")).not.toBeInTheDocument();
   });
 
-  it("renders description when present and fallback for last import", async () => {
+  it("renders description when present and fallback for last import", () => {
     const noImportRepository = (repositories as Local[]).find(
       (repo) => !repo.lastImportTime,
     );
@@ -87,7 +90,6 @@ describe("ViewLocalRepositoryDetailsTab", () => {
       <ViewLocalRepositoryDetailsTab repository={noImportRepository} />,
     );
 
-    expect(await screen.findByText("Last import")).toBeInTheDocument();
     expect(container).toHaveInfoItem("Last import", NO_DATA_TEXT);
     expect(container).toHaveInfoItem("Description", noImportRepository.comment);
   });

--- a/src/features/local-repositories/components/ViewLocalRepositorySidePanel/components/ViewLocalRepositoryDetailsTab/ViewLocalRepositoryDetailsTab.test.tsx
+++ b/src/features/local-repositories/components/ViewLocalRepositorySidePanel/components/ViewLocalRepositoryDetailsTab/ViewLocalRepositoryDetailsTab.test.tsx
@@ -1,7 +1,7 @@
 import type { AuthContextProps } from "@/context/auth";
 import useAuth from "@/hooks/useAuth";
 import { renderWithProviders } from "@/tests/render";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import ViewLocalRepositoryDetailsTab from "./ViewLocalRepositoryDetailsTab";
 import { repositories } from "@/tests/mocks/localRepositories";
 import { screen } from "@testing-library/react";

--- a/src/features/local-repositories/components/ViewLocalRepositorySidePanel/components/ViewLocalRepositoryDetailsTab/ViewLocalRepositoryDetailsTab.tsx
+++ b/src/features/local-repositories/components/ViewLocalRepositorySidePanel/components/ViewLocalRepositoryDetailsTab/ViewLocalRepositoryDetailsTab.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/features/operations";
 import moment from "moment";
 import { DISPLAY_DATE_TIME_FORMAT } from "@/constants";
+import useAuth from "@/hooks/useAuth";
 
 interface ViewLocalRepositoryDetailsTabProps {
   readonly repository: Local;
@@ -23,6 +24,7 @@ const ViewLocalRepositoryDetailsTab: FC<ViewLocalRepositoryDetailsTabProps> = ({
   repository,
   operationMetadata,
 }) => {
+  const { isFeatureEnabled } = useAuth();
   const { publications, isGettingPublications } = useGetPublicationsBySource(
     repository.name,
   );
@@ -44,16 +46,18 @@ const ViewLocalRepositoryDetailsTab: FC<ViewLocalRepositoryDetailsTabProps> = ({
             }
           />
 
-          <InfoGrid.Item
-            label="Last import"
-            value={
-              repository.lastImportTime
-                ? moment(repository.lastImportTime).format(
-                    DISPLAY_DATE_TIME_FORMAT,
-                  )
-                : null
-            }
-          />
+          {isFeatureEnabled("local-repository-last-import") && (
+            <InfoGrid.Item
+              label="Last import"
+              value={
+                repository.lastImportTime
+                  ? moment(repository.lastImportTime).format(
+                      DISPLAY_DATE_TIME_FORMAT,
+                    )
+                  : null
+              }
+            />
+          )}
 
           <InfoGrid.Item label="Description" large value={repository.comment} />
 

--- a/src/tests/mocks/features.ts
+++ b/src/tests/mocks/features.ts
@@ -113,4 +113,14 @@ export const features: Feature[] = [
       configuration: true,
     },
   },
+  {
+    name: "Local Repository Last Import",
+    description: "Show the last import date and time for local repositories.",
+    key: "local-repository-last-import",
+    database_key: 16,
+    enabled: true,
+    details: {
+      configuration: true,
+    },
+  },
 ];

--- a/src/types/FeatureKey.ts
+++ b/src/types/FeatureKey.ts
@@ -2,6 +2,7 @@ export type FeatureKey =
   | "computer-soft-deletion"
   | "employee-management"
   | "instance-reports"
+  | "local-repository-last-import"
   | "oidc-configuration"
   | "script-profiles"
   | "spa-dashboard"


### PR DESCRIPTION
## Summary

Gates the (not-yet-backend-supported) `Last import` field behind a new `local-repository-last-import` feature flag in the local repositories list and details views.

## Changes

- Added `"local-repository-last-import"` to FeatureKey.ts.
- LocalRepositoriesList.tsx: filters out the `Last import` column when the flag is disabled (same pattern as `ScriptList`'s `associated_profiles` column).
- ViewLocalRepositoryDetailsTab.tsx: conditionally renders the `Last import` `InfoGrid.Item`.
- Added `local-repository-last-import` to the features mock (enabled by default, for MSW-driven scenarios elsewhere in the app).
- Tests in both components mock `useAuth()` directly (matching ScriptList.test.tsx) to deterministically force `isFeatureEnabled` on/off and verify the column/item is hidden when the flag is disabled, avoiding a race with the async features query that the MSW `server.use(...)` approach would have introduced.

## Testing

- `pnpm vitest` for the two affected test files (11 tests passing).

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [X] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [X] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [X] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [X] **UI verified** — I have verified the changes locally.
- [ ] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Reviewer Setup

This section is intended to help reviewers find which pages of the UI were changed, and whether any special conditions are required to run the code.

**MSW (Mock Service Worker)**

- [ ] MSW must be enabled (`VITE_MSW_ENABLED=true` in `.env.local`)
- [ ] MSW not required
- [ ] Not Applicable

**Backend**

- [ ] A specific backend branch from Landscape server must be utilized locally — Branch: `______`
- [ ] No specific backend branch required
- [ ] Not Applicable

**Where to Find the UI Changes (if applicable)**

_Describe where in the UI the changes are visible and how to navigate there (if applicable). Paste a direct URL to the new page/component if applicable (e.g. `http://localhost:5173/...`):_

> **Example:** To test restarting an instance — navigate to the home page → click **Instances** → select an instance → open the **Operations** action menu → click **Restart**.
>
> _describe here_

**Testing Instructions** _(optional)_

_Describe any special testing instructions:_

1.

**Screenshots** _(optional)_

<!-- Attach screenshots of UI changes -->

---

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
