### PR TITLE
Fix: Profiles page header disappearing during loading

### DIFF
--- a/.changeset/yummy-bottles-tease.md
+++ b/.changeset/yummy-bottles-tease.md
@@ -1,0 +1,5 @@
+---
+"landscape-ui": patch
+---
+
+Fixes profiles pages issue where the header disappears during loading

--- a/src/features/profiles/components/ProfilesContainer/ProfilesContainer.tsx
+++ b/src/features/profiles/components/ProfilesContainer/ProfilesContainer.tsx
@@ -1,6 +1,6 @@
 import LoadingState from "@/components/layout/LoadingState";
 import usePageParams from "@/hooks/usePageParams";
-import { type FC } from "react";
+import { type FC, Suspense } from "react";
 import ProfilesHeader from "../ProfilesHeader";
 import ProfilesList from "../ProfilesList";
 import ProfilesEmptyState from "../ProfilesEmptyState";
@@ -39,7 +39,7 @@ const ProfilesContainer: FC<ProfilesContainerProps> = ({
   const removalType = canArchiveProfile(type) ? "archive" : "remove";
 
   return (
-    <>
+    <Suspense fallback={<LoadingState />}>
       <ProfilesHeader type={type} />
       {isNotificationVisible && isProfileLimitReached && (
         <Notification
@@ -60,7 +60,7 @@ const ProfilesContainer: FC<ProfilesContainerProps> = ({
           currentItemCount={profiles.length}
         />
       )}
-    </>
+    </Suspense>
   );
 };
 


### PR DESCRIPTION
## Summary

fixed disappearing header issue. you can see what the issue looked like in [the ticket](https://warthogs.atlassian.net/browse/LNDENG-4909), or by loading straight into a profiles page in the dev site

## Release Impact

Pick the target branch (see [RELEASES.md](../RELEASES.md) for the full model):

- [ ] `dev` — internal testing → publishes to `ppa-build-dev`
- [x] `main` — next beta → publishes to `ppa-build`
- [ ] `release/YY.MM` — point release on a maintained cycle → publishes to `ppa-build-YY.MM` (and to `ppa-build-stable` if this is the currently-promoted branch). Specify cycle: `release/____`

Change type (tick one):

- [x] Patch (fix)
- [ ] Minor (feature)
- [ ] Major (breaking)

> The change-type label is informational and only affects how the entry is rendered in the CHANGELOG. The actual version is computed from the branch and CalVer cycle — `pnpm changeset`'s `patch`/`minor` choice does not influence it.

## Checklist

- [x] **Changeset added** — I have run `pnpm changeset` (or `pnpm changeset --empty` if no CHANGELOG line is warranted) and committed the resulting `.md` file. Required for PRs targeting `main` and `release/*`; enforced by the `Changeset check` workflow.
- [x] **UI verified** — I have verified the changes locally.
- [x] **Linting clean** — No linting errors are present (especially in `scripts/`).

## Reviewer Setup

This section is intended to help reviewers find which pages of the UI were changed, and whether any special conditions are required to run the code.

**MSW (Mock Service Worker)**

- [ ] MSW must be enabled (`VITE_MSW_ENABLED=true` in `.env.local`)
- [x] MSW not required
- [ ] Not Applicable

**Backend**

- [ ] A specific backend branch from Landscape server must be utilized locally — Branch: `______`
- [x] No specific backend branch required
- [ ] Not Applicable

**Where to Find the UI Changes (if applicable)**

_Describe where in the UI the changes are visible and how to navigate there (if applicable). Paste a direct URL to the new page/component if applicable (e.g. `http://localhost:5173/...`):_

> **Example:** To test restarting an instance — navigate to the home page → click **Instances** → select an instance → open the **Operations** action menu → click **Restart**.
>
> _describe here_

**Testing Instructions** _(optional)_

_Describe any special testing instructions:_

1.

**Screenshots** _(optional)_

<!-- Attach screenshots of UI changes -->

---

## Versioning Reminder

> [!IMPORTANT]
> Landscape UI uses **CalVer** (`YY.MM.Point.Build`). Version derivation by branch:
>
> - `main` / `point/*` → `YY.MM.0.<run>-beta`
> - `dev` → `YY.MM.0.<run>-dev`
> - `release/YY.MM` → `YY.MM.1.<run>` (cycle pinned by branch name)
