### PR TITLE
fix: LNDENG-4859 Edit Profile Type Error

### DIFF
--- a/src/features/account-settings/edit-user-form/EditUserForm.tsx
+++ b/src/features/account-settings/edit-user-form/EditUserForm.tsx
@@ -37,12 +37,12 @@ const EditUserForm: FC<EditUserFormProps> = ({ user }) => {
     isLoading: isChangingPreferredAccount,
   } = setPreferredAccount;
 
-  const emails = user.allowable_emails.map((email) => ({
+  const emails = (user.allowable_emails ?? []).map((email) => ({
     label: email,
     value: email,
   }));
 
-  const ORGANISATIONS_OPTIONS = user.accounts.map((acc) => ({
+  const ORGANISATIONS_OPTIONS = (user.accounts ?? []).map((acc) => ({
     label: acc.title,
     value: acc.name,
   }));
@@ -52,7 +52,7 @@ const EditUserForm: FC<EditUserFormProps> = ({ user }) => {
     initialValues: {
       name: user.name,
       timezone: user.timezone,
-      email: currentEmail?.label ?? "Select",
+      email: currentEmail?.label ?? user.email,
       defaultOrganisation:
         authUser?.accounts.find((acc) => acc.name === user.preferred_account)
           ?.name ?? "Select",
@@ -117,7 +117,7 @@ const EditUserForm: FC<EditUserFormProps> = ({ user }) => {
           }
         />
       ) : (
-        <InfoItem label="Email address" value={emails[0].value} />
+        <InfoItem label="Email address" value={user.email} />
       )}
       {TIMEZONES_FILTER.type === "select" && (
         <Select

--- a/src/types/UserDetails.d.ts
+++ b/src/types/UserDetails.d.ts
@@ -1,6 +1,6 @@
 export interface UserDetails {
   accounts: AccountKeyAndRoleInformation[];
-  allowable_emails: string[];
+  allowable_emails: string[] | null;
   email: string;
   identity: string;
   last_login_host: string;


### PR DESCRIPTION
## Summary

Fix for this bug: https://warthogs.atlassian.net/browse/LNDENG-4859 


Guard against null allowable_emails and accounts in EditUserForm.

Standalone GlobalAdmin accounts with no external identity provider return null for allowable_emails and accounts from the API. Calling .map() on these null values caused a fatal render crash when opening the Edit Profile panel in the modern dashboard.

- Null-coalesce allowable_emails and accounts to [] before mapping
- Fall back to user.email as the formik initial value when no allowable_emails are present
- Use user.email directly in the read-only InfoItem display



Essentially if the user doesn't have an external identity provider (like Ubuntu SSO), the allowable emails array is null and so is the accounts array. Our code doesn't have optional chaining to deal with these situations and so map is called on null causing the crash.


Additionally in our Formik form, we had:  `email: currentEmail?.label ?? "Select",`    this causes an error again when allowable emails is null, because emails would be an empty array and thus currentEmail would also be undefined. This would leave a string in the email portion of Formik causing a submit error.



## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [X] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [X] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [ ] ~~**Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.~~

This code base did not utilize change sets

- [X] **UI verified** — I have verified the changes locally.
- [X] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Reviewer Setup

This section is intended to help reviewers find which pages of the UI were changed, and whether any special conditions are required to run the code.

**MSW (Mock Service Worker)**

- [ ] MSW must be enabled (`VITE_MSW_ENABLED=true` in `.env.local`)
- [ ] MSW not required
- [X] Not Applicable

**Backend**

- [ ] A specific backend branch from Landscape server must be utilized locally — Branch: `______`
- [ ] No specific backend branch required
- [X] Not Applicable

**Where to Find the UI Changes (if applicable)**

_Describe where in the UI the changes are visible and how to navigate there (if applicable). Paste a direct URL to the new page/component if applicable (e.g. `http://localhost:5173/...`):_

 
> First read the special testing instructions below.

> The URL for the bug: [http://localhost:5173/user](http://localhost:5173/user)   <- Click on this to avoid the trouble of navigating the UI and fighting errors.

> To get to this page manually from the launch you need to quickly click the user name "John smith" in the bottom left corner as soon as the page loads, otherwise unrelated errors will pop up. These errors are likely due to the differences between the current backend environment and how we run this old front end.

> Once on this page you click the edit profile button, and notice there are no errors and the side panel will now open up and not crash like before.

> Also, if you save changes, it will display invalid account, I am not sure why that occurs because I did not alter that part of the logic, but you can see that the changes still go through. I suspect this is due to the differences in the back end code compared to this old ui.


**Testing Instructions** _(optional)_

_Describe any special testing instructions:_

1. First go to this mattermost post to find the required .env.local file and vite.config.ts file to use to run this branch: https://chat.canonical.com/canonical/pl/nfab486rbty18dm5a6ph1zq9ir

2. This code base uses NPM, not PNPM so  you will install it like this: `npm install` and run it like this: `npm run dev`

**Screenshots** _(optional)_

<!-- Attach screenshots of UI changes -->

---

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
